### PR TITLE
docs: change default license to BUSL-1.1

### DIFF
--- a/LICENSE-GPL.md
+++ b/LICENSE-GPL.md
@@ -1,0 +1,331 @@
+This software is available under your choice of the GNU General Public License, version 2 or later, or the Business
+Source License, as set forth below.
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU
+General Public License is intended to guarantee your freedom to share and change free software--to make sure the
+software is free for all its users. This General Public License applies to most of the Free Software Foundation's
+software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is
+covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make
+sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you
+receive source code or can get it if you want it, that you can change the software or use pieces of it in new free
+programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to
+surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all
+the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them
+these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty
+for this free software. If the software is modified by someone else and passed on, we want its recipients to know that
+what they have is not the original, so that any problems introduced by others will not reflect on the original authors'
+reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors
+of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this,
+we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it
+   may be distributed under the terms of this General Public License. The "Program", below, refers to any such program
+   or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that
+   is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated
+   into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each
+   licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its
+scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by running the Program). Whether that is true
+depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided
+   that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of
+   warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any
+   other recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection
+in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and
+   copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of
+   these conditions:
+
+   a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of
+   any change.
+
+   b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the
+   Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this
+   License.
+
+   c) If the modified program normally reads commands interactively when run, you must cause it, when started running
+   for such interactive use in the most ordinary way, to print or display an announcement including an appropriate
+   copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users
+   may redistribute the program under these conditions, and telling the user how to view a copy of this License.
+   (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on
+   the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the
+Program, and can be reasonably considered independent and separate works in themselves, then this License, and its
+terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same
+sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part
+regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you;
+rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the
+Program.
+
+In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the
+Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form
+   under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+   a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the
+   terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+   b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more
+   than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding
+   source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software
+   interchange; or,
+
+   c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This
+   alternative is allowed only for noncommercial distribution and only if you received the program in object code or
+   executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making modifications to it. For an executable work,
+complete source code means all the source code for all modules it contains, plus any associated interface definition
+files, plus the scripts used to control compilation and installation of the executable. However, as a special exception,
+the source code distributed need not include anything that is normally distributed (in either source or binary form)
+with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless
+that component itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy from a designated place, then offering
+equivalent access to copy the source code from the same place counts as distribution of the source code, even though
+third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any
+   attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate
+   your rights under this License. However, parties who have received copies, or rights, from you under this License
+   will not have their licenses terminated so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it. However, nothing else grants you
+   permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do
+   not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you
+   indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or
+   modifying the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a
+   license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions.
+   You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not
+   responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to
+   patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the
+   conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so
+   as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a
+   consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free
+   redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way
+   you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the
+section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest
+validity of any such claims; this section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices. Many people have made generous contributions to
+the wide range of software distributed through that system in reliance on consistent application of that system; it is
+up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee
+cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted
+   interfaces, the original copyright holder who places the Program under this License may add an explicit geographical
+   distribution limitation excluding those countries, so that distribution is permitted only in or among countries not
+   thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time.
+   Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems
+   or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies a version number of this License which
+applies to it and "any later version", you have the option of following the terms and conditions either of that version
+or of any later version published by the Free Software Foundation. If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are
+    different, write to the author to ask for permission. For software which is copyrighted by the Free Software
+    Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be
+    guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the
+    sharing and reuse of software generally.
+
+                                NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+    APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE
+    PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND
+    PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY
+    SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY
+    WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+    GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+    (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+    PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+                         END OF TERMS AND CONDITIONS
+
+                How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve
+this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to
+most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer
+to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of
+course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks
+or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer"
+for the program, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers)
+written by James Hacker.
+
+<signature of Ty Coon>, 1 April 1989 Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into proprietary programs. If your program is a
+subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this
+is what you want to do, use the GNU Lesser General Public License instead of this License.
+
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved. "Business Source License" is a trademark of
+MariaDB Corporation Ab.
+
+---
+
+Parameters
+
+Licensor: Sablier Labs Ltd
+
+Licensed Work: Sablier V2 Core The Licensed Work is (C) 2023 Sablier Labs Ltd
+
+Additional Use Grant: Any uses listed and defined at v2-core-license-grants.sablier.eth
+
+Change Date: The earlier of 2025-06-01 or a date specified at v2-core-license-date.sablier.eth
+
+Change License: GNU General Public License v2.0 or later
+
+---
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production
+use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific
+version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License,
+you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must
+refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this
+License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the
+Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply
+to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License
+for the current and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may
+use a trademark or logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS
+ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license your works, and to refer to it using the
+trademark "Business Source License", as long as you comply with the Covenants of Licensor below.
+
+---
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the "Business Source License" name and trademark, Licensor
+covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version, or a license that is compatible with GPL
+   Version 2.0 or a later version, where "compatible" means that software provided under the Change License can be
+   included in a program with software provided under GPL Version 2.0 or a later version. Licensor may specify
+   additional Change Licenses without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not impose any additional restriction on the
+   right granted in this License, as the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+---
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open Source license. However, the Licensed Work
+will eventually be made available under an Open Source License, as stated in this License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,125 +1,80 @@
-GNU LESSER GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+Business Source License 1.1
 
-Copyright (C) 2023 Sablier Labs Ltd. Everyone is permitted to copy and distribute verbatim copies of this license
-document, but changing it is not allowed.
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved. "Business Source License" is a trademark of
+MariaDB Corporation Ab.
 
-This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU
-General Public License, supplemented by the additional permissions listed below.
+---
 
-0. Additional Definitions.
+Parameters
 
-As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to
-version 3 of the GNU General Public License.
+Licensor: Sablier Labs Ltd
 
-"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined
-below.
+Licensed Work: Sablier V2 Core The Licensed Work is (C) 2023 Sablier Labs Ltd
 
-An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on
-the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by
-the Library.
+Additional Use Grant: Any uses listed and defined at v2-core-license-grants.sablier.eth
 
-A "Combined Work" is a work produced by combining or linking an Application with the Library. The particular version of
-the Library with which the Combined Work was made is also called the "Linked Version".
+Change Date: The earlier of 2025-06-01 or a date specified at v2-core-license-date.sablier.eth
 
-The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding
-any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not
-on the Linked Version.
+Change License: GNU General Public License v2.0 or later
 
-The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application,
-including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the
-System Libraries of the Combined Work.
+---
 
-1. Exception to Section 3 of the GNU GPL.
+Terms
 
-You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production
+use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
 
-2. Conveying Modified Versions.
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific
+version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above terminate.
 
-If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied
-by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may
-convey a copy of the modified version:
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License,
+you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must
+refrain from using the Licensed Work.
 
-a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not
-supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful,
-or
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this
+License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
 
-b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the
+Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply
+to your use of that work.
 
-3. Object Code Incorporating Material from Library Header Files.
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License
+for the current and all other versions of the Licensed Work.
 
-The object code form of an Application may incorporate material from a header file that is part of the Library. You may
-convey such object code under terms of your choice, provided that, if the incorporated material is not limited to
-numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or
-fewer lines in length), you do both of the following:
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may
+use a trademark or logo of Licensor as expressly required by this License).
 
-a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its
-use are covered by this License.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS
+ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
 
-b) Accompany the object code with a copy of the GNU GPL and this license document.
+MariaDB hereby grants you permission to use this License’s text to license your works, and to refer to it using the
+trademark "Business Source License", as long as you comply with the Covenants of Licensor below.
 
-4. Combined Works.
+---
 
-You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification
-of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications,
-if you also do each of the following:
+Covenants of Licensor
 
-a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its
-use are covered by this License.
+In consideration of the right to use this License’s text and the "Business Source License" name and trademark, Licensor
+covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:
 
-b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+1. To specify as the Change License the GPL Version 2.0 or any later version, or a license that is compatible with GPL
+   Version 2.0 or a later version, where "compatible" means that software provided under the Change License can be
+   included in a program with software provided under GPL Version 2.0 or a later version. Licensor may specify
+   additional Change Licenses without limitation.
 
-c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library
-among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+2. To either: (a) specify an additional grant of rights to use that does not impose any additional restriction on the
+   right granted in this License, as the Additional Use Grant; or (b) insert the text "None".
 
-d) Do one of the following:
+3. To specify a Change Date.
 
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
+4. Not to modify this License in any other way.
 
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
+---
 
-e) Provide Installation Information, but only if you would otherwise be required to provide such information under
-section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified
-version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked
-Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and
-Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner
-specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+Notice
 
-5. Combined Libraries.
-
-You may place library facilities that are a work based on the Library side by side in a single library together with
-other library facilities that are not Applications and are not covered by this License, and convey such a combined
-library under terms of your choice, if you do both of the following:
-
-a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library
-facilities, conveyed under the terms of this License.
-
-b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where
-to find the accompanying uncombined form of the same work.
-
-6. Revised Versions of the GNU Lesser General Public License.
-
-The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time
-to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new
-problems or concerns.
-
-Each version is given a distinguishing version number. If the Library as you received it specifies that a certain
-numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of
-following the terms and conditions either of that published version or of any later version published by the Free
-Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General
-Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software
-Foundation.
-
-If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General
-Public License shall apply, that proxy's public statement of acceptance of any version is permanent authorization for
-you to choose that version for the Library.
+The Business Source License (this document, or the "License") is not an Open Source license. However, the Licensed Work
+will eventually be made available under an Open Source License, as stated in this License.

--- a/README.md
+++ b/README.md
@@ -338,6 +338,16 @@ There are many other commands available in Foundry. Check out the [Foundry Book]
 For security concerns, please email [security@sablier.com](mailto:security@sablier.com). This repository is subject to
 the Sablier bug bounty program, per the terms defined [here](https://docs.sablier.com/).
 
-## License
+## Licensing
 
-[LPGL v3.0](./LICENSE.md) © Sablier Labs Ltd
+The primary license for Sablier V2 Core is the Business Source License 1.1 (`BUSL-1.1`), see
+[`LICENSE.md`](./LICENSE.md). However, some files are dual-licensed under `GPL-2.0-or-later`:
+
+- All files in `src/interfaces/` and `src/types` may also be licensed under `GPL-2.0-or-later` (as indicated in their
+  SPDX headers), see [`LICENSE-GPL.md`](./GPL-LICENSE.md).
+- Several files in `src/libraries/` may also be licensed under `GPL-2.0-or-later` (as indicated in their SPDX headers),
+  see [`LICENSE-GPL.md`](./GPL-LICENSE.md).
+
+### Other Exceptions
+
+- All files in `test/` remain unlicensed (as indicated in their SPDX headers).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sablier/v2-core",
-  "description": "Core smart contracts for the Sablier V2 cryptoasset streaming protocol",
+  "description": "Core smart contracts of the Sablier V2 cryptoasset streaming protocol",
   "version": "1.0.0",
   "author": {
     "name": "Sablier Labs Ltd.",

--- a/script/bootstrap/BootstrapProtocol.s.sol
+++ b/script/bootstrap/BootstrapProtocol.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/script/deploy/DeployComptroller.s.sol
+++ b/script/deploy/DeployComptroller.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployDeterministicComptroller.s.sol
+++ b/script/deploy/DeployDeterministicComptroller.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployDeterministicLockupLinear.s.sol
+++ b/script/deploy/DeployDeterministicLockupLinear.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployDeterministicLockupPro.s.sol
+++ b/script/deploy/DeployDeterministicLockupPro.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployDeterministicProtocol.s.sol
+++ b/script/deploy/DeployDeterministicProtocol.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployLockupLinear.s.sol
+++ b/script/deploy/DeployLockupLinear.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployLockupPro.s.sol
+++ b/script/deploy/DeployLockupPro.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployProtocol.s.sol
+++ b/script/deploy/DeployProtocol.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/script/deploy/DeployTestAsset.s.sol
+++ b/script/deploy/DeployTestAsset.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { ERC20GodMode } from "@prb/contracts/token/erc20/ERC20GodMode.sol";

--- a/script/shared/Base.s.sol
+++ b/script/shared/Base.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18 <0.9.0;
 
 import { Script } from "forge-std/Script.sol";

--- a/src/SablierV2Comptroller.sol
+++ b/src/SablierV2Comptroller.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/SablierV2LockupLinear.sol
+++ b/src/SablierV2LockupLinear.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/SablierV2LockupPro.sol
+++ b/src/SablierV2LockupPro.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/abstracts/SablierV2Config.sol
+++ b/src/abstracts/SablierV2Config.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/abstracts/SablierV2FlashLoan.sol
+++ b/src/abstracts/SablierV2FlashLoan.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/abstracts/SablierV2Lockup.sol
+++ b/src/abstracts/SablierV2Lockup.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/ISablierV2Adminable.sol
+++ b/src/interfaces/ISablierV2Adminable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 /// @title ISablierV2Adminable

--- a/src/interfaces/ISablierV2Comptroller.sol
+++ b/src/interfaces/ISablierV2Comptroller.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/ISablierV2Config.sol
+++ b/src/interfaces/ISablierV2Config.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/ISablierV2Lockup.sol
+++ b/src/interfaces/ISablierV2Lockup.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/ISablierV2LockupLinear.sol
+++ b/src/interfaces/ISablierV2LockupLinear.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/ISablierV2LockupPro.sol
+++ b/src/interfaces/ISablierV2LockupPro.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/hooks/ISablierV2LockupRecipient.sol
+++ b/src/interfaces/hooks/ISablierV2LockupRecipient.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 /// @title ISablierV2LockupRecipient

--- a/src/interfaces/hooks/ISablierV2LockupSender.sol
+++ b/src/interfaces/hooks/ISablierV2LockupSender.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 /// @title ISablierV2LockupSender

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/libraries/Events.sol
+++ b/src/libraries/Events.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/libraries/Helpers.sol
+++ b/src/libraries/Helpers.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.18;
 
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";

--- a/src/types/Math.sol
+++ b/src/types/Math.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 /// This file simply re-exports all PRBMath types needed in v2-core. It is provided for convenience to

--- a/src/types/Tokens.sol
+++ b/src/types/Tokens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.18;
 
 /// This file simply re-exports all token interfaces needed in v2-core. It is provided for convenience to


### PR DESCRIPTION
Implements the suggestion I left in this [comment](https://github.com/sablierhq/v2-core/discussions/53#discussioncomment-4981760) to switch to use the [BUSL-1.1](https://spdx.org/licenses/BUSL-1.1.html) license instead of LPGL 3.0.

But I have made the interfaces, the types, and some helpers (`Errors` and `Events`) dual-licenseble as GPL v2, so that integrators can easily import these files.