### PR TITLE
Fix "cancelAll" to never revert.

### DIFF
--- a/src/SablierV2.sol
+++ b/src/SablierV2.sol
@@ -54,6 +54,11 @@ abstract contract SablierV2 is ISablierV2 {
             revert SablierV2__StreamNonExistent(streamId);
         }
 
+        // Checks: the `msg.sender` is either the sender or the recipient of the stream.
+        if (msg.sender != getSender(streamId) && msg.sender != getRecipient(streamId)) {
+            revert SablierV2__Unauthorized(streamId, msg.sender);
+        }
+
         // Checks: the stream is cancelable.
         if (!isCancelable(streamId)) {
             revert SablierV2__StreamNonCancelable(streamId);
@@ -72,7 +77,10 @@ abstract contract SablierV2 is ISablierV2 {
 
             // Cancel the stream only if the `streamId` points to a stream that exists and is cancelable.
             if (getSender(streamId) != address(0) && isCancelable(streamId)) {
-                cancelInternal(streamId);
+                // Cancel the stream only if the caller is either the sender or the recipient of any stream.
+                if (msg.sender == getSender(streamId) || msg.sender == getRecipient(streamId)) {
+                    cancelInternal(streamId);
+                }
             }
 
             // Increment the for loop iterator.

--- a/src/SablierV2Cliff.sol
+++ b/src/SablierV2Cliff.sol
@@ -367,7 +367,7 @@ contract SablierV2Cliff is
     /// INTERNAL NON-CONSTANT FUNCTIONS ///
 
     /// @dev See the documentation for the public functions that call this internal function.
-    function cancelInternal(uint256 streamId) internal override onlySenderOrRecipient(streamId) {
+    function cancelInternal(uint256 streamId) internal override {
         Stream memory stream = streams[streamId];
 
         // Calculate the withdraw and the return amounts.

--- a/src/SablierV2Linear.sol
+++ b/src/SablierV2Linear.sol
@@ -327,7 +327,7 @@ contract SablierV2Linear is
     /// INTERNAL NON-CONSTANT FUNCTIONS ///
 
     /// @dev See the documentation for the public functions that call this internal function.
-    function cancelInternal(uint256 streamId) internal override onlySenderOrRecipient(streamId) {
+    function cancelInternal(uint256 streamId) internal override {
         Stream memory stream = streams[streamId];
 
         // Calculate the withdraw and the return amounts.

--- a/src/SablierV2Pro.sol
+++ b/src/SablierV2Pro.sol
@@ -513,7 +513,7 @@ contract SablierV2Pro is
     /// INTERNAL NON-CONSTANT FUNCTIONS ///
 
     /// @dev See the documentation for the public functions that call this internal function.
-    function cancelInternal(uint256 streamId) internal override onlySenderOrRecipient(streamId) {
+    function cancelInternal(uint256 streamId) internal override {
         Stream memory stream = streams[streamId];
 
         // Calculate the withdraw and the return amounts.

--- a/test/unit/sablier-v2-cliff/cancel-all/cancelAll.t.sol
+++ b/test/unit/sablier-v2-cliff/cancel-all/cancelAll.t.sol
@@ -36,25 +36,21 @@ contract SablierV2Cliff__UnitTest__CancelAll is SablierV2CliffUnitTest {
         assertEq(actualStream, expectedStream);
     }
 
-    /// @dev When the caller is neither the sender nor the recipient of any stream, it should revert.
+    /// @dev When the caller is neither the sender nor the recipient of any stream, it should do nothing
     function testCannotCancelAll__CallerUnauthorized__AllStreams() external {
         // Make Eve the `msg.sender` in this test case.
         changePrank(users.eve);
-
-        // Run the test.
-        vm.expectRevert(
-            abi.encodeWithSelector(ISablierV2.SablierV2__Unauthorized.selector, defaultStreamIds[0], users.eve)
-        );
         sablierV2Cliff.cancelAll(defaultStreamIds);
     }
 
-    /// @dev When the caller is neither the sender nor the recipient of some of the streams, it should revert.
+    /// @dev When the caller is neither the sender nor the recipient of some of the streams, it should cancel
+    /// and delete the allowed streams.
     function testCannotCancelAll__CallerUnauthorized__SomeStreams() external {
         // Make Eve the `msg.sender` in this test case.
         changePrank(users.eve);
 
         // Create a stream with Eve as the sender.
-        uint256 eveStreamId = sablierV2Cliff.create(
+        uint256 streamIdEve = sablierV2Cliff.create(
             users.eve,
             users.eve,
             stream.recipient,
@@ -67,11 +63,11 @@ contract SablierV2Cliff__UnitTest__CancelAll is SablierV2CliffUnitTest {
         );
 
         // Run the test.
-        uint256[] memory streamIds = createDynamicArray(eveStreamId, defaultStreamIds[0]);
-        vm.expectRevert(
-            abi.encodeWithSelector(ISablierV2.SablierV2__Unauthorized.selector, defaultStreamIds[0], users.eve)
-        );
+        uint256[] memory streamIds = createDynamicArray(streamIdEve, defaultStreamIds[0]);
         sablierV2Cliff.cancelAll(streamIds);
+        ISablierV2Cliff.Stream memory actualStream = sablierV2Cliff.getStream(streamIdEve);
+        ISablierV2Cliff.Stream memory expectedStream;
+        assertEq(actualStream, expectedStream);
     }
 
     /// @dev When the caller is the recipient of all streams, it should cancel and delete the streams.

--- a/test/unit/sablier-v2-cliff/cancel-all/cancelAll.tree
+++ b/test/unit/sablier-v2-cliff/cancel-all/cancelAll.tree
@@ -5,9 +5,9 @@ cancelAll.t.sol
 │  └── it should cancel and delete the existing streams
 └── when the stream ids array points only to existing streams
   ├── when the caller is neither the sender nor the recipient of any stream
-  │  └── it should revert
+  │  └── it should do nothing
   ├── when the caller is neither the sender nor the recipient of some of the streams
-  │  └── it should revert
+  │  └── it should cancel and delete the allowed streams
   ├── when the caller is the recipient of all streams
   │  └── it should cancel and delete the streams
   └── when the caller is the sender of all streams

--- a/test/unit/sablier-v2-linear/cancel-all/cancelAll.t.sol
+++ b/test/unit/sablier-v2-linear/cancel-all/cancelAll.t.sol
@@ -40,11 +40,6 @@ contract SablierV2Linear__UnitTest__CancelAll is SablierV2LinearUnitTest {
     function testCannotCancelAll__CallerUnauthorized__AllStreams() external {
         // Make Eve the `msg.sender` in this test case.
         changePrank(users.eve);
-
-        // Run the test.
-        vm.expectRevert(
-            abi.encodeWithSelector(ISablierV2.SablierV2__Unauthorized.selector, defaultStreamIds[0], users.eve)
-        );
         sablierV2Linear.cancelAll(defaultStreamIds);
     }
 
@@ -67,10 +62,10 @@ contract SablierV2Linear__UnitTest__CancelAll is SablierV2LinearUnitTest {
 
         // Run the test.
         uint256[] memory streamIds = createDynamicArray(streamIdEve, defaultStreamIds[0]);
-        vm.expectRevert(
-            abi.encodeWithSelector(ISablierV2.SablierV2__Unauthorized.selector, defaultStreamIds[0], users.eve)
-        );
         sablierV2Linear.cancelAll(streamIds);
+        ISablierV2Linear.Stream memory actualStream = sablierV2Linear.getStream(streamIdEve);
+        ISablierV2Linear.Stream memory expectedStream;
+        assertEq(actualStream, expectedStream);
     }
 
     /// @dev When the caller is the recipient of all streams, it should cancel and delete the streams.

--- a/test/unit/sablier-v2-linear/cancel-all/cancelAll.tree
+++ b/test/unit/sablier-v2-linear/cancel-all/cancelAll.tree
@@ -8,9 +8,9 @@ cancelAll.t.sol
    │  └── it should cancel and delete the existing streams
    └── when the stream ids array points only to existing streams
       ├── when the caller is neither the sender nor the recipient of any stream
-      │  └── it should revert
+      │  └── it should do nothing
       ├── when the caller is neither the sender nor the recipient of some of the streams
-      │  └── it should revert
+      │  └── it should cancel and delete the allowed streams
       ├── when the caller is the recipient of all streams
       │  └── it should cancel and delete the streams
       └── when the caller is the sender of all streams


### PR DESCRIPTION
Closes https://github.com/sablierhq/v2-core/issues/84
- [x] fix: cancelAll never revert
- [x] test: branches when caller is neither the sender nor the recipient for
cancelAll