### PR TITLE
perf: use vanilla minus instead of "uncheckedSub"

### DIFF
--- a/src/SablierV2Linear.sol
+++ b/src/SablierV2Linear.sol
@@ -117,8 +117,7 @@ contract SablierV2Linear is
             UD60x18 elapsedTimePercentage = elapsedTime.div(totalTime);
             UD60x18 depositAmount = UD60x18.wrap(_streams[streamId].depositAmount);
             UD60x18 streamedAmount = elapsedTimePercentage.mul(depositAmount);
-            UD60x18 withdrawnAmount = UD60x18.wrap(_streams[streamId].withdrawnAmount);
-            withdrawableAmount = uint128(UD60x18.unwrap(streamedAmount) - UD60x18.unwrap(withdrawnAmount));
+            withdrawableAmount = uint128(UD60x18.unwrap(streamedAmount)) - _streams[streamId].withdrawnAmount;
         }
     }
 

--- a/src/SablierV2Pro.sol
+++ b/src/SablierV2Pro.sol
@@ -194,8 +194,7 @@ contract SablierV2Pro is
             SD59x18 multiplier = elapsedTimePercentage.pow(currentSegmentExponent);
             SD59x18 proRataAmount = multiplier.mul(currentSegmentAmount);
             SD59x18 streamedAmount = SD59x18.wrap(int256(uint256(previousSegmentAmounts))).add(proRataAmount);
-            SD59x18 withdrawnAmount = SD59x18.wrap(int256(uint256(_streams[streamId].withdrawnAmount)));
-            withdrawableAmount = uint128(uint256(SD59x18.unwrap(streamedAmount) - SD59x18.unwrap(withdrawnAmount)));
+            withdrawableAmount = uint128(uint256(SD59x18.unwrap(streamedAmount))) - _streams[streamId].withdrawnAmount;
         }
     }
 


### PR DESCRIPTION
## Description

Implements #185.

## Gas Comparison

Implementing this has resulted in a little gas saving of 25 gas for the `getWithdrawableAmount` function.

<details>
<summary>Before (commit c1fa61 on the "main" branch)</summary>
<img width="882" alt="gas-c1fa61" src="https://user-images.githubusercontent.com/8782666/205900542-564805ba-704e-45d4-b484-9af7793e00b4.png">
</details>

<details>
<summary>After (commit 5676fe on the "vanilla-minus" branch)</summary>
<img width="872" alt="gas-5676fe" src="https://user-images.githubusercontent.com/8782666/205900561-61e51992-bd08-4bee-9cbe-d9e719ed8d9a.png">
</details>