### PR TITLE
refactor: use "Adminable" instead of "Ownable"

### DIFF
--- a/src/SablierV2.sol
+++ b/src/SablierV2.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0
 pragma solidity >=0.8.13;
 
+import { Adminable } from "@prb/contracts/access/Adminable.sol";
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
-import { Ownable } from "@prb/contracts/access/Ownable.sol";
 import { SafeERC20 } from "@prb/contracts/token/erc20/SafeERC20.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
@@ -15,7 +15,7 @@ import { ISablierV2Comptroller } from "./interfaces/ISablierV2Comptroller.sol";
 /// @title SablierV2
 /// @dev Abstract contract implementing common logic. Implements the ISablierV2 interface.
 abstract contract SablierV2 is
-    Ownable, // one dependency
+    Adminable, // one dependency
     ISablierV2 // three dependencies
 {
     using SafeERC20 for IERC20;
@@ -155,7 +155,7 @@ abstract contract SablierV2 is
     }
 
     /// @inheritdoc ISablierV2
-    function claimProtocolRevenues(IERC20 token) external override onlyOwner {
+    function claimProtocolRevenues(IERC20 token) external override onlyAdmin {
         // Checks: the protocol revenues are not zero.
         uint128 protocolRevenues = _protocolRevenues[token];
         if (protocolRevenues == 0) {
@@ -188,14 +188,14 @@ abstract contract SablierV2 is
     }
 
     /// @inheritdoc ISablierV2
-    function setComptroller(ISablierV2Comptroller newComptroller) external override onlyOwner {
+    function setComptroller(ISablierV2Comptroller newComptroller) external override onlyAdmin {
         // Effects: set the comptroller.
         ISablierV2Comptroller oldComptroller = comptroller;
         comptroller = newComptroller;
 
         // Emit an event.
         emit Events.SetComptroller({
-            owner: msg.sender,
+            admin: msg.sender,
             oldComptroller: oldComptroller,
             newComptroller: newComptroller
         });

--- a/src/SablierV2Comptroller.sol
+++ b/src/SablierV2Comptroller.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0
 pragma solidity >=0.8.13;
 
+import { Adminable } from "@prb/contracts/access/Adminable.sol";
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
-import { Ownable } from "@prb/contracts/access/Ownable.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 import { Events } from "./libraries/Events.sol";
@@ -13,7 +13,7 @@ import { ISablierV2Comptroller } from "./interfaces/ISablierV2Comptroller.sol";
 /// @dev This contract implements the ISablierV2Comptroller interface.
 contract SablierV2Comptroller is
     ISablierV2Comptroller, // one dependency
-    Ownable // one dependency
+    Adminable // one dependency
 {
     /*//////////////////////////////////////////////////////////////////////////
                                   INTERNAL STORAGE
@@ -36,12 +36,12 @@ contract SablierV2Comptroller is
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ISablierV2Comptroller
-    function setProtocolFee(IERC20 token, UD60x18 newProtocolFee) external onlyOwner {
+    function setProtocolFee(IERC20 token, UD60x18 newProtocolFee) external onlyAdmin {
         // Effects: set the new global fee.
         UD60x18 oldProtocolFee = _protocolFees[token];
         _protocolFees[token] = newProtocolFee;
 
         // Emit an event.
-        emit Events.SetProtocolFee(owner, token, oldProtocolFee, newProtocolFee);
+        emit Events.SetProtocolFee(msg.sender, token, oldProtocolFee, newProtocolFee);
     }
 }

--- a/src/interfaces/ISablierV2.sol
+++ b/src/interfaces/ISablierV2.sol
@@ -3,14 +3,14 @@ pragma solidity >=0.8.13;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { IOwnable } from "@prb/contracts/access/IOwnable.sol";
+import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 /// @title ISablierV2
 /// @notice The common interface between all Sablier V2 streaming contracts.
 interface ISablierV2 is
-    IOwnable, // no dependencies
+    IAdminable, // no dependencies
     IERC721 // one dependency
 {
     /*//////////////////////////////////////////////////////////////////////////
@@ -170,7 +170,7 @@ interface ISablierV2 is
     /// - It is not an error to set the same comptroller.
     ///
     /// Requirements:
-    /// - The caller must be the owner of the contract.
+    /// - The caller must be the admin of the contract.
     ///
     /// @param newComptroller The address of the new SablierV2Comptroller contract.
     function setComptroller(ISablierV2Comptroller newComptroller) external;
@@ -184,8 +184,8 @@ interface ISablierV2 is
     ///
     /// Requirements:
     /// - `streamId` must point to an existent stream.
-    /// - `msg.sender` must be the sender of the stream, an approved operator, or the owner of the
-    /// NFT (also known as the recipient of the stream).
+    /// - `msg.sender` must be the sender of the stream, an approved operator, or the owner of the NFT (also known
+    /// as the recipient of the stream).
     /// - `to` must be the recipient if `msg.sender` is the sender of the stream.
     /// - `amount` must not be zero and must not exceed the withdrawable amount.
     ///

--- a/src/interfaces/ISablierV2Comptroller.sol
+++ b/src/interfaces/ISablierV2Comptroller.sol
@@ -2,13 +2,13 @@
 pragma solidity >=0.8.13;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
-import { IOwnable } from "@prb/contracts/access/IOwnable.sol";
+import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 /// @title ISablierV2Controller
 /// @notice This contract is in charge of the Sablier V2 protocol configuration, handling such values as the
 /// protocol fees.
-interface ISablierV2Comptroller is IOwnable {
+interface ISablierV2Comptroller is IAdminable {
     /// @notice Queries the protocol fee charged on all Sablier V2 streams created with the provided token.
     /// @param token The address of the token to make the query for.
     /// @return protocolFee The protocol fee as an UD60x18 number where 100% = 1e18.
@@ -24,7 +24,7 @@ interface ISablierV2Comptroller is IOwnable {
     /// - Does not revert if the fee is the same.
     ///
     /// Requirements:
-    /// - The caller must be the owner.
+    /// - The caller must be the admin of the contract.
     /// - The new protocol fee cannot be greater than `MAX_FEE`.
     ///
     /// @param token The address of the token to make the query for.

--- a/src/libraries/Events.sol
+++ b/src/libraries/Events.sol
@@ -91,20 +91,22 @@ library Events {
     /// @param streamId The id of the stream.
     event Renounce(uint256 indexed streamId);
 
-    /// @notice Emitted when the SablierV2Comptroller contract is set.
+    /// @notice Emitted when the contract admin sets a new comptroller contract.
+    /// @param admin The address of the current contract admin.
+    /// @param oldComptroller The address of the old SablierV2Comptroller contract.
     /// @param newComptroller The address of the new SablierV2Comptroller contract.
     event SetComptroller(
-        address indexed owner,
+        address indexed admin,
         ISablierV2Comptroller oldComptroller,
         ISablierV2Comptroller newComptroller
     );
 
-    /// @notice Emitted when the contract owner sets a new protocol fee for the provided token.
-    /// @param owner The address of the current contract owner.
+    /// @notice Emitted when the contract admin sets a new protocol fee for the provided token.
+    /// @param admin The address of the current contract admin.
     /// @param token The address of the ERC-20 token the new protocol fee was set for.
     /// @param oldFee The old global fee for the provided token, as an UD60x18 number.
     /// @param newFee The new global fee for the provided token, as an UD60x18 number.
-    event SetProtocolFee(address indexed owner, IERC20 indexed token, UD60x18 oldFee, UD60x18 newFee);
+    event SetProtocolFee(address indexed admin, IERC20 indexed token, UD60x18 oldFee, UD60x18 newFee);
 
     /// @notice Emitted when tokens are withdrawn from a stream.
     /// @param streamId The id of the stream.

--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -27,6 +27,8 @@ abstract contract BaseTest is Assertions, Constants, Utils, StdCheats {
     //////////////////////////////////////////////////////////////////////////*/
 
     struct Users {
+        // Default admin of all Sablier V2 contracts.
+        address payable admin;
         // Neutral user.
         address payable alice;
         // Default stream broker.
@@ -35,8 +37,6 @@ abstract contract BaseTest is Assertions, Constants, Utils, StdCheats {
         address payable eve;
         // Default NFT operator.
         address payable operator;
-        // Default owner of all Sablier V2 contracts.
-        address payable owner;
         // Default stream recipient.
         address payable recipient;
         // Default stream sender.
@@ -102,11 +102,11 @@ abstract contract BaseTest is Assertions, Constants, Utils, StdCheats {
     function setUp() public virtual {
         // Create users for testing.
         users = Users({
+            admin: createUser("Admin"),
             alice: createUser("Alice"),
             broker: createUser("Broker"),
             eve: createUser("Eve"),
             operator: createUser("Operator"),
-            owner: createUser("Owner"),
             recipient: createUser("Recipient"),
             sender: createUser("Sender")
         });
@@ -149,7 +149,7 @@ abstract contract BaseTest is Assertions, Constants, Utils, StdCheats {
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @dev Approves all Sablier contracts to spend tokens from the sender, recipient, Alice and Eve,
-    /// and then change the active prank back to the owner.
+    /// and then change the active prank back to the admin.
     function approveSablierContracts() internal {
         changePrank(users.sender);
         dai.approve({ spender: address(linear), value: UINT256_MAX });
@@ -175,8 +175,8 @@ abstract contract BaseTest is Assertions, Constants, Utils, StdCheats {
         nonCompliantToken.approve({ spender: address(linear), value: UINT256_MAX });
         nonCompliantToken.approve({ spender: address(pro), value: UINT256_MAX });
 
-        // Finally, change the active prank back to the owner.
-        changePrank(users.owner);
+        // Finally, change the active prank back to the admin.
+        changePrank(users.admin);
     }
 
     /// @dev Generates an address by hashing the name, labels the address and funds it with 100 ETH, 1 million DAI,
@@ -191,8 +191,8 @@ abstract contract BaseTest is Assertions, Constants, Utils, StdCheats {
 
     /// @dev Conditionally deploy contracts normally or from precompiled source.
     function deploySablierContracts() internal {
-        // We deploy all contracts with the owner as the caller.
-        vm.startPrank({ msgSender: users.owner });
+        // We deploy all contracts with the admin as the caller.
+        vm.startPrank({ msgSender: users.admin });
 
         // We deploy from precompiled source if the profile is "test-optimized".
         if (isTestOptimizedProfile()) {

--- a/test/unit/UnitTest.t.sol
+++ b/test/unit/UnitTest.t.sol
@@ -40,8 +40,8 @@ abstract contract UnitTest is BaseTest {
         // Label the test contracts.
         labelTestContracts();
 
-        // Finally, change the active prank back to the owner.
-        changePrank(users.owner);
+        // Finally, change the active prank back to the admin.
+        changePrank(users.admin);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
+++ b/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import { IOwnable } from "@prb/contracts/access/IOwnable.sol";
+import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
@@ -13,8 +13,8 @@ contract GetProtocolFee__ComptrollerTest is ComptrollerTest {
     function setUp() public override {
         ComptrollerTest.setUp();
 
-        // Make the owner the caller in this test suite.
-        changePrank(users.owner);
+        // Make the admin the caller in this test suite.
+        changePrank(users.admin);
     }
 
     /// @dev it should return zero.

--- a/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
+++ b/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import { IOwnable } from "@prb/contracts/access/IOwnable.sol";
+import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
@@ -11,25 +11,25 @@ import { ComptrollerTest } from "../ComptrollerTest.t.sol";
 
 contract SetProtocolFee__ComptrollerTest is ComptrollerTest {
     /// @dev it should revert.
-    function testCannotSetProtocolFee__CallerNotOwner(address eve) external {
-        vm.assume(eve != users.owner);
+    function testCannotSetProtocolFee__CallerNotAdmin(address eve) external {
+        vm.assume(eve != users.admin);
 
         // Make Eve the caller in this test.
         changePrank(eve);
 
         // Run the test.
-        vm.expectRevert(abi.encodeWithSelector(IOwnable.Ownable__CallerNotOwner.selector, users.owner, eve));
+        vm.expectRevert(abi.encodeWithSelector(IAdminable.Adminable__CallerNotAdmin.selector, users.admin, eve));
         comptroller.setProtocolFee(dai, DEFAULT_MAX_FEE);
     }
 
-    modifier CallerOwner() {
-        // Make the owner the caller in the rest of this test suite.
-        changePrank(users.owner);
+    modifier CallerAdmin() {
+        // Make the admin the caller in the rest of this test suite.
+        changePrank(users.admin);
         _;
     }
 
     /// @dev it should re-set the protocol fee.
-    function testSetProtocolFee__SameFee() external CallerOwner {
+    function testSetProtocolFee__SameFee() external CallerAdmin {
         UD60x18 newProtocolFee = ud(0);
         comptroller.setProtocolFee(dai, newProtocolFee);
 
@@ -39,7 +39,7 @@ contract SetProtocolFee__ComptrollerTest is ComptrollerTest {
     }
 
     /// @dev it should set the new protocol fee
-    function testSetProtocolFee__DifferentFee(UD60x18 newProtocolFee) external CallerOwner {
+    function testSetProtocolFee__DifferentFee(UD60x18 newProtocolFee) external CallerAdmin {
         newProtocolFee = bound(newProtocolFee, 1, DEFAULT_MAX_FEE);
         comptroller.setProtocolFee(dai, newProtocolFee);
 

--- a/test/unit/comptroller/set-protocol-fee/setProtocolFee.tree
+++ b/test/unit/comptroller/set-protocol-fee/setProtocolFee.tree
@@ -1,7 +1,7 @@
 setProtocolFee.t.sol
-├── when the caller is not the owner
+├── when the caller is not the admin
 │  └── it should revert
-└── when the caller is the owner
+└── when the caller is the admin
    ├── when the new protocol fee is the same as the current protocol fee
    │  └── it should re-set the protocol fee
    └── when the new protocol fee is not the same as the current protocol fee

--- a/test/unit/sablier-v2/linear/create-with-range/createWithRange.t.sol
+++ b/test/unit/sablier-v2/linear/create-with-range/createWithRange.t.sol
@@ -102,7 +102,7 @@ contract CreateWithRange__LinearTest is LinearTest {
         protocolFee = bound(protocolFee, DEFAULT_MAX_FEE.add(ud(1)), MAX_UD60x18);
 
         // Set the protocol fee.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(params.createWithRange.token, protocolFee);
 
         // Run the test.
@@ -349,7 +349,7 @@ contract CreateWithRange__LinearTest is LinearTest {
         protocolFee = bound(protocolFee, 0, DEFAULT_MAX_FEE);
 
         // Set the fuzzed protocol fee.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(params.createWithRange.token, protocolFee);
 
         // Make the sender the funder in this test.

--- a/test/unit/sablier-v2/linear/get-withdrawable-amount/getWithdrawableAmount.t.sol
+++ b/test/unit/sablier-v2/linear/get-withdrawable-amount/getWithdrawableAmount.t.sol
@@ -86,7 +86,7 @@ contract GetWithdrawableAmount__LinearTest is LinearTest {
 
     modifier CurrentTimeLessThanStopTime() {
         // Disable the protocol fee so that it doesn't interfere with the calculations.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(dai, ZERO);
         changePrank(users.sender);
         _;

--- a/test/unit/sablier-v2/pro/create-with-milestones/createWithMilestones.t.sol
+++ b/test/unit/sablier-v2/pro/create-with-milestones/createWithMilestones.t.sol
@@ -136,7 +136,7 @@ contract CreateWithMilestones__ProTest is ProTest {
         depositDelta = boundUint128(depositDelta, 100, DEFAULT_GROSS_DEPOSIT_AMOUNT);
 
         // Disable both the protocol and the broker fee so that they don't interfere with the calculations.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(params.createWithMilestones.token, ZERO);
         UD60x18 brokerFee = ZERO;
         changePrank(params.createWithMilestones.sender);
@@ -186,7 +186,7 @@ contract CreateWithMilestones__ProTest is ProTest {
         protocolFee = bound(protocolFee, DEFAULT_MAX_FEE.add(ud(1)), MAX_UD60x18);
 
         // Set the protocol fee.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(defaultStream.token, protocolFee);
 
         // Run the test.
@@ -253,7 +253,7 @@ contract CreateWithMilestones__ProTest is ProTest {
 
         // Set the default protocol fee so that the test does not revert due to the net deposit amount not being
         // equal to the segment amounts sum.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(nonToken, DEFAULT_PROTOCOL_FEE);
         changePrank(users.sender);
 
@@ -471,7 +471,7 @@ contract CreateWithMilestones__ProTest is ProTest {
         protocolFee = bound(protocolFee, 0, DEFAULT_MAX_FEE);
 
         // Set the fuzzed protocol fee.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(params.createWithMilestones.token, protocolFee);
 
         // Make the sender the funder in this test.

--- a/test/unit/sablier-v2/pro/get-withdrawable-amount/getWithdrawableAmount.t.sol
+++ b/test/unit/sablier-v2/pro/get-withdrawable-amount/getWithdrawableAmount.t.sol
@@ -95,7 +95,7 @@ contract GetWithdrawableAmount__ProTest is ProTest {
 
     modifier CurrentTimeLessThanStopTime() {
         // Disable the protocol fee so that it doesn't interfere with the calculations.
-        changePrank(users.owner);
+        changePrank(users.admin);
         comptroller.setProtocolFee(dai, ZERO);
         changePrank(users.sender);
         _;

--- a/test/unit/sablier-v2/shared/burn/burn.t.sol
+++ b/test/unit/sablier-v2/shared/burn/burn.t.sol
@@ -14,7 +14,7 @@ abstract contract Burn__Test is SharedTest {
         // Create the default stream, since most tests need it.
         defaultStreamId = createDefaultStream();
 
-        // Make the owner of the NFT the caller in this test suite.
+        // Make the recipient (owner of the NFT) the caller in this test suite.
         changePrank(users.recipient);
     }
 

--- a/test/unit/sablier-v2/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
+import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
-import { IOwnable } from "@prb/contracts/access/IOwnable.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
@@ -12,23 +12,23 @@ import { SharedTest } from "../SharedTest.t.sol";
 
 abstract contract ClaimProtocolRevenues__Test is SharedTest {
     /// @dev it should revert.
-    function testCannotClaimProtocolRevenues__CallerNotOwner() external {
+    function testCannotClaimProtocolRevenues__CallerNotAdmin() external {
         // Make Eve the caller in this test.
         changePrank(users.eve);
 
         // Run the test.
-        vm.expectRevert(abi.encodeWithSelector(IOwnable.Ownable__CallerNotOwner.selector, users.owner, users.eve));
+        vm.expectRevert(abi.encodeWithSelector(IAdminable.Adminable__CallerNotAdmin.selector, users.admin, users.eve));
         sablierV2.claimProtocolRevenues(dai);
     }
 
-    modifier CallerOwner() {
-        // Make the owner the caller in the rest of this test suite.
-        changePrank(users.owner);
+    modifier CallerAdmin() {
+        // Make the admin the caller in the rest of this test suite.
+        changePrank(users.admin);
         _;
     }
 
     /// @dev it should revert.
-    function testCannotClaimProtocolRevenues__ProtocolRevenuesZero() external CallerOwner {
+    function testCannotClaimProtocolRevenues__ProtocolRevenuesZero() external CallerAdmin {
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2__ClaimZeroProtocolRevenues.selector, dai));
         sablierV2.claimProtocolRevenues(dai);
     }
@@ -37,25 +37,25 @@ abstract contract ClaimProtocolRevenues__Test is SharedTest {
         // Create the default stream, which will accrue revenues for the protocol.
         changePrank(users.sender);
         createDefaultStream();
-        changePrank(users.owner);
+        changePrank(users.admin);
         _;
     }
 
     /// @dev it should claim the protocol revenues.
-    function testClaimProtocolRevenues() external CallerOwner ProtocolRevenuesNotZero {
+    function testClaimProtocolRevenues() external CallerAdmin ProtocolRevenuesNotZero {
         // Expect the protocol revenues to be claimed.
         uint128 protocolRevenues = DEFAULT_PROTOCOL_FEE_AMOUNT;
-        vm.expectCall(address(dai), abi.encodeCall(IERC20.transfer, (users.owner, protocolRevenues)));
+        vm.expectCall(address(dai), abi.encodeCall(IERC20.transfer, (users.admin, protocolRevenues)));
 
         // Claim the protocol revenues.
         sablierV2.claimProtocolRevenues(dai);
     }
 
     /// @dev it should set the protocol revenues to zero.
-    function testClaimProtocolRevenues__SetToZero() external CallerOwner ProtocolRevenuesNotZero {
+    function testClaimProtocolRevenues__SetToZero() external CallerAdmin ProtocolRevenuesNotZero {
         // Expect the protocol revenues to be claimed.
         uint128 protocolRevenues = DEFAULT_PROTOCOL_FEE_AMOUNT;
-        vm.expectCall(address(dai), abi.encodeCall(IERC20.transfer, (users.owner, protocolRevenues)));
+        vm.expectCall(address(dai), abi.encodeCall(IERC20.transfer, (users.admin, protocolRevenues)));
 
         // Claim the protocol revenues.
         sablierV2.claimProtocolRevenues(dai);
@@ -67,11 +67,11 @@ abstract contract ClaimProtocolRevenues__Test is SharedTest {
     }
 
     /// @dev it should emit a ClaimProtocolRevenues event.
-    function testClaimProtocolRevenues__Event() external CallerOwner ProtocolRevenuesNotZero {
+    function testClaimProtocolRevenues__Event() external CallerAdmin ProtocolRevenuesNotZero {
         // Expect the protocol revenues to be claimed.
         uint128 protocolRevenues = DEFAULT_PROTOCOL_FEE_AMOUNT;
         vm.expectEmit({ checkTopic1: true, checkTopic2: true, checkTopic3: false, checkData: true });
-        emit Events.ClaimProtocolRevenues(users.owner, dai, protocolRevenues);
+        emit Events.ClaimProtocolRevenues(users.admin, dai, protocolRevenues);
 
         // Claim the protocol revenues.
         sablierV2.claimProtocolRevenues(dai);

--- a/test/unit/sablier-v2/shared/claim-protocol-revenues/claimProtocolRevenus.tree
+++ b/test/unit/sablier-v2/shared/claim-protocol-revenues/claimProtocolRevenus.tree
@@ -1,7 +1,7 @@
 claimProtocolRevenues.t.sol
-├── when the caller is not the owner
+├── when the caller is not the admin
 │  └── it should revert
-└── when the caller is the owner
+└── when the caller is the admin
    ├── when the protocol revenues are zero
    │  └── it should revert
    └── when the protocol revenues are not zero

--- a/test/unit/sablier-v2/shared/get-protocol-revenues/getProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/shared/get-protocol-revenues/getProtocolRevenues.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import { IOwnable } from "@prb/contracts/access/IOwnable.sol";
+import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
@@ -21,7 +21,7 @@ abstract contract GetProtocolRevenues__Test is SharedTest {
         // Create the default stream, which will accrue revenues for the protocol.
         changePrank(users.sender);
         createDefaultStream();
-        changePrank(users.owner);
+        changePrank(users.admin);
         _;
     }
 

--- a/test/unit/sablier-v2/shared/set-comptroller/setComptroller.t.sol
+++ b/test/unit/sablier-v2/shared/set-comptroller/setComptroller.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import { IOwnable } from "@prb/contracts/access/IOwnable.sol";
+import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 
 import { Events } from "src/libraries/Events.sol";
 
@@ -12,28 +12,28 @@ import { SharedTest } from "../SharedTest.t.sol";
 
 abstract contract SetComptroller__Test is SharedTest {
     /// @dev it should revert.
-    function testCannotSetComptroller__CallerNotOwner(address eve) external {
-        vm.assume(eve != users.owner);
+    function testCannotSetComptroller__CallerNotAdmin(address eve) external {
+        vm.assume(eve != users.admin);
 
         // Make Eve the caller in this test.
         changePrank(eve);
 
         // Run the test.
-        vm.expectRevert(abi.encodeWithSelector(IOwnable.Ownable__CallerNotOwner.selector, users.owner, eve));
+        vm.expectRevert(abi.encodeWithSelector(IAdminable.Adminable__CallerNotAdmin.selector, users.admin, eve));
         sablierV2.setComptroller(ISablierV2Comptroller(eve));
     }
 
-    modifier CallerOwner() {
-        // Make the owner the caller in the rest of this test suite.
-        changePrank(users.owner);
+    modifier CallerAdmin() {
+        // Make the admin the caller in the rest of this test suite.
+        changePrank(users.admin);
         _;
     }
 
     /// @dev it should emit a SetComptroller event and re-set the comptroller.
-    function testSetComptroller__SameComptroller() external CallerOwner {
+    function testSetComptroller__SameComptroller() external CallerAdmin {
         // Expect an event to be emitted.
         vm.expectEmit({ checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true });
-        emit Events.SetComptroller(users.owner, comptroller, comptroller);
+        emit Events.SetComptroller(users.admin, comptroller, comptroller);
 
         // Re-set the comptroller.
         sablierV2.setComptroller(comptroller);
@@ -45,13 +45,13 @@ abstract contract SetComptroller__Test is SharedTest {
     }
 
     /// @dev it should set the new comptroller.
-    function testSetComptroller__NewComptroller() external CallerOwner {
+    function testSetComptroller__NewComptroller() external CallerAdmin {
         // Deploy the new comptroller.
         ISablierV2Comptroller newComptroller = new SablierV2Comptroller();
 
         // Expect an event to be emitted.
         vm.expectEmit({ checkTopic1: true, checkTopic2: false, checkTopic3: false, checkData: true });
-        emit Events.SetComptroller(users.owner, comptroller, newComptroller);
+        emit Events.SetComptroller(users.admin, comptroller, newComptroller);
 
         // Set the new comptroller.
         sablierV2.setComptroller(newComptroller);

--- a/test/unit/sablier-v2/shared/set-comptroller/setComptroller.tree
+++ b/test/unit/sablier-v2/shared/set-comptroller/setComptroller.tree
@@ -1,7 +1,7 @@
 setProtocolFee.t.sol
-├── when the caller is not the owner
+├── when the caller is not the admin
 │  └── it should revert
-└── when the caller is the owner
+└── when the caller is the admin
    ├── when the comptroller is the same as the current comptroller
    │  └── it should emit a SetComptroller event and re-set the comptroller
    └── when the comptroller is not the same as the current comptroller


### PR DESCRIPTION
Two major reasons in favor of using `Adminable` over `Ownable`:

1. Signals less of a control over the protocol (and rightly so! we are not owners)
2. Clears up the terminology namespace - the ERC-721 standard already uses the term "owner" to refer to the owner of the NFT.