### PR TITLE
Move withdraw functions to the "SablierV2" contract

### DIFF
--- a/src/SablierV2Linear.sol
+++ b/src/SablierV2Linear.sol
@@ -22,32 +22,6 @@ contract SablierV2Linear is
     /// @dev Sablier V2 linear streams mapped by unsigned integers.
     mapping(uint256 => Stream) internal streams;
 
-    /// MODIFIERS ///
-
-    /// @notice Checks that `msg.sender` is the recipient of the stream.
-    modifier onlyRecipient(uint256 streamId) {
-        if (msg.sender != streams[streamId].recipient) {
-            revert SablierV2__Unauthorized(streamId, msg.sender);
-        }
-        _;
-    }
-
-    /// @notice Checks that `msg.sender` is either the sender or the recipient of the stream.
-    modifier onlySenderOrRecipient(uint256 streamId) {
-        if (msg.sender != streams[streamId].sender && msg.sender != streams[streamId].recipient) {
-            revert SablierV2__Unauthorized(streamId, msg.sender);
-        }
-        _;
-    }
-
-    /// @dev Checks that `streamId` points to a stream that exists.
-    modifier streamExists(uint256 streamId) {
-        if (streams[streamId].sender == address(0)) {
-            revert SablierV2__StreamNonExistent(streamId);
-        }
-        _;
-    }
-
     /// CONSTANT FUNCTIONS ///
 
     /// @inheritdoc ISablierV2Linear
@@ -206,106 +180,6 @@ contract SablierV2Linear is
         emit Renounce(streamId);
     }
 
-    /// @inheritdoc ISablierV2
-    function withdraw(uint256 streamId, uint256 amount)
-        external
-        streamExists(streamId)
-        onlySenderOrRecipient(streamId)
-    {
-        address to = streams[streamId].recipient;
-        withdrawInternal(streamId, to, amount);
-    }
-
-    /// @inheritdoc ISablierV2
-    function withdrawAll(uint256[] calldata streamIds, uint256[] calldata amounts) external {
-        // Checks: count of `streamIds` matches count of `amounts`.
-        uint256 streamIdsCount = streamIds.length;
-        uint256 amountsCount = amounts.length;
-        if (streamIdsCount != amountsCount) {
-            revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);
-        }
-
-        // Iterate over the provided array of stream ids and withdraw from each stream.
-        address sender;
-        uint256 streamId;
-        for (uint256 i = 0; i < streamIdsCount; ) {
-            streamId = streamIds[i];
-
-            // If the `streamId` points to a stream that does not exist, skip it.
-            sender = streams[streamId].sender;
-            if (sender != address(0)) {
-                // Checks: the `msg.sender` is either the sender or the recipient of the stream.
-                if (msg.sender != sender && msg.sender != streams[streamId].recipient) {
-                    revert SablierV2__Unauthorized(streamId, msg.sender);
-                }
-
-                // Checks, Effects and Interactions: make the withdrawal.
-                withdrawInternal(streamId, streams[streamId].recipient, amounts[i]);
-            }
-
-            // Increment the for loop iterator.
-            unchecked {
-                i += 1;
-            }
-        }
-    }
-
-    /// @inheritdoc ISablierV2
-    function withdrawTo(
-        uint256 streamId,
-        address to,
-        uint256 amount
-    ) external streamExists(streamId) onlyRecipient(streamId) {
-        // Checks: the provided address to withdraw to is not zero.
-        if (to == address(0)) {
-            revert SablierV2__WithdrawZeroAddress();
-        }
-
-        // Checks, Effects and Interactions: make the withdrawal.
-        withdrawInternal(streamId, to, amount);
-    }
-
-    /// @inheritdoc ISablierV2
-    function withdrawAllTo(
-        uint256[] calldata streamIds,
-        address to,
-        uint256[] calldata amounts
-    ) external {
-        // Checks: the provided address to withdraw to is not zero.
-        if (to == address(0)) {
-            revert SablierV2__WithdrawZeroAddress();
-        }
-
-        // Checks: count of `streamIds` matches `amounts`.
-        uint256 streamIdsCount = streamIds.length;
-        uint256 amountsCount = amounts.length;
-        if (streamIdsCount != amountsCount) {
-            revert SablierV2__WithdrawAllArraysNotEqual(streamIdsCount, amountsCount);
-        }
-
-        // Iterate over the provided array of stream ids and withdraw from each stream.
-        uint256 streamId;
-        for (uint256 i = 0; i < streamIdsCount; ) {
-            streamId = streamIds[i];
-
-            // If the `streamId` points to a stream that does not exist, skip it.
-            if (streams[streamId].sender != address(0)) {
-                // Checks: the `msg.sender` is the recipient of the stream.
-                if (msg.sender != streams[streamId].recipient) {
-                    revert SablierV2__Unauthorized(streamId, msg.sender);
-                }
-
-                // Checks, Effects and Interactions: make the withdrawal.
-                withdrawInternal(streamId, to, amounts[i]);
-            }
-
-            // Increment the for loop iterator.
-            unchecked {
-                i += 1;
-            }
-        }
-    }
-
     /// INTERNAL NON-CONSTANT FUNCTIONS ///
 
     /// @dev See the documentation for the public functions that call this internal function.
@@ -403,7 +277,7 @@ contract SablierV2Linear is
         uint256 streamId,
         address to,
         uint256 amount
-    ) internal {
+    ) internal override {
         // Checks: the amount must not be zero.
         if (amount == 0) {
             revert SablierV2__WithdrawAmountZero(streamId);

--- a/test/unit/abstract-sablier-v2/AbstractSablierV2UnitTest.t.sol
+++ b/test/unit/abstract-sablier-v2/AbstractSablierV2UnitTest.t.sol
@@ -75,44 +75,20 @@ contract AbstractSablierV2 is SablierV2 {
         streamId;
     }
 
-    /// @inheritdoc ISablierV2
-    function withdraw(uint256 streamId, uint256 amount) external pure override {
-        streamId;
-        amount;
-    }
-
-    /// @inheritdoc ISablierV2
-    function withdrawAll(uint256[] calldata streamIds, uint256[] calldata amounts) external pure override {
-        streamIds;
-        amounts;
-    }
-
-    /// @inheritdoc ISablierV2
-    function withdrawTo(
-        uint256 streamId,
-        address to,
-        uint256 amount
-    ) external pure override {
-        streamId;
-        to;
-        amount;
-    }
-
-    /// @inheritdoc ISablierV2
-    function withdrawAllTo(
-        uint256[] calldata streamIds,
-        address to,
-        uint256[] calldata amounts
-    ) external pure override {
-        streamIds;
-        to;
-        amounts;
-    }
-
     /// INTERNAL NON-CONSTANT FUNCTIONS ///
 
     function cancelInternal(uint256 streamId) internal pure override {
         streamId;
+    }
+
+    function withdrawInternal(
+        uint256 streamId,
+        address to,
+        uint256 amount
+    ) internal pure override {
+        streamId;
+        to;
+        amount;
     }
 }
 


### PR DESCRIPTION
Moves the `withdraw` functions to the abstract `SablierV2` contract.

Depends upon #75, #78, #79, #82, #83 and #87 being merged first.