### PR TITLE
Don't revert when array is empty in "all" functions

### DIFF
--- a/src/SablierV2.sol
+++ b/src/SablierV2.sol
@@ -33,7 +33,7 @@ abstract contract SablierV2 is ISablierV2 {
         address funder,
         IERC20 token
     ) external view returns (uint256 authorization) {
-        return authorizations[sender][funder][token];
+        authorization = authorizations[sender][funder][token];
     }
 
     /// NON-CONSTANT FUNCTIONS ///
@@ -45,13 +45,8 @@ abstract contract SablierV2 is ISablierV2 {
 
     /// @inheritdoc ISablierV2
     function cancelAll(uint256[] calldata streamIds) external {
-        // Checks: `streamIds` is non-empty.
-        uint256 count = streamIds.length;
-        if (count == 0) {
-            revert SablierV2__StreamIdsArrayEmpty();
-        }
-
         // Iterate over the provided array of stream ids and cancel each stream.
+        uint256 count = streamIds.length;
         for (uint256 i = 0; i < count; ) {
             // Effects: cancel the stream.
             cancelInternal(streamIds[i]);

--- a/src/SablierV2Cliff.sol
+++ b/src/SablierV2Cliff.sol
@@ -332,13 +332,8 @@ contract SablierV2Cliff is
 
     /// @inheritdoc ISablierV2
     function withdrawAll(uint256[] calldata streamIds, uint256[] calldata amounts) external {
-        // Checks: `streamIds` is non-empty.
+        // Checks: count of `streamIds` matches count of `amounts`.
         uint256 streamIdsCount = streamIds.length;
-        if (streamIdsCount == 0) {
-            revert SablierV2__StreamIdsArrayEmpty();
-        }
-
-        // Checks: count of `streamIds` matches `amounts`.
         uint256 amountsCount = amounts.length;
         if (streamIdsCount != amountsCount) {
             revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);
@@ -393,13 +388,8 @@ contract SablierV2Cliff is
             revert SablierV2__WithdrawZeroAddress();
         }
 
-        // Checks: `streamIds` is non-empty.
-        uint256 streamIdsCount = streamIds.length;
-        if (streamIdsCount == 0) {
-            revert SablierV2__StreamIdsArrayEmpty();
-        }
-
         // Checks: count of `streamIds` matches `amounts`.
+        uint256 streamIdsCount = streamIds.length;
         uint256 amountsCount = amounts.length;
         if (streamIdsCount != amountsCount) {
             revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);

--- a/src/SablierV2Linear.sol
+++ b/src/SablierV2Linear.sol
@@ -277,13 +277,8 @@ contract SablierV2Linear is
 
     /// @inheritdoc ISablierV2
     function withdrawAll(uint256[] calldata streamIds, uint256[] calldata amounts) external {
-        // Checks: `streamIds` is non-empty.
+        // Checks: count of `streamIds` matches count of `amounts`.
         uint256 streamIdsCount = streamIds.length;
-        if (streamIdsCount == 0) {
-            revert SablierV2__StreamIdsArrayEmpty();
-        }
-
-        // Checks: count of `streamIds` matches `amounts`.
         uint256 amountsCount = amounts.length;
         if (streamIdsCount != amountsCount) {
             revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);
@@ -338,13 +333,8 @@ contract SablierV2Linear is
             revert SablierV2__WithdrawZeroAddress();
         }
 
-        // Checks: `streamIds` is non-empty.
+        // Checks: count of `streamIds` matches count of `amounts`.
         uint256 streamIdsCount = streamIds.length;
-        if (streamIdsCount == 0) {
-            revert SablierV2__StreamIdsArrayEmpty();
-        }
-
-        // Checks: count of `streamIds` matches `amounts`.
         uint256 amountsCount = amounts.length;
         if (streamIdsCount != amountsCount) {
             revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);

--- a/src/SablierV2Pro.sol
+++ b/src/SablierV2Pro.sol
@@ -299,13 +299,8 @@ contract SablierV2Pro is
 
     /// @inheritdoc ISablierV2
     function withdrawAll(uint256[] calldata streamIds, uint256[] calldata amounts) external {
-        // Checks: `streamIds` is non-empty.
+        // Checks: count of `streamIds` matches count of `amounts`.
         uint256 streamIdsCount = streamIds.length;
-        if (streamIdsCount == 0) {
-            revert SablierV2__StreamIdsArrayEmpty();
-        }
-
-        // Checks: count of `streamIds` matches `amounts`.
         uint256 amountsCount = amounts.length;
         if (streamIdsCount != amountsCount) {
             revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);
@@ -360,13 +355,8 @@ contract SablierV2Pro is
             revert SablierV2__WithdrawZeroAddress();
         }
 
-        // Checks: `streamIds` is non-empty.
-        uint256 streamIdsCount = streamIds.length;
-        if (streamIdsCount == 0) {
-            revert SablierV2__StreamIdsArrayEmpty();
-        }
-
         // Checks: count of `streamIds` matches `amounts`.
+        uint256 streamIdsCount = streamIds.length;
         uint256 amountsCount = amounts.length;
         if (streamIdsCount != amountsCount) {
             revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);

--- a/src/interfaces/ISablierV2.sol
+++ b/src/interfaces/ISablierV2.sol
@@ -41,9 +41,6 @@ interface ISablierV2 {
     /// @notice Emitted when attempting to create a stream with the start time greater than the stop time.
     error SablierV2__StartTimeGreaterThanStopTime(uint256 startTime, uint256 stopTime);
 
-    /// @notice Emitted when attempting to withdraw from or cancel multiple streams with an empty array of stream ids.
-    error SablierV2__StreamIdsArrayEmpty();
-
     /// @notice Emitted when attempting to cancel a stream that is already non-cancelable.
     error SablierV2__StreamNonCancelable(uint256 streamId);
 
@@ -176,9 +173,9 @@ interface ISablierV2 {
     /// @dev Emits multiple {Cancel} events.
     ///
     /// Requiremenets:
-    /// - `streamIds` must be non-empty and each element must point to an existing stream.
+    /// - Each stream id in `streamIds` must point to an existing stream.
     /// - `msg.sender` must be either the sender or recipient of every stream.
-    /// - The stream must be cancelable.
+    /// - Each stream must be cancelable.
     ///
     /// @param streamIds The ids of the streams to cancel.
     function cancelAll(uint256[] calldata streamIds) external;
@@ -220,7 +217,7 @@ interface ISablierV2 {
     ) external;
 
     /// @notice Counter for stream ids.
-    /// @return The next stream id;
+    /// @return The next stream id.
     function nextStreamId() external view returns (uint256);
 
     /// @notice Makes the stream non-cancelable.
@@ -253,9 +250,10 @@ interface ISablierV2 {
     /// @dev Emits multiple {Withdraw} event.
     ///
     /// Requirements:
+    /// - The count of `streamIds` must match the count of `amounts`.
     /// - `msg.sender` must be either the sender or recipient of every stream.
-    /// - `streamIds` must be non-empty and each stream id must point to an existing stream.
-    /// - `amounts` must be non-empty and each amount must not be zero and must not exceed the withdrawable amount.
+    /// - Each stream id in `streamIds` must point to an existing stream.
+    /// - Each amount in `amounts` must not be zero and must not exceed the withdrawable amount.
     ///
     /// @param streamIds The ids of the streams to withdraw.
     /// @param amounts The amounts to withdraw, in units of the ERC-20 token's decimals.
@@ -266,10 +264,11 @@ interface ISablierV2 {
     /// @dev Emits multiple {Withdraw} event.
     ///
     /// Requirements:
-    /// - `streamIds` must be non-empty and each stream id must point to an existing stream.
     /// - `to` must not be the zero address.
+    /// - The count of `streamIds` must match the count of `amounts`.
+    /// - Each stream id in `streamIds` must point to an existing stream.
     /// - `msg.sender` must be the recipient of every stream.
-    /// - `amounts` must be non-empty and each amount must not be zero and must not exceed the withdrawable amount.
+    /// - Each amount in `amounts` must not be zero and must not exceed the withdrawable amount.
     ///
     /// @param streamIds The ids of the streams to withdraw.
     /// @param to The address that will receive the withdrawn tokens.

--- a/test/unit/sablier-v2-cliff/cancel-all/cancelAll.t.sol
+++ b/test/unit/sablier-v2-cliff/cancel-all/cancelAll.t.sol
@@ -18,13 +18,6 @@ contract SablierV2Cliff__UnitTest__CancelAll is SablierV2CliffUnitTest {
         defaultStreamIds.push(createDefaultStream());
     }
 
-    /// @dev When the stream ids array length is zero, it should revert.
-    function testCannotCancelAll__StreamIdsArrayEmpty() external {
-        uint256[] memory streamIds;
-        vm.expectRevert(abi.encodeWithSelector(ISablierV2.SablierV2__StreamIdsArrayEmpty.selector));
-        sablierV2Cliff.cancelAll(streamIds);
-    }
-
     /// @dev When the stream ids array points only to non existing streams, it should revert.
     function testCannotCancelAll__OnlyNonExistentStreams() external {
         uint256 nonStreamId = 1729;

--- a/test/unit/sablier-v2-cliff/cancel-all/cancelAll.tree
+++ b/test/unit/sablier-v2-cliff/cancel-all/cancelAll.tree
@@ -1,34 +1,30 @@
 cancelAll.t.sol
-├── when the stream ids array is empty
+├── when the stream ids array points only to non existing streams
 │  └── it should revert
-└── when the stream ids array is not empty
-   ├── when the stream ids array points only to non existing streams
-   │  └── it should revert
-   ├── when the stream ids array points to some non existing streams
-   │  └── it should revert
-   └── when the stream ids array points only to existing streams
-      ├── when the caller is neither the sender nor the recipient of any stream
+├── when the stream ids array points to some non existing streams
+│  └── it should revert
+└── when the stream ids array points only to existing streams
+  ├── when the caller is neither the sender nor the recipient of any stream
+  │  └── it should revert
+  ├── when the caller is neither the sender nor the recipient of some of the streams
+  │  └── it should revert
+  ├── when the caller is the recipient of all the streams
+  │  └── it should cancel the streams
+  └── when the caller is the sender of all the streams
+      ├── when all streams are non-cancelable
       │  └── it should revert
-      ├── when the caller is neither the sender nor the recipient of some of the streams
+      ├── when some of the streams are non-cancelable
       │  └── it should revert
-      ├── when the caller is the recipient of all the streams
-      │  └── it should cancel the streams
-      └── when the caller is the sender of all the streams
-         ├── when all streams are non-cancelable
-         │  └── it should revert
-         ├── when some of the streams are non-cancelable
-         │  └── it should revert
-         └── when all streams are cancelable
-            ├── when all streams are ended
-            │  ├── it should cancel the streams
-            │  ├── it should delete all the streams
-            │  └── it should emit multiple Cancel events
-            ├── when all streams are ongoing
-            │  ├── it should cancel the streams
-            │  ├── it should delete all the streams
-            │  └── it should emit multiple Cancel events
-            └── when some of the streams are ended and some are ongoing
-               ├── it should cancel the streams
-               ├── it should delete all the streams
-               └── it should emit multiple Cancel events
-
+      └── when all streams are cancelable
+        ├── when all streams are ended
+        │  ├── it should cancel the streams
+        │  ├── it should delete all the streams
+        │  └── it should emit multiple Cancel events
+        ├── when all streams are ongoing
+        │  ├── it should cancel the streams
+        │  ├── it should delete all the streams
+        │  └── it should emit multiple Cancel events
+        └── when some of the streams are ended and some are ongoing
+            ├── it should cancel the streams
+            ├── it should delete all the streams
+            └── it should emit multiple Cancel events

--- a/test/unit/sablier-v2-cliff/withdraw-all-to/withdrawAllTo.t.sol
+++ b/test/unit/sablier-v2-cliff/withdraw-all-to/withdrawAllTo.t.sol
@@ -37,14 +37,6 @@ contract SablierV2Cliff__UnitTest__WithdrawAllTo is SablierV2CliffUnitTest {
         sablierV2Cliff.withdrawAllTo(defaultStreamIds, toZero, defaultAmounts);
     }
 
-    /// @dev When the stream ids array is empty, it should revert.
-    function testCannotWithdrawAllTo__StreamIdsArrayEmpty() external {
-        uint256[] memory streamIds;
-        uint256[] memory amounts;
-        vm.expectRevert(abi.encodeWithSelector(ISablierV2.SablierV2__StreamIdsArrayEmpty.selector));
-        sablierV2Cliff.withdrawAllTo(streamIds, toAlice, amounts);
-    }
-
     /// @dev When the array counts are not equal, it should revert.
     function testCannotWithdrawAllTo__WithdrawAllArraysNotEqual() external {
         uint256[] memory streamIds = new uint256[](2);

--- a/test/unit/sablier-v2-cliff/withdraw-all-to/withdrawAllTo.tree
+++ b/test/unit/sablier-v2-cliff/withdraw-all-to/withdrawAllTo.tree
@@ -2,46 +2,43 @@ withdrawAllTo.t.sol
 ├── when the to address is zero
 │  └── it should revert
 └── when the to address is not zero
-   ├── when the stream ids array is empty
+   ├── when the array counts are not equal
    │  └── it should revert
-   └── when the stream ids array is not empty
-     ├── when the array counts are not equal
-     │  └── it should revert
-     └── when the array counts are equal
-           ├── when the stream ids array points only to non existing streams
-           │  └── it should revert
-           ├── when the stream ids array points to some non existing streams
-           │  └── it should revert
-           └── when the stream ids array points only to existing stream
-             ├── when the caller is not the recipient of any stream
-             │  ├── when the caller is the sender
-             │  │  └── it should revert
-             │  └── when the caller is an unauthorized third-party
-             │     └── it should revert
-             ├── when the caller is not the recipient of some of the streams
-             │  ├── when the caller is the sender
-             │  │  └── it should revert
-             │  └── when the caller is an unauthorized third-party
-             │     └── it should revert
-             └── when the caller is the recipient of all of the streams
-                 ├── when some amounts are zero
+   └── when the array counts are equal
+         ├── when the stream ids array points only to non existing streams
+         │  └── it should revert
+         ├── when the stream ids array points to some non existing streams
+         │  └── it should revert
+         └── when the stream ids array points only to existing stream
+           ├── when the caller is not the recipient of any stream
+           │  ├── when the caller is the sender
+           │  │  └── it should revert
+           │  └── when the caller is an unauthorized third-party
+           │     └── it should revert
+           ├── when the caller is not the recipient of some of the streams
+           │  ├── when the caller is the sender
+           │  │  └── it should revert
+           │  └── when the caller is an unauthorized third-party
+           │     └── it should revert
+           └── when the caller is the recipient of all of the streams
+               ├── when some amounts are zero
+               │  └── it should revert
+               └── when all amounts are not zero
+                 ├── when some amounts are greater than the withrawable amounts
                  │  └── it should revert
-                 └── when all amounts are not zero
-                   ├── when some amounts are greater than the withrawable amounts
-                   │  └── it should revert
-                   └── when all amounts are less than or equal to the withdrawable amounts
-                      ├── when the to address is the recipient
-                      │  └── it should make the withdrawals
-                      └── when the to address is a third-party
-                         ├── when all streams are ended
-                         │  ├── it should make the withdrawals
-                         │  ├── it should delete the streams
-                         │  └── it should emit multiple Withdraw events
-                         ├── when all streams are ongoing
-                         │  ├── it should make the withdrawals
-                         │  ├── it should update the withdrawn amounts
-                         │  └── it should emit multiple Withdraw events
-                         └── when some streams are ended and some streams are ongoing
-                           ├── it should make the withdrawals
-                           ├── it should delete the ended streams and update the withdrawn amounts
-                           └── it should emit multiple Withdraw events
+                 └── when all amounts are less than or equal to the withdrawable amounts
+                   ├── when the to address is the recipient
+                   │  └── it should make the withdrawals
+                   └── when the to address is a third-party
+                       ├── when all streams are ended
+                       │  ├── it should make the withdrawals
+                       │  ├── it should delete the streams
+                       │  └── it should emit multiple Withdraw events
+                       ├── when all streams are ongoing
+                       │  ├── it should make the withdrawals
+                       │  ├── it should update the withdrawn amounts
+                       │  └── it should emit multiple Withdraw events
+                       └── when some streams are ended and some streams are ongoing
+                         ├── it should make the withdrawals
+                         ├── it should delete the ended streams and update the withdrawn amounts
+                         └── it should emit multiple Withdraw events

--- a/test/unit/sablier-v2-cliff/withdraw-all/withdrawAll.t.sol
+++ b/test/unit/sablier-v2-cliff/withdraw-all/withdrawAll.t.sol
@@ -26,14 +26,6 @@ contract SablierV2Cliff__UnitTest__WithdrawAll is SablierV2CliffUnitTest {
         changePrank(users.recipient);
     }
 
-    /// @dev When the stream ids array is empty, it should revert.
-    function testCannotWithdrawAll__StreamIdsArrayEmpty() external {
-        uint256[] memory streamIds;
-        uint256[] memory amounts;
-        vm.expectRevert(abi.encodeWithSelector(ISablierV2.SablierV2__StreamIdsArrayEmpty.selector));
-        sablierV2Cliff.withdrawAll(streamIds, amounts);
-    }
-
     /// @dev When the array counts are not equal, it should revert.
     function testCannotWithdrawAll__WithdrawAllArraysNotEqual() external {
         uint256[] memory streamIds = new uint256[](2);

--- a/test/unit/sablier-v2-cliff/withdraw-all/withdrawAll.tree
+++ b/test/unit/sablier-v2-cliff/withdraw-all/withdrawAll.tree
@@ -1,37 +1,34 @@
 withdrawAll.t.sol
-├── when the stream ids array is empty
+├── when the array counts are not equal
 │  └── it should revert
-└── when the stream ids array is not empty
-   ├── when the array counts are not equal
+└── when the array counts are equal
+   ├── when the stream ids array points only to non existing streams
    │  └── it should revert
-   └── when the array counts are equal
-        ├── when the stream ids array points only to non existing streams
-        │  └── it should revert
-        ├── when the stream ids array points to some non existing streams
-        │  └── it should revert
-        └── when the stream ids array points only to existing stream
-           ├── when the caller is neither the sender nor the recipient of any stream
+   ├── when the stream ids array points to some non existing streams
+   │  └── it should revert
+   └── when the stream ids array points only to existing stream
+     ├── when the caller is neither the sender nor the recipient of any stream
+     │  └── it should revert
+     ├── when the caller is neither the sender nor the recipient of some of the streams
+     │  └── it should revert
+     ├── when the caller is the sender of all of the streams
+     │  └── it should make the withdrawals
+     └── when the caller is the recipient of all of the streams
+         ├── when some amounts are zero
+         │  └── it should revert
+         └── when all amounts are not zero
+           ├── when some amounts are greater than the withrawable amounts
            │  └── it should revert
-           ├── when the caller is neither the sender nor the recipient of some of the streams
-           │  └── it should revert
-           ├── when the caller is the sender of all of the streams
-           │  └── it should make the withdrawals
-           └── when the caller is the recipient of all of the streams
-              ├── when some amounts are zero
-              │  └── it should revert
-              └── when all amounts are not zero
-                 ├── when some amounts are greater than the withrawable amounts
-                 │  └── it should revert
-                 └── when all amounts are less than or equal to the withdrawable amounts
-                    ├── when all streams are ended
-                    │  ├── it should make the withdrawals
-                    │  ├── it should delete the streams
-                    │  └── it should emit multiple Withdraw events
-                    ├── when all streams are ongoing
-                    │  ├── it should make the withdrawals
-                    │  ├── it should update the withdrawn amounts
-                    │  └── it should emit multiple Withdraw events
-                    └── when some streams are ended and some streams are ongoing
-                       ├── it should make the withdrawals
-                       ├── it should delete the ended streams and update the withdrawn amounts
-                       └── it should emit multiple Withdraw events
+           └── when all amounts are less than or equal to the withdrawable amounts
+               ├── when all streams are ended
+               │  ├── it should make the withdrawals
+               │  ├── it should delete the streams
+               │  └── it should emit multiple Withdraw events
+               ├── when all streams are ongoing
+               │  ├── it should make the withdrawals
+               │  ├── it should update the withdrawn amounts
+               │  └── it should emit multiple Withdraw events
+               └── when some streams are ended and some streams are ongoing
+                 ├── it should make the withdrawals
+                 ├── it should delete the ended streams and update the withdrawn amounts
+                 └── it should emit multiple Withdraw events

--- a/test/unit/sablier-v2-linear/cancel-all/cancelAll.t.sol
+++ b/test/unit/sablier-v2-linear/cancel-all/cancelAll.t.sol
@@ -18,13 +18,6 @@ contract SablierV2Linear__UnitTest__CancelAll is SablierV2LinearUnitTest {
         defaultStreamIds.push(createDefaultStream());
     }
 
-    /// @dev When the stream ids array length is zero, it should revert.
-    function testCannotCancelAll__StreamIdsArrayEmpty() external {
-        uint256[] memory streamIds;
-        vm.expectRevert(abi.encodeWithSelector(ISablierV2.SablierV2__StreamIdsArrayEmpty.selector));
-        sablierV2Linear.cancelAll(streamIds);
-    }
-
     /// @dev When the stream ids array points only to non existing streams, it should revert.
     function testCannotCancelAll__OnlyNonExistentStreams() external {
         uint256 nonStreamId = 1729;

--- a/test/unit/sablier-v2-linear/withdraw-all-to/withdrawAllTo.t.sol
+++ b/test/unit/sablier-v2-linear/withdraw-all-to/withdrawAllTo.t.sol
@@ -37,14 +37,6 @@ contract SablierV2Linear__UnitTest__WithdrawAllTo is SablierV2LinearUnitTest {
         sablierV2Linear.withdrawAllTo(defaultStreamIds, toZero, defaultAmounts);
     }
 
-    /// @dev When the stream ids array is empty, it should revert.
-    function testCannotWithdrawAllTo__StreamIdsArrayEmpty() external {
-        uint256[] memory streamIds;
-        uint256[] memory amounts;
-        vm.expectRevert(abi.encodeWithSelector(ISablierV2.SablierV2__StreamIdsArrayEmpty.selector));
-        sablierV2Linear.withdrawAllTo(streamIds, toAlice, amounts);
-    }
-
     /// @dev When the array counts are not equal, it should revert.
     function testCannotWithdrawAllTo__WithdrawAllArraysNotEqual() external {
         uint256[] memory streamIds = new uint256[](2);

--- a/test/unit/sablier-v2-linear/withdraw-all-to/withdrawAllTo.tree
+++ b/test/unit/sablier-v2-linear/withdraw-all-to/withdrawAllTo.tree
@@ -2,46 +2,43 @@ withdrawAllTo.t.sol
 ├── when the to address is zero
 │  └── it should revert
 └── when the to address is not zero
-   ├── when the stream ids array is empty
+   ├── when the array counts are not equal
    │  └── it should revert
-   └── when the stream ids array is not empty
-     ├── when the array counts are not equal
-     │  └── it should revert
-     └── when the array counts are equal
-           ├── when the stream ids array points only to non existing streams
-           │  └── it should revert
-           ├── when the stream ids array points to some non existing streams
-           │  └── it should revert
-           └── when the stream ids array points only to existing stream
-             ├── when the caller is not the recipient of any stream
-             │  ├── when the caller is the sender
-             │  │  └── it should revert
-             │  └── when the caller is an unauthorized third-party
-             │     └── it should revert
-             ├── when the caller is not the recipient of some of the streams
-             │  ├── when the caller is the sender
-             │  │  └── it should revert
-             │  └── when the caller is an unauthorized third-party
-             │     └── it should revert
-             └── when the caller is the recipient of all of the streams
-                 ├── when some amounts are zero
+   └── when the array counts are equal
+         ├── when the stream ids array points only to non existing streams
+         │  └── it should revert
+         ├── when the stream ids array points to some non existing streams
+         │  └── it should revert
+         └── when the stream ids array points only to existing stream
+           ├── when the caller is not the recipient of any stream
+           │  ├── when the caller is the sender
+           │  │  └── it should revert
+           │  └── when the caller is an unauthorized third-party
+           │     └── it should revert
+           ├── when the caller is not the recipient of some of the streams
+           │  ├── when the caller is the sender
+           │  │  └── it should revert
+           │  └── when the caller is an unauthorized third-party
+           │     └── it should revert
+           └── when the caller is the recipient of all of the streams
+               ├── when some amounts are zero
+               │  └── it should revert
+               └── when all amounts are not zero
+                 ├── when some amounts are greater than the withrawable amounts
                  │  └── it should revert
-                 └── when all amounts are not zero
-                   ├── when some amounts are greater than the withrawable amounts
-                   │  └── it should revert
-                   └── when all amounts are less than or equal to the withdrawable amounts
-                      ├── when the to address is the recipient
-                      │  └── it should make the withdrawals
-                      └── when the to address is a third-party
-                         ├── when all streams are ended
-                         │  ├── it should make the withdrawals
-                         │  ├── it should delete the streams
-                         │  └── it should emit multiple Withdraw events
-                         ├── when all streams are ongoing
-                         │  ├── it should make the withdrawals
-                         │  ├── it should update the withdrawn amounts
-                         │  └── it should emit multiple Withdraw events
-                         └── when some streams are ended and some streams are ongoing
-                           ├── it should make the withdrawals
-                           ├── it should delete the ended streams and update the withdrawn amounts
-                           └── it should emit multiple Withdraw events
+                 └── when all amounts are less than or equal to the withdrawable amounts
+                   ├── when the to address is the recipient
+                   │  └── it should make the withdrawals
+                   └── when the to address is a third-party
+                       ├── when all streams are ended
+                       │  ├── it should make the withdrawals
+                       │  ├── it should delete the streams
+                       │  └── it should emit multiple Withdraw events
+                       ├── when all streams are ongoing
+                       │  ├── it should make the withdrawals
+                       │  ├── it should update the withdrawn amounts
+                       │  └── it should emit multiple Withdraw events
+                       └── when some streams are ended and some streams are ongoing
+                         ├── it should make the withdrawals
+                         ├── it should delete the ended streams and update the withdrawn amounts
+                         └── it should emit multiple Withdraw events

--- a/test/unit/sablier-v2-linear/withdraw-all/withdrawAll.t.sol
+++ b/test/unit/sablier-v2-linear/withdraw-all/withdrawAll.t.sol
@@ -26,14 +26,6 @@ contract SablierV2Linear__UnitTest__WithdrawAll is SablierV2LinearUnitTest {
         changePrank(users.recipient);
     }
 
-    /// @dev When the stream ids array is empty, it should revert.
-    function testCannotWithdrawAll__StreamIdsArrayEmpty() external {
-        uint256[] memory streamIds;
-        uint256[] memory amounts;
-        vm.expectRevert(abi.encodeWithSelector(ISablierV2.SablierV2__StreamIdsArrayEmpty.selector));
-        sablierV2Linear.withdrawAll(streamIds, amounts);
-    }
-
     /// @dev When the array counts are not equal, it should revert.
     function testCannotWithdrawAll__WithdrawAllArraysNotEqual() external {
         uint256[] memory streamIds = new uint256[](2);

--- a/test/unit/sablier-v2-linear/withdraw-all/withdrawAll.tree
+++ b/test/unit/sablier-v2-linear/withdraw-all/withdrawAll.tree
@@ -1,37 +1,34 @@
 withdrawAll.t.sol
-├── when the stream ids array is empty
+├── when the array counts are not equal
 │  └── it should revert
-└── when the stream ids array is not empty
-   ├── when the array counts are not equal
+└── when the array counts are equal
+   ├── when the stream ids array points only to non existing streams
    │  └── it should revert
-   └── when the array counts are equal
-        ├── when the stream ids array points only to non existing streams
-        │  └── it should revert
-        ├── when the stream ids array points to some non existing streams
-        │  └── it should revert
-        └── when the stream ids array points only to existing stream
-           ├── when the caller is neither the sender nor the recipient of any stream
-           │  └── it should revert
-           ├── when the caller is neither the sender nor the recipient of some of the streams
-           │  └── it should revert
-           ├── when the caller is the sender of all of the streams
-           │  └── it should make the withdrawals
-           └── when the caller is the recipient of all of the streams
-              ├── when some amounts are zero
-              │  └── it should revert
-              └── when all amounts are not zero
-                 ├── when some amounts are greater than the withrawable amounts
-                 │  └── it should revert
-                 └── when all amounts are less than or equal to the withdrawable amounts
-                    ├── when all streams are ended
-                    │  ├── it should make the withdrawals
-                    │  ├── it should delete the streams
-                    │  └── it should emit multiple Withdraw events
-                    ├── when all streams are ongoing
-                    │  ├── it should make the withdrawals
-                    │  ├── it should update the withdrawn amounts
-                    │  └── it should emit multiple Withdraw events
-                    └── when some streams are ended and some streams are ongoing
-                       ├── it should make the withdrawals
-                       ├── it should delete the ended streams and update the withdrawn amounts
-                       └── it should emit multiple Withdraw events
+   ├── when the stream ids array points to some non existing streams
+   │  └── it should revert
+   └── when the stream ids array points only to existing stream
+       ├── when the caller is neither the sender nor the recipient of any stream
+       │  └── it should revert
+       ├── when the caller is neither the sender nor the recipient of some of the streams
+       │  └── it should revert
+       ├── when the caller is the sender of all of the streams
+       │  └── it should make the withdrawals
+       └── when the caller is the recipient of all of the streams
+         ├── when some amounts are zero
+         │  └── it should revert
+         └── when all amounts are not zero
+             ├── when some amounts are greater than the withrawable amounts
+             │  └── it should revert
+             └── when all amounts are less than or equal to the withdrawable amounts
+               ├── when all streams are ended
+               │  ├── it should make the withdrawals
+               │  ├── it should delete the streams
+               │  └── it should emit multiple Withdraw events
+               ├── when all streams are ongoing
+               │  ├── it should make the withdrawals
+               │  ├── it should update the withdrawn amounts
+               │  └── it should emit multiple Withdraw events
+               └── when some streams are ended and some streams are ongoing
+                   ├── it should make the withdrawals
+                   ├── it should delete the ended streams and update the withdrawn amounts
+                   └── it should emit multiple Withdraw events


### PR DESCRIPTION
Addresses #63, plus:

- [x] chore: improve wording in "all" function comments
- [x] docs: improve wording and formatting in "all" function NatSpec comments
- [x] refactor: set named return variable in "getAuthorization"
- [x] test: delete tests related to the array being empty in "all" functions