### PR TITLE
ci: multicall + fuzz seed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,16 @@ jobs:
       - name: "Show the Foundry config"
         run: "forge config"
 
-      - name: "Build the production code with --via-ir"
+      - name: "Generate fuzz seed that changes weekly to avoid burning through RPC allowance"
+        run: >
+          echo "FOUNDRY_FUZZ_SEED=$(
+            echo $(($EPOCHSECONDS - $EPOCHSECONDS % 604800))
+          )" >> $GITHUB_ENV
+
+      - name: "Build the production contracts with --via-ir"
         run: "FOUNDRY_PROFILE=optimized forge build"
 
-      - name: "Test the optimized code"
+      - name: "Run the unit and the integration tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test"
 
       - name: "Add test summary"

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,4 @@
   branch = "master"
   path = "lib/solarray"
   url = "https://github.com/paulrberg/solarray"
+

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,7 @@ test = "test/unit"
 
 [profile.ci]
 fuzz = { runs = 5_000 }
+test = "test" # run both unit and integration tests
 
 [profile.optimized]
 out = "optimized-out"
@@ -25,4 +26,5 @@ via_ir = true
 
 [profile.test-optimized]
 fuzz = { runs = 5_000 }
-src = "test/unit" # do not re-compile the production code
+src = "test" # do not re-compile the production code
+test = "test"  # run both unit and integration tests

--- a/test/helpers/Constants.t.sol
+++ b/test/helpers/Constants.t.sol
@@ -21,6 +21,7 @@ abstract contract Constants {
     uint40 internal constant DEFAULT_TIME_WARP = 2_600 seconds;
     uint40 internal constant DEFAULT_TOTAL_DURATION = 10_000 seconds;
     uint128 internal constant DEFAULT_WITHDRAW_AMOUNT = 2_600e18;
+    address internal constant MULTICALL3_ADDRESS = 0xcA11bde05977b3631167028862bE2a173976CA11;
     uint256 internal constant UINT256_MAX = type(uint256).max;
     uint128 internal constant UINT128_MAX = type(uint128).max;
     uint40 internal constant UINT40_MAX = type(uint40).max;

--- a/test/helpers/IMulticall3.t.sol
+++ b/test/helpers/IMulticall3.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+interface IMulticall3 {
+    struct Call {
+        address target;
+        bytes callData;
+    }
+
+    struct Call3 {
+        address target;
+        bool allowFailure;
+        bytes callData;
+    }
+
+    struct Call3Value {
+        address target;
+        bool allowFailure;
+        uint256 value;
+        bytes callData;
+    }
+
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    function aggregate(Call[] memory calls) external payable returns (uint256 blockNumber, bytes[] memory returnData);
+
+    function aggregate3(Call3[] memory calls) external payable returns (Result[] memory returnData);
+
+    function aggregate3Value(Call3Value[] memory calls) external payable returns (Result[] memory returnData);
+
+    function blockAndAggregate(
+        Call[] memory calls
+    ) external payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
+
+    function getBasefee() external view returns (uint256 basefee);
+
+    function getBlockHash(uint256 blockNumber) external view returns (bytes32 blockHash);
+
+    function getBlockNumber() external view returns (uint256 blockNumber);
+
+    function getChainId() external view returns (uint256 chainid);
+
+    function getCurrentBlockCoinbase() external view returns (address coinbase);
+
+    function getCurrentBlockDifficulty() external view returns (uint256 difficulty);
+
+    function getCurrentBlockGasLimit() external view returns (uint256 gaslimit);
+
+    function getCurrentBlockTimestamp() external view returns (uint256 timestamp);
+
+    function getEthBalance(address addr) external view returns (uint256 balance);
+
+    function getLastBlockHash() external view returns (bytes32 blockHash);
+
+    function tryAggregate(
+        bool requireSuccess,
+        Call[] memory calls
+    ) external payable returns (Result[] memory returnData);
+
+    function tryBlockAndAggregate(
+        bool requireSuccess,
+        Call[] memory calls
+    ) external payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
+}

--- a/test/integration/create/createWithMilestones.t.sol
+++ b/test/integration/create/createWithMilestones.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.13 <0.9.0;
 
 import { IERC20 } from "@prb/contracts/token/erc20/IERC20.sol";
 import { SD1x18 } from "@prb/math/SD1x18.sol";
+import { Solarray } from "solarray/Solarray.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 
 import { Amounts, Broker, CreateAmounts, ProStream, Segment } from "src/types/Structs.sol";
@@ -44,8 +45,8 @@ abstract contract CreateWithMilestones__Test is IntegrationTest {
     }
 
     struct Vars {
-        uint256 initialContractBalance;
-        uint256 initialHolderBalance;
+        uint256[] initialBalances;
+        uint256 initialProBalance;
         uint256 initialBrokerBalance;
         uint128 brokerFeeAmount;
         uint128 netDepositAmount;
@@ -54,8 +55,9 @@ abstract contract CreateWithMilestones__Test is IntegrationTest {
         uint256 expectedNextStreamId;
         address actualNFTOwner;
         address expectedNFTOwner;
-        uint256 actualContractBalance;
-        uint256 expectedContractBalance;
+        uint256[] actualBalances;
+        uint256 actualProBalance;
+        uint256 expectedProBalance;
         uint256 actualHolderBalance;
         uint256 expectedHolderBalance;
         uint256 actualBrokerBalance;
@@ -76,15 +78,15 @@ abstract contract CreateWithMilestones__Test is IntegrationTest {
     function testCreateWithMilestones(Params memory params) external {
         vm.assume(params.sender != address(0) && params.recipient != address(0) && params.broker.addr != address(0));
         vm.assume(params.broker.addr != holder && params.broker.addr != address(pro));
-        vm.assume(params.grossDepositAmount != 0 && params.grossDepositAmount <= holderBalance);
+        vm.assume(params.grossDepositAmount != 0 && params.grossDepositAmount <= initialHolderBalance);
         params.broker.fee = bound(params.broker.fee, 0, DEFAULT_MAX_FEE);
         params.startTime = boundUint40(params.startTime, 0, DEFAULT_SEGMENTS[0].milestone);
 
-        // Load the current token balances.
+        // Load the initial token balances.
         Vars memory vars;
-        vars.initialContractBalance = IERC20(token).balanceOf(address(pro));
-        vars.initialHolderBalance = IERC20(token).balanceOf(holder);
-        vars.initialBrokerBalance = IERC20(token).balanceOf(params.broker.addr);
+        vars.initialBalances = getTokenBalances(Solarray.addresses(address(pro), params.broker.addr));
+        vars.initialProBalance = vars.initialBalances[0];
+        vars.initialBrokerBalance = vars.initialBalances[1];
 
         // Calculate the fee amounts and the net deposit amount.
         vars.brokerFeeAmount = uint128(UD60x18.unwrap(ud(params.grossDepositAmount).mul(params.broker.fee)));
@@ -147,18 +149,21 @@ abstract contract CreateWithMilestones__Test is IntegrationTest {
         vars.expectedNFTOwner = params.recipient;
         assertEq(vars.actualNFTOwner, vars.expectedNFTOwner, "NFT owner");
 
+        // Load the actual token balances.
+        vars.actualBalances = getTokenBalances(Solarray.addresses(address(pro), holder, params.broker.addr));
+        vars.actualProBalance = vars.actualBalances[0];
+        vars.actualHolderBalance = vars.actualBalances[1];
+        vars.actualBrokerBalance = vars.actualBalances[2];
+
         // Assert that the contract's balance was updated.
-        vars.actualContractBalance = IERC20(token).balanceOf(address(pro));
-        vars.expectedContractBalance = vars.initialContractBalance + vars.netDepositAmount;
-        assertEq(vars.actualContractBalance, vars.expectedContractBalance, "contract balance");
+        vars.expectedProBalance = vars.initialProBalance + vars.netDepositAmount;
+        assertEq(vars.actualProBalance, vars.expectedProBalance, "contract balance");
 
         // Assert that the holder's balance was updated.
-        vars.actualHolderBalance = IERC20(token).balanceOf(holder);
-        vars.expectedHolderBalance = vars.initialHolderBalance - params.grossDepositAmount;
+        vars.expectedHolderBalance = initialHolderBalance - params.grossDepositAmount;
         assertEq(vars.actualHolderBalance, vars.expectedHolderBalance, "holder balance");
 
         // Assert that the broker's balance was updated.
-        vars.actualBrokerBalance = IERC20(token).balanceOf(params.broker.addr);
         vars.expectedBrokerBalance = vars.initialBrokerBalance + vars.brokerFeeAmount;
         assertEq(vars.actualBrokerBalance, vars.expectedBrokerBalance, "broker balance");
     }


### PR DESCRIPTION
Fixes #233 by:

1. Setting a fuzz seed that changes weekly in CI (see my [tweet](https://twitter.com/PaulRBerg/status/1611116650664796166?s=20&t=Wga_aiHDrEjN-PYOYqdgtA)) .
2. Using [Multicall3](https://github.com/mds1/multicall) to query the token balances in the integration tests.

This should at the same time lower the number of RPC requests (since we are also [caching the RPC requests](https://github.com/sablierhq/v2-core/issues/182)) and decrease our average test run times. However, the first test run will still take a long time because the initial RPC requests have to be made. I hope that the Multicall trick will help with that (prior to this PR, the CI run [took 31 minutes](https://github.com/sablierhq/v2-core/actions/runs/3812969761/jobs/6486455094)).