### PR TITLE
test: restrict the pragma to "0.9.0"

### DIFF
--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ERC20 } from "@prb/contracts/token/erc20/ERC20.sol";
 import { eqString } from "@prb/test/Helpers.sol";

--- a/test/helpers/Assertions.t.sol
+++ b/test/helpers/Assertions.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { PRBMathAssertions } from "@prb/math/test/Assertions.sol";

--- a/test/helpers/Constants.t.sol
+++ b/test/helpers/Constants.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { Amounts, CreateAmounts, Durations } from "src/types/Structs.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";

--- a/test/helpers/Utils.t.sol
+++ b/test/helpers/Utils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { PRBMathUtils } from "@prb/math/test/Utils.sol";
 import { SD59x18 } from "@prb/math/SD59x18.sol";

--- a/test/helpers/hooks/Empty.t.sol
+++ b/test/helpers/hooks/Empty.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // solhint-disable reason-string
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 /// @dev This contract does nothing.
 contract Empty {

--- a/test/helpers/hooks/GoodRecipient.t.sol
+++ b/test/helpers/hooks/GoodRecipient.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
 

--- a/test/helpers/hooks/GoodSender.t.sol
+++ b/test/helpers/hooks/GoodSender.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";
 

--- a/test/helpers/hooks/ReentrantRecipient.t.sol
+++ b/test/helpers/hooks/ReentrantRecipient.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";

--- a/test/helpers/hooks/ReentrantSender.t.sol
+++ b/test/helpers/hooks/ReentrantSender.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";

--- a/test/helpers/hooks/RevertingRecipient.t.sol
+++ b/test/helpers/hooks/RevertingRecipient.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
 

--- a/test/helpers/hooks/RevertingSender.t.sol
+++ b/test/helpers/hooks/RevertingSender.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";
 

--- a/test/helpers/mocks/SablierV2Mock.t.sol
+++ b/test/helpers/mocks/SablierV2Mock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 

--- a/test/integration/IntegrationTest.t.sol
+++ b/test/integration/IntegrationTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 

--- a/test/integration/create/createWithMilestones.t.sol
+++ b/test/integration/create/createWithMilestones.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { SD1x18 } from "@prb/math/SD1x18.sol";

--- a/test/integration/create/createWithRange.t.sol
+++ b/test/integration/create/createWithRange.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";

--- a/test/integration/tokens/DAI.t.sol
+++ b/test/integration/tokens/DAI.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 

--- a/test/integration/tokens/SHIB.t.sol
+++ b/test/integration/tokens/SHIB.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 

--- a/test/integration/tokens/USDC.t.sol
+++ b/test/integration/tokens/USDC.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 

--- a/test/integration/tokens/USDT.t.sol
+++ b/test/integration/tokens/USDT.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 

--- a/test/unit/UnitTest.t.sol
+++ b/test/unit/UnitTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { BaseTest } from "test/BaseTest.t.sol";
 import { Empty } from "test/helpers/hooks/Empty.t.sol";

--- a/test/unit/comptroller/ComptrollerTest.t.sol
+++ b/test/unit/comptroller/ComptrollerTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { UnitTest } from "../UnitTest.t.sol";
 

--- a/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
+++ b/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";

--- a/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
+++ b/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";

--- a/test/unit/sablier-v2/SablierV2.t.sol
+++ b/test/unit/sablier-v2/SablierV2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { UnitTest } from "../UnitTest.t.sol";
 

--- a/test/unit/sablier-v2/linear/LinearTest.t.sol
+++ b/test/unit/sablier-v2/linear/LinearTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { ERC20 } from "@prb/contracts/token/erc20/ERC20.sol";

--- a/test/unit/sablier-v2/linear/burn/burn.t.sol
+++ b/test/unit/sablier-v2/linear/burn/burn.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/cancel-multiple/cancelMultiple.t.sol
+++ b/test/unit/sablier-v2/linear/cancel-multiple/cancelMultiple.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/cancel/cancel.t.sol
+++ b/test/unit/sablier-v2/linear/cancel/cancel.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/claim-protocol-revenues/claimProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/linear/claim-protocol-revenues/claimProtocolRevenues.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/constructor/constructor.t.sol
+++ b/test/unit/sablier-v2/linear/constructor/constructor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { LinearTest } from "../LinearTest.t.sol";
 

--- a/test/unit/sablier-v2/linear/create-with-durations/createWithDurations.t.sol
+++ b/test/unit/sablier-v2/linear/create-with-durations/createWithDurations.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";

--- a/test/unit/sablier-v2/linear/create-with-range/createWithRange.t.sol
+++ b/test/unit/sablier-v2/linear/create-with-range/createWithRange.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { MAX_UD60x18, UD60x18, ud } from "@prb/math/UD60x18.sol";

--- a/test/unit/sablier-v2/linear/get-cliff-time/getCliffTime.t.sol
+++ b/test/unit/sablier-v2/linear/get-cliff-time/getCliffTime.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { LinearTest } from "../LinearTest.t.sol";
 

--- a/test/unit/sablier-v2/linear/get-deposit-amount/getDepositAmount.t.sol
+++ b/test/unit/sablier-v2/linear/get-deposit-amount/getDepositAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/get-protocol-revenues/getProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/linear/get-protocol-revenues/getProtocolRevenues.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/get-range/getRange.t.sol
+++ b/test/unit/sablier-v2/linear/get-range/getRange.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { Range } from "src/types/Structs.sol";
 

--- a/test/unit/sablier-v2/linear/get-recipient/getRecipient.t.sol
+++ b/test/unit/sablier-v2/linear/get-recipient/getRecipient.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/get-returnable-amount/getReturnableAmount.t.sol
+++ b/test/unit/sablier-v2/linear/get-returnable-amount/getReturnableAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/get-sender/getSender.t.sol
+++ b/test/unit/sablier-v2/linear/get-sender/getSender.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/get-start-time/getStartTime.t.sol
+++ b/test/unit/sablier-v2/linear/get-start-time/getStartTime.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/get-stop-time/getStopTime.t.sol
+++ b/test/unit/sablier-v2/linear/get-stop-time/getStopTime.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/get-stream/getStream.t.sol
+++ b/test/unit/sablier-v2/linear/get-stream/getStream.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { LinearStream } from "src/types/Structs.sol";
 

--- a/test/unit/sablier-v2/linear/get-withdrawable-amount/getWithdrawableAmount.t.sol
+++ b/test/unit/sablier-v2/linear/get-withdrawable-amount/getWithdrawableAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";

--- a/test/unit/sablier-v2/linear/get-withdrawn-amount/getWithdrawnAmount.t.sol
+++ b/test/unit/sablier-v2/linear/get-withdrawn-amount/getWithdrawnAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/is-cancelable/isCancelable.t.sol
+++ b/test/unit/sablier-v2/linear/is-cancelable/isCancelable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/is-entity/isEntity.t.sol
+++ b/test/unit/sablier-v2/linear/is-entity/isEntity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/renounce/renounce.t.sol
+++ b/test/unit/sablier-v2/linear/renounce/renounce.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/set-comptroller/setComptroller.t.sol
+++ b/test/unit/sablier-v2/linear/set-comptroller/setComptroller.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/withdraw-multipe/withdrawMultiple.t.sol
+++ b/test/unit/sablier-v2/linear/withdraw-multipe/withdrawMultiple.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/linear/withdraw/withdraw.t.sol
+++ b/test/unit/sablier-v2/linear/withdraw/withdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/ProTest.t.sol
+++ b/test/unit/sablier-v2/pro/ProTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { SD1x18 } from "@prb/math/SD1x18.sol";

--- a/test/unit/sablier-v2/pro/burn/burn.t.sol
+++ b/test/unit/sablier-v2/pro/burn/burn.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/cancel-multiple/cancelMultiple.t.sol
+++ b/test/unit/sablier-v2/pro/cancel-multiple/cancelMultiple.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/cancel/cancel.t.sol
+++ b/test/unit/sablier-v2/pro/cancel/cancel.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/claim-protocol-revenues/claimProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/pro/claim-protocol-revenues/claimProtocolRevenues.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/constructor/constructor.t.sol
+++ b/test/unit/sablier-v2/pro/constructor/constructor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ProTest } from "../ProTest.t.sol";
 

--- a/test/unit/sablier-v2/pro/create-with-deltas/createWithDeltas.t.sol
+++ b/test/unit/sablier-v2/pro/create-with-deltas/createWithDeltas.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // solhint-disable max-line-length
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { SD1x18, sd1x18 } from "@prb/math/SD1x18.sol";
 import { Solarray } from "solarray/Solarray.sol";

--- a/test/unit/sablier-v2/pro/create-with-milestones/createWithMilestones.t.sol
+++ b/test/unit/sablier-v2/pro/create-with-milestones/createWithMilestones.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { MAX_UD60x18, UD60x18, ud, ZERO } from "@prb/math/UD60x18.sol";

--- a/test/unit/sablier-v2/pro/get-deposit-amount/getDepositAmount.t.sol
+++ b/test/unit/sablier-v2/pro/get-deposit-amount/getDepositAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/get-protocol-revenues/getProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/pro/get-protocol-revenues/getProtocolRevenues.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/get-recipient/getRecipient.t.sol
+++ b/test/unit/sablier-v2/pro/get-recipient/getRecipient.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/get-returnable-amount/getReturnableAmount.t.sol
+++ b/test/unit/sablier-v2/pro/get-returnable-amount/getReturnableAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/get-segments/getSegments.t.sol
+++ b/test/unit/sablier-v2/pro/get-segments/getSegments.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { Segment } from "src/types/Structs.sol";
 

--- a/test/unit/sablier-v2/pro/get-sender/getSender.t.sol
+++ b/test/unit/sablier-v2/pro/get-sender/getSender.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/get-start-time/getStartTime.t.sol
+++ b/test/unit/sablier-v2/pro/get-start-time/getStartTime.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/get-stop-time/getStopTime.t.sol
+++ b/test/unit/sablier-v2/pro/get-stop-time/getStopTime.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/get-stream/getStream.t.sol
+++ b/test/unit/sablier-v2/pro/get-stream/getStream.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ProStream } from "src/types/Structs.sol";
 

--- a/test/unit/sablier-v2/pro/get-withdrawable-amount/getWithdrawableAmount.t.sol
+++ b/test/unit/sablier-v2/pro/get-withdrawable-amount/getWithdrawableAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { E, SD1x18 } from "@prb/math/SD1x18.sol";
 import { Solarray } from "solarray/Solarray.sol";

--- a/test/unit/sablier-v2/pro/get-withdrawn-amount/getWithdrawnAmount.t.sol
+++ b/test/unit/sablier-v2/pro/get-withdrawn-amount/getWithdrawnAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/is-cancelable/isCancelable.t.sol
+++ b/test/unit/sablier-v2/pro/is-cancelable/isCancelable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/is-entity/isEntity.t.sol
+++ b/test/unit/sablier-v2/pro/is-entity/isEntity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/renounce/renounce.t.sol
+++ b/test/unit/sablier-v2/pro/renounce/renounce.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/set-comptroller/setComptroller.t.sol
+++ b/test/unit/sablier-v2/pro/set-comptroller/setComptroller.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/withdraw-multiple/withdrawMultiple.t.sol
+++ b/test/unit/sablier-v2/pro/withdraw-multiple/withdrawMultiple.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/pro/withdraw/withdraw.t.sol
+++ b/test/unit/sablier-v2/pro/withdraw/withdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 

--- a/test/unit/sablier-v2/shared/SharedTest.t.sol
+++ b/test/unit/sablier-v2/shared/SharedTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { ISablierV2 } from "src/interfaces/ISablierV2.sol";
 import { SablierV2 } from "src/SablierV2.sol";

--- a/test/unit/sablier-v2/shared/burn/burn.t.sol
+++ b/test/unit/sablier-v2/shared/burn/burn.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { Errors } from "src/libraries/Errors.sol";
 

--- a/test/unit/sablier-v2/shared/cancel-multiple/cancelMultiple.t.sol
+++ b/test/unit/sablier-v2/shared/cancel-multiple/cancelMultiple.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { Solarray } from "solarray/Solarray.sol";

--- a/test/unit/sablier-v2/shared/cancel/cancel.t.sol
+++ b/test/unit/sablier-v2/shared/cancel/cancel.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 

--- a/test/unit/sablier-v2/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";

--- a/test/unit/sablier-v2/shared/get-deposit-amount/getDepositAmount.t.sol
+++ b/test/unit/sablier-v2/shared/get-deposit-amount/getDepositAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/get-protocol-revenues/getProtocolRevenues.t.sol
+++ b/test/unit/sablier-v2/shared/get-protocol-revenues/getProtocolRevenues.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";

--- a/test/unit/sablier-v2/shared/get-recipient/getRecipient.t.sol
+++ b/test/unit/sablier-v2/shared/get-recipient/getRecipient.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/get-returnable-amount/getReturnableAmount.t.sol
+++ b/test/unit/sablier-v2/shared/get-returnable-amount/getReturnableAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/get-sender/getSender.t.sol
+++ b/test/unit/sablier-v2/shared/get-sender/getSender.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/get-start-time/getStartTime.t.sol
+++ b/test/unit/sablier-v2/shared/get-start-time/getStartTime.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/get-stop-time/getStopTime.t.sol
+++ b/test/unit/sablier-v2/shared/get-stop-time/getStopTime.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/get-withdrawn-amount/getWithdrawnAmount.t.sol
+++ b/test/unit/sablier-v2/shared/get-withdrawn-amount/getWithdrawnAmount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/is-cancelable/isCancelable.t.sol
+++ b/test/unit/sablier-v2/shared/is-cancelable/isCancelable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/is-entity/isEntity.t.sol
+++ b/test/unit/sablier-v2/shared/is-entity/isEntity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { SharedTest } from "../SharedTest.t.sol";
 

--- a/test/unit/sablier-v2/shared/renounce/renounce.t.sol
+++ b/test/unit/sablier-v2/shared/renounce/renounce.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { Errors } from "src/libraries/Errors.sol";
 import { Events } from "src/libraries/Events.sol";

--- a/test/unit/sablier-v2/shared/set-comptroller/setComptroller.t.sol
+++ b/test/unit/sablier-v2/shared/set-comptroller/setComptroller.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IAdminable } from "@prb/contracts/access/IAdminable.sol";
 

--- a/test/unit/sablier-v2/shared/withdraw-multiple/withdrawMultiple.t.sol
+++ b/test/unit/sablier-v2/shared/withdraw-multiple/withdrawMultiple.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { Solarray } from "solarray/Solarray.sol";

--- a/test/unit/sablier-v2/shared/withdraw/withdraw.t.sol
+++ b/test/unit/sablier-v2/shared/withdraw/withdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 


### PR DESCRIPTION
We still want to keep the pragma open in the production code, just so that we let the protocol remain compatible with future versions of Solidity.

However, we should not run the tests with any version but Solidity v0.8.17, to avoid the risk of false positives.