### PR TITLE
refactor: use "_mint" instead of "_safeMint"

### DIFF
--- a/src/SablierV2Linear.sol
+++ b/src/SablierV2Linear.sol
@@ -262,7 +262,7 @@ contract SablierV2Linear is
         });
 
         // Effects: mint the NFT for the recipient.
-        _safeMint(recipient, streamId);
+        _mint(recipient, streamId);
 
         // Effects: bump the next stream id.
         // We're using unchecked arithmetic here because this cannot realistically overflow, ever.

--- a/src/SablierV2Pro.sol
+++ b/src/SablierV2Pro.sol
@@ -466,7 +466,7 @@ contract SablierV2Pro is
         });
 
         // Effects: mint the NFT for the recipient.
-        _safeMint(recipient, streamId);
+        _mint(recipient, streamId);
 
         // Effects: bump the next stream id. This cannot realistically overflow, ever.
         unchecked {

--- a/test/unit/sablier-v2-linear/cancel-all/cancelAll.t.sol
+++ b/test/unit/sablier-v2-linear/cancel-all/cancelAll.t.sol
@@ -187,8 +187,8 @@ contract SablierV2Linear__CancelAll is SablierV2LinearUnitTest {
         CallerRecipientAllStreams
     {
         // Transfer the streams to Alice.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, defaultStreamIds[0]);
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, defaultStreamIds[1]);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, defaultStreamIds[0]);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, defaultStreamIds[1]);
 
         // Run the test.
         vm.expectRevert(
@@ -206,7 +206,7 @@ contract SablierV2Linear__CancelAll is SablierV2LinearUnitTest {
         CallerRecipientAllStreams
     {
         // Transfer one of the streams to eve.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, defaultStreamIds[0]);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, defaultStreamIds[0]);
 
         // Run the test.
         vm.expectRevert(

--- a/test/unit/sablier-v2-linear/cancel/cancel.t.sol
+++ b/test/unit/sablier-v2-linear/cancel/cancel.t.sol
@@ -109,7 +109,7 @@ contract SablierV2Linear__Cancel is SablierV2LinearUnitTest {
         CallerRecipient
     {
         // Transfer the stream to Alice.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, daiStreamId);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, daiStreamId);
 
         // Run the test.
         vm.expectRevert(

--- a/test/unit/sablier-v2-linear/withdraw-all-to/withdrawAllTo.t.sol
+++ b/test/unit/sablier-v2-linear/withdraw-all-to/withdrawAllTo.t.sol
@@ -239,8 +239,8 @@ contract SablierV2Linear__WithdrawAllTo is SablierV2LinearUnitTest {
         CallerRecipientAllStreams
     {
         // Transfer the streams to eve.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.eve, defaultStreamIds[0]);
-        sablierV2Linear.safeTransferFrom(users.recipient, users.eve, defaultStreamIds[1]);
+        sablierV2Linear.transferFrom(users.recipient, users.eve, defaultStreamIds[0]);
+        sablierV2Linear.transferFrom(users.recipient, users.eve, defaultStreamIds[1]);
 
         // Run the test.
         vm.expectRevert(
@@ -259,7 +259,7 @@ contract SablierV2Linear__WithdrawAllTo is SablierV2LinearUnitTest {
         CallerRecipientAllStreams
     {
         // Transfer one of the streams to eve.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.eve, defaultStreamIds[0]);
+        sablierV2Linear.transferFrom(users.recipient, users.eve, defaultStreamIds[0]);
 
         // Run the test.
         vm.expectRevert(

--- a/test/unit/sablier-v2-linear/withdraw-all/withdrawAll.t.sol
+++ b/test/unit/sablier-v2-linear/withdraw-all/withdrawAll.t.sol
@@ -187,8 +187,8 @@ contract SablierV2Linear__WithdrawAll is SablierV2LinearUnitTest {
         CallerRecipientAllStreams
     {
         // Transfer the streams to Alice.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, defaultStreamIds[0]);
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, defaultStreamIds[1]);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, defaultStreamIds[0]);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, defaultStreamIds[1]);
 
         // Run the test.
         vm.expectRevert(
@@ -206,7 +206,7 @@ contract SablierV2Linear__WithdrawAll is SablierV2LinearUnitTest {
         CallerRecipientAllStreams
     {
         // Transfer one of the streams to eve.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, defaultStreamIds[0]);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, defaultStreamIds[0]);
 
         // Run the test.
         vm.expectRevert(

--- a/test/unit/sablier-v2-linear/withdraw-to/withdrawTo.t.sol
+++ b/test/unit/sablier-v2-linear/withdraw-to/withdrawTo.t.sol
@@ -107,7 +107,7 @@ contract SablierV2Linear__WithdrawTo is SablierV2LinearUnitTest {
         CallerRecipient
     {
         // Transfer the stream to Alice.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, daiStreamId);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, daiStreamId);
 
         // Run the test.
         vm.expectRevert(

--- a/test/unit/sablier-v2-linear/withdraw/withdraw.t.sol
+++ b/test/unit/sablier-v2-linear/withdraw/withdraw.t.sol
@@ -95,7 +95,7 @@ contract SablierV2Linear__Withdraw is SablierV2LinearUnitTest {
         CallerRecipient
     {
         // Transfer the stream to Alice.
-        sablierV2Linear.safeTransferFrom(users.recipient, users.alice, daiStreamId);
+        sablierV2Linear.transferFrom(users.recipient, users.alice, daiStreamId);
 
         // Run the test.
         vm.expectRevert(


### PR DESCRIPTION
## Rationale

In the previous PR, @andreivladbrg used the `_safeMint` function to mint the NFTs in our `create` functions. But this is not quite right, because it means that smart contract wallet recipients like Gnosis Safe won't be able to receive streams (since they don't implement the [`IERC721receiver`][ierc721-receiver] interface). This is a big no-no.

This PR changes the function to `_mint`, which does not check for the receiver interface. And this is fine because:

1. Smart contract wallets can still transfer NFTs (see explanation [here][se])
2. Those contract which cannot transfer NFTs can presumably still interact with Sablier, otherwise the sender wouldn't have created the stream with them as `recipient`. And if they can interact with Sablier, they can cancel and withdraw from the stream.

Our protocol is first and foremost a streaming service, and only second an NFT project. The NFT is there only to give us interoperability with the outer DeFi ecosystem.

Separately, this PR also changes the tests to use `transferFrom` function instead of `safeTransferFrom`, since the latter is not needed for EOAs (and it's only EOAs that we use in our tests).

## Changelog:

- [x] refactor: use "_mint" instead of "_safeMint"
- [x] test: use "transferFrom" instead of "safeTransferFrom"

[ierc721-receiver]: https://docs.openzeppelin.com/contracts/2.x/api/token/erc721#IERC721Receiver
[se]: https://ethereum.stackexchange.com/questions/124516/safetransferfrom-of-erc721-not-working-when-transfering-nft-to-a-safe-address