### PR TITLE
ci: switch coverage report to Codecov instead of Coveralls

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "./test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,15 +105,11 @@ jobs:
       - name: "Generate the coverage report"
         run: "forge coverage --report lcov"
 
-      # See discussion in https://github.com/foundry-rs/foundry/issues/1961
-      - name: "Delete the coverage report generated for the test contracts"
-        run: "git clean -f -- ./test"
-
-      - name: "Upload coverage report to Coveralls"
-        uses: "coverallsapp/github-action@master"
+      - name: "Upload coverage report to Codecov"
+        uses: "codecov/codecov-action@v3"
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          path-to-lcov: "./lcov.info"
+          files: "./lcov.info"
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: "Add coverage summary"
         run: |

--- a/src/SablierV2Pro.sol
+++ b/src/SablierV2Pro.sol
@@ -276,6 +276,9 @@ contract SablierV2Pro is
             uint128 previousSegmentAmounts;
             uint40 currentSegmentMilestone = _streams[streamId].segments[0].milestone;
             uint256 index = 1;
+
+            // Important: this function must be called only after checking that the current time is less than the last
+            // segment's milestone, lest the loop below encounters an "index out of bounds" error.
             while (currentSegmentMilestone < currentTime) {
                 previousSegmentAmounts += _streams[streamId].segments[index - 1].amount;
                 currentSegmentMilestone = _streams[streamId].segments[index].milestone;


### PR DESCRIPTION
- Codecov has a nicer UI than Coveralls.
- The Codecov GitHub Action is up to date and doesn't emit any warnings (see https://github.com/coverallsapp/github-action/issues/132 and https://github.com/coverallsapp/github-action/pull/139).
- With Codecov, it is possible [to ignore the coverage for the test contracts](https://github.com/foundry-rs/foundry/issues/1961#issuecomment-1219107365).