### PR TITLE
refactor: define events in abstract contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
           name: contract-abis
           path: |
             optimized-out/Errors.sol/Errors.json
-            optimized-out/Events.sol/Events.json
             optimized-out/IERC20.sol/IERC20.json
             optimized-out/IERC721.sol/IERC721.json
             optimized-out/IERC721Metadata.sol/IERC721Metadata.json
@@ -85,6 +84,7 @@ jobs:
             optimized-out/SablierV2Adminable.sol/SablierV2Adminable.json
             optimized-out/SablierV2Comptroller.sol/SablierV2Comptroller.json
             optimized-out/SablierV2Config.sol/ISablierV2Config.json
+            optimized-out/SablierV2Events.sol/SablierV2Events.json
             optimized-out/SablierV2Lockup.sol/SablierV2Lockup.json
             optimized-out/SablierV2LockupLinear.sol/SablierV2LockupLinear.json
             optimized-out/SablierV2LockupPro.sol/SablierV2LockupPro.json

--- a/src/SablierV2Comptroller.sol
+++ b/src/SablierV2Comptroller.sol
@@ -5,8 +5,8 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 import { SablierV2Adminable } from "./abstracts/SablierV2Adminable.sol";
+import { SablierV2Events } from "./abstracts/SablierV2Events.sol";
 import { ISablierV2Comptroller } from "./interfaces/ISablierV2Comptroller.sol";
-import { Events } from "./libraries/Events.sol";
 
 /*
 
@@ -29,6 +29,7 @@ import { Events } from "./libraries/Events.sol";
 /// @title SablierV2Comptroller
 /// @dev This contract implements the {ISablierV2Comptroller} interface.
 contract SablierV2Comptroller is
+    SablierV2Events, // no dependencies
     ISablierV2Comptroller, // one dependency
     SablierV2Adminable // one dependency
 {
@@ -57,7 +58,7 @@ contract SablierV2Comptroller is
     /// @param initialAdmin The address of the initial contract admin.
     constructor(address initialAdmin) {
         admin = initialAdmin;
-        emit Events.TransferAdmin({ oldAdmin: address(0), newAdmin: initialAdmin });
+        emit TransferAdmin({ oldAdmin: address(0), newAdmin: initialAdmin });
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -85,7 +86,7 @@ contract SablierV2Comptroller is
         flashFee = newFlashFee;
 
         // Log the change of the flash fee.
-        emit Events.SetFlashFee({ admin: msg.sender, oldFlashFee: oldFlashFee, newFlashFee: newFlashFee });
+        emit SetFlashFee({ admin: msg.sender, oldFlashFee: oldFlashFee, newFlashFee: newFlashFee });
     }
 
     /// @inheritdoc ISablierV2Comptroller
@@ -95,7 +96,7 @@ contract SablierV2Comptroller is
         _protocolFees[asset] = newProtocolFee;
 
         // Log the change of the protocol fee.
-        emit Events.SetProtocolFee({
+        emit SetProtocolFee({
             admin: msg.sender,
             asset: asset,
             oldProtocolFee: oldProtocolFee,
@@ -110,6 +111,6 @@ contract SablierV2Comptroller is
         _flashAssets[asset] = !oldFlag;
 
         // Log the change of the flash asset flag.
-        emit Events.ToggleFlashAsset({ admin: msg.sender, asset: asset, newFlag: !oldFlag });
+        emit ToggleFlashAsset({ admin: msg.sender, asset: asset, newFlag: !oldFlag });
     }
 }

--- a/src/SablierV2LockupLinear.sol
+++ b/src/SablierV2LockupLinear.sol
@@ -15,7 +15,6 @@ import { ISablierV2NftDescriptor } from "./interfaces/ISablierV2NftDescriptor.so
 import { ISablierV2LockupRecipient } from "./interfaces/hooks/ISablierV2LockupRecipient.sol";
 import { ISablierV2LockupSender } from "./interfaces/hooks/ISablierV2LockupSender.sol";
 import { Errors } from "./libraries/Errors.sol";
-import { Events } from "./libraries/Events.sol";
 import { Helpers } from "./libraries/Helpers.sol";
 import { Lockup, LockupLinear } from "./types/DataTypes.sol";
 
@@ -352,7 +351,7 @@ contract SablierV2LockupLinear is
         }
 
         // Log the cancellation.
-        emit Events.CancelLockupStream(streamId, sender, recipient, senderAmount, recipientAmount);
+        emit CancelLockupStream(streamId, sender, recipient, senderAmount, recipientAmount);
     }
 
     /// @dev See the documentation for the public functions that call this internal function.
@@ -417,7 +416,7 @@ contract SablierV2LockupLinear is
         }
 
         // Log the newly created stream, and the address that funded it.
-        emit Events.CreateLockupLinearStream({
+        emit CreateLockupLinearStream({
             streamId: streamId,
             funder: msg.sender,
             sender: params.sender,
@@ -443,7 +442,7 @@ contract SablierV2LockupLinear is
         }
 
         // Log the renouncement.
-        emit Events.RenounceLockupStream(streamId);
+        emit RenounceLockupStream(streamId);
     }
 
     /// @dev See the documentation for the public functions that call this internal function.
@@ -498,6 +497,6 @@ contract SablierV2LockupLinear is
         }
 
         // Log the withdrawal.
-        emit Events.WithdrawFromLockupStream(streamId, to, amount);
+        emit WithdrawFromLockupStream(streamId, to, amount);
     }
 }

--- a/src/SablierV2LockupPro.sol
+++ b/src/SablierV2LockupPro.sol
@@ -18,7 +18,6 @@ import { ISablierV2LockupRecipient } from "./interfaces/hooks/ISablierV2LockupRe
 import { ISablierV2LockupSender } from "./interfaces/hooks/ISablierV2LockupSender.sol";
 import { ISablierV2NftDescriptor } from "./interfaces/ISablierV2NftDescriptor.sol";
 import { Errors } from "./libraries/Errors.sol";
-import { Events } from "./libraries/Events.sol";
 import { Helpers } from "./libraries/Helpers.sol";
 import { Lockup, LockupPro } from "./types/DataTypes.sol";
 
@@ -421,7 +420,7 @@ contract SablierV2LockupPro is
         }
 
         // Log the cancellation.
-        emit Events.CancelLockupStream(streamId, sender, recipient, senderAmount, recipientAmount);
+        emit CancelLockupStream(streamId, sender, recipient, senderAmount, recipientAmount);
     }
 
     /// @dev See the documentation for the public functions that call this internal function.
@@ -494,7 +493,7 @@ contract SablierV2LockupPro is
         }
 
         // Log the newly created stream, and the address that funded it.
-        emit Events.CreateLockupProStream({
+        emit CreateLockupProStream({
             streamId: streamId,
             funder: msg.sender,
             sender: params.sender,
@@ -521,7 +520,7 @@ contract SablierV2LockupPro is
         }
 
         // Log the renouncement.
-        emit Events.RenounceLockupStream(streamId);
+        emit RenounceLockupStream(streamId);
     }
 
     /// @dev See the documentation for the public functions that call this internal function.
@@ -576,6 +575,6 @@ contract SablierV2LockupPro is
         }
 
         // Log the withdrawal.
-        emit Events.WithdrawFromLockupStream(streamId, to, amount);
+        emit WithdrawFromLockupStream(streamId, to, amount);
     }
 }

--- a/src/abstracts/SablierV2Adminable.sol
+++ b/src/abstracts/SablierV2Adminable.sol
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
+import { SablierV2Events } from "../abstracts/SablierV2Events.sol";
 import { ISablierV2Adminable } from "../interfaces/ISablierV2Adminable.sol";
 import { Errors } from "../libraries/Errors.sol";
-import { Events } from "../libraries/Events.sol";
 
 /// @title SablierV2Adminable
 /// @dev Abstract contract that implements the {ISablierV2Adminable} interface.
-abstract contract SablierV2Adminable is ISablierV2Adminable {
+abstract contract SablierV2Adminable is
+    ISablierV2Adminable, // no dependencies
+    SablierV2Events // no dependencies
+{
     /*//////////////////////////////////////////////////////////////////////////
                                        STORAGE
     //////////////////////////////////////////////////////////////////////////*/
@@ -40,6 +43,6 @@ abstract contract SablierV2Adminable is ISablierV2Adminable {
         admin = newAdmin;
 
         // Log the transfer of the admin.
-        emit Events.TransferAdmin(oldAdmin, newAdmin);
+        emit TransferAdmin(oldAdmin, newAdmin);
     }
 }

--- a/src/abstracts/SablierV2Config.sol
+++ b/src/abstracts/SablierV2Config.sol
@@ -5,16 +5,17 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
+import { SablierV2Events } from "../abstracts/SablierV2Events.sol";
 import { ISablierV2Config } from "../interfaces/ISablierV2Config.sol";
 import { ISablierV2Comptroller } from "../interfaces/ISablierV2Comptroller.sol";
 import { Errors } from "../libraries/Errors.sol";
-import { Events } from "../libraries/Events.sol";
 import { SablierV2Adminable } from "./SablierV2Adminable.sol";
 
 /// @title SablierV2Config
 /// @dev Abstract contract that implements the {ISablierV2Config} interface.
 abstract contract SablierV2Config is
     ISablierV2Config, // no dependencies
+    SablierV2Events, // no dependencies
     SablierV2Adminable // one dependency
 {
     using SafeERC20 for IERC20;
@@ -53,7 +54,7 @@ abstract contract SablierV2Config is
         admin = initialAdmin;
         comptroller = initialComptroller;
         MAX_FEE = maxFee;
-        emit Events.TransferAdmin({ oldAdmin: address(0), newAdmin: initialAdmin });
+        emit TransferAdmin({ oldAdmin: address(0), newAdmin: initialAdmin });
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -84,7 +85,7 @@ abstract contract SablierV2Config is
         asset.safeTransfer({ to: msg.sender, value: protocolRevenues });
 
         // Log the claim of the protocol revenues.
-        emit Events.ClaimProtocolRevenues({ admin: msg.sender, asset: asset, protocolRevenues: protocolRevenues });
+        emit ClaimProtocolRevenues({ admin: msg.sender, asset: asset, protocolRevenues: protocolRevenues });
     }
 
     /// @inheritdoc ISablierV2Config
@@ -94,10 +95,6 @@ abstract contract SablierV2Config is
         comptroller = newComptroller;
 
         // Log the change of the comptroller.
-        emit Events.SetComptroller({
-            admin: msg.sender,
-            oldComptroller: oldComptroller,
-            newComptroller: newComptroller
-        });
+        emit SetComptroller({ admin: msg.sender, oldComptroller: oldComptroller, newComptroller: newComptroller });
     }
 }

--- a/src/abstracts/SablierV2Events.sol
+++ b/src/abstracts/SablierV2Events.sol
@@ -8,9 +8,9 @@ import { IERC3156FlashBorrower } from "erc3156/interfaces/IERC3156FlashBorrower.
 import { ISablierV2Comptroller } from "../interfaces/ISablierV2Comptroller.sol";
 import { Lockup, LockupLinear, LockupPro } from "../types/DataTypes.sol";
 
-/// @title Events
+/// @title SablierV2Events
 /// @notice Library with events emitted across all contracts.
-library Events {
+abstract contract SablierV2Events {
     /*//////////////////////////////////////////////////////////////////////////
                                 SABLIER-V2-ADMINABLE
     //////////////////////////////////////////////////////////////////////////*/
@@ -21,7 +21,7 @@ library Events {
     event TransferAdmin(address indexed oldAdmin, address indexed newAdmin);
 
     /*//////////////////////////////////////////////////////////////////////////
-                                     SABLIER-V2-CONFIG
+                                 SABLIER-V2-CONFIG
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Emitted when the contract admin claims all protocol revenues accrued for the provided ERC-20 asset.

--- a/src/abstracts/SablierV2FlashLoan.sol
+++ b/src/abstracts/SablierV2FlashLoan.sol
@@ -7,13 +7,14 @@ import { ud } from "@prb/math/UD60x18.sol";
 import { IERC3156FlashBorrower } from "erc3156/interfaces/IERC3156FlashBorrower.sol";
 import { IERC3156FlashLender } from "erc3156/interfaces/IERC3156FlashLender.sol";
 
+import { SablierV2Events } from "../abstracts/SablierV2Events.sol";
 import { Errors } from "../libraries/Errors.sol";
-import { Events } from "../libraries/Events.sol";
 import { SablierV2Config } from "./SablierV2Config.sol";
 
 /// @dev Abstract contract that implements the {IERC3156FlashLender} interface.
 abstract contract SablierV2FlashLoan is
     IERC3156FlashLender, // no dependencies
+    SablierV2Events, // no dependencies
     SablierV2Config // three dependencies
 {
     using SafeERC20 for IERC20;
@@ -147,7 +148,7 @@ abstract contract SablierV2FlashLoan is
         IERC20(asset).safeTransferFrom({ from: address(receiver), to: address(this), value: returnAmount });
 
         // Log the flash loan.
-        emit Events.FlashLoan({
+        emit FlashLoan({
             initiator: msg.sender,
             receiver: receiver,
             asset: IERC20(asset),

--- a/src/abstracts/SablierV2Lockup.sol
+++ b/src/abstracts/SablierV2Lockup.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.18;
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
+import { SablierV2Events } from "../abstracts/SablierV2Events.sol";
 import { ISablierV2Comptroller } from "../interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2Lockup } from "../interfaces/ISablierV2Lockup.sol";
 import { ISablierV2NftDescriptor } from "../interfaces/ISablierV2NftDescriptor.sol";
@@ -15,6 +16,7 @@ import { SablierV2FlashLoan } from "./SablierV2FlashLoan.sol";
 /// @title SablierV2Lockup
 /// @dev Abstract contract that implements the {ISablierV2Lockup} interface and other common logic.
 abstract contract SablierV2Lockup is
+    SablierV2Events, // no dependencies
     SablierV2Config, // three dependencies
     ISablierV2Lockup, // four dependencies
     SablierV2FlashLoan // five dependencies

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -8,6 +8,7 @@ import { eqString } from "@prb/test/Helpers.sol";
 import { StdCheats } from "forge-std/StdCheats.sol";
 
 import { DeployProtocol } from "script/deploy/DeployProtocol.s.sol";
+import { SablierV2Events } from "src/abstracts/SablierV2Events.sol";
 import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2LockupLinear } from "src/interfaces/ISablierV2LockupLinear.sol";
 import { ISablierV2LockupPro } from "src/interfaces/ISablierV2LockupPro.sol";
@@ -22,7 +23,13 @@ import { GoodSender } from "./shared/mockups/hooks/GoodSender.t.sol";
 
 /// @title Base_Test
 /// @notice Base test contract with common logic needed by all test contracts.
-abstract contract Base_Test is Assertions, Calculations, Fuzzers, StdCheats {
+abstract contract Base_Test is
+    SablierV2Events, // no dependencies
+    Calculations, // one dependency
+    StdCheats, // one dependency
+    Assertions, // two dependencies
+    Fuzzers // two dependencies
+{
     /*//////////////////////////////////////////////////////////////////////////
                                        STRUCTS
     //////////////////////////////////////////////////////////////////////////*/

--- a/test/fork/lockup/linear/Linear.t.sol
+++ b/test/fork/lockup/linear/Linear.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Broker, Lockup, LockupLinear } from "src/types/DataTypes.sol";
 
 import { Fork_Test } from "../../Fork.t.sol";
@@ -147,7 +146,7 @@ abstract contract Linear_Fork_Test is Fork_Test {
         // Expect a {CreateLockupLinearStream} event to be emitted.
         vars.streamId = linear.nextStreamId();
         expectEmit();
-        emit Events.CreateLockupLinearStream({
+        emit CreateLockupLinearStream({
             streamId: vars.streamId,
             funder: holder,
             sender: params.sender,
@@ -242,7 +241,7 @@ abstract contract Linear_Fork_Test is Fork_Test {
 
             // Expect a {WithdrawFromLockupStream} event to be emitted.
             expectEmit();
-            emit Events.WithdrawFromLockupStream({
+            emit WithdrawFromLockupStream({
                 streamId: vars.streamId,
                 to: params.recipient,
                 amount: params.withdrawAmount
@@ -290,7 +289,7 @@ abstract contract Linear_Fork_Test is Fork_Test {
             expectEmit();
             vars.senderAmount = linear.returnableAmountOf(vars.streamId);
             vars.recipientAmount = linear.withdrawableAmountOf(vars.streamId);
-            emit Events.CancelLockupStream(
+            emit CancelLockupStream(
                 vars.streamId,
                 params.sender,
                 params.recipient,

--- a/test/fork/lockup/pro/Pro.t.sol
+++ b/test/fork/lockup/pro/Pro.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Broker, Lockup, LockupPro } from "src/types/DataTypes.sol";
 
 import { Fork_Test } from "../../Fork.t.sol";
@@ -152,7 +151,7 @@ abstract contract Pro_Fork_Test is Fork_Test {
             start: params.startTime,
             end: params.segments[params.segments.length - 1].milestone
         });
-        emit Events.CreateLockupProStream({
+        emit CreateLockupProStream({
             streamId: vars.streamId,
             funder: holder,
             sender: params.sender,
@@ -246,7 +245,7 @@ abstract contract Pro_Fork_Test is Fork_Test {
 
             // Expect a {WithdrawFromLockupStream} event to be emitted.
             expectEmit();
-            emit Events.WithdrawFromLockupStream({
+            emit WithdrawFromLockupStream({
                 streamId: vars.streamId,
                 to: params.recipient,
                 amount: params.withdrawAmount
@@ -294,7 +293,7 @@ abstract contract Pro_Fork_Test is Fork_Test {
             expectEmit();
             vars.senderAmount = pro.returnableAmountOf(vars.streamId);
             vars.recipientAmount = pro.withdrawableAmountOf(vars.streamId);
-            emit Events.CancelLockupStream(
+            emit CancelLockupStream(
                 vars.streamId,
                 params.sender,
                 params.recipient,

--- a/test/fuzz/adminable/transfer-admin/transferAdmin.t.sol
+++ b/test/fuzz/adminable/transfer-admin/transferAdmin.t.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Adminable_Fuzz_Test } from "../Adminable.t.sol";
 
@@ -17,7 +16,7 @@ contract TransferAdmin_Fuzz_Test is Adminable_Fuzz_Test {
 
         // Expect a {TransferAdmin} event to be emitted.
         expectEmit();
-        emit Events.TransferAdmin({ oldAdmin: users.admin, newAdmin: newAdmin });
+        emit TransferAdmin({ oldAdmin: users.admin, newAdmin: newAdmin });
 
         // Transfer the admin.
         adminable.transferAdmin(newAdmin);

--- a/test/fuzz/comptroller/set-flash-fee/setFlashFee.t.sol
+++ b/test/fuzz/comptroller/set-flash-fee/setFlashFee.t.sol
@@ -3,8 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
-import { Events } from "src/libraries/Events.sol";
-
 import { Comptroller_Fuzz_Test } from "../Comptroller.t.sol";
 
 contract SetFlashFee_Fuzz_Test is Comptroller_Fuzz_Test {
@@ -14,7 +12,7 @@ contract SetFlashFee_Fuzz_Test is Comptroller_Fuzz_Test {
 
         // Expect a {SetFlashFee} event to be emitted.
         expectEmit();
-        emit Events.SetFlashFee({ admin: users.admin, oldFlashFee: ZERO, newFlashFee: newFlashFee });
+        emit SetFlashFee({ admin: users.admin, oldFlashFee: ZERO, newFlashFee: newFlashFee });
 
         // She the new flash fee.
         comptroller.setFlashFee(newFlashFee);

--- a/test/fuzz/comptroller/set-protocol-fee/setProtocolFee.t.sol
+++ b/test/fuzz/comptroller/set-protocol-fee/setProtocolFee.t.sol
@@ -3,8 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
-import { Events } from "src/libraries/Events.sol";
-
 import { Comptroller_Fuzz_Test } from "../Comptroller.t.sol";
 
 contract SetProtocolFee_Fuzz_Test is Comptroller_Fuzz_Test {
@@ -14,7 +12,7 @@ contract SetProtocolFee_Fuzz_Test is Comptroller_Fuzz_Test {
 
         // Expect a {SetProtocolFee} event to be emitted.
         expectEmit();
-        emit Events.SetProtocolFee({
+        emit SetProtocolFee({
             admin: users.admin,
             asset: DEFAULT_ASSET,
             oldProtocolFee: ZERO,

--- a/test/fuzz/flash-loan/flash-loan/flashLoan.t.sol
+++ b/test/fuzz/flash-loan/flash-loan/flashLoan.t.sol
@@ -6,7 +6,6 @@ import { MAX_UD60x18, UD60x18, ud } from "@prb/math/UD60x18.sol";
 import { IERC3156FlashBorrower } from "erc3156/interfaces/IERC3156FlashBorrower.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { FlashLoan_Fuzz_Test } from "../FlashLoan.t.sol";
 
@@ -85,7 +84,7 @@ contract FlashLoanFunction_Fuzz_Test is FlashLoan_Fuzz_Test {
 
         // Expect a {FlashLoan} event to be emitted.
         expectEmit();
-        emit Events.FlashLoan({
+        emit FlashLoan({
             initiator: users.admin,
             receiver: goodFlashLoanReceiver,
             asset: DEFAULT_ASSET,

--- a/test/fuzz/lockup/linear/create-with-durations/createWithDurations.t.sol
+++ b/test/fuzz/lockup/linear/create-with-durations/createWithDurations.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Lockup, LockupLinear } from "src/types/DataTypes.sol";
 
 import { Linear_Fuzz_Test } from "../Linear.t.sol";
@@ -114,7 +113,7 @@ contract CreateWithDurations_Linear_Fuzz_Test is Linear_Fuzz_Test {
 
         // Expect a {CreateLockupLinearStream} event to be emitted.
         expectEmit();
-        emit Events.CreateLockupLinearStream({
+        emit CreateLockupLinearStream({
             streamId: streamId,
             funder: funder,
             sender: defaultParams.createWithDurations.sender,

--- a/test/fuzz/lockup/linear/create-with-range/createWithRange.t.sol
+++ b/test/fuzz/lockup/linear/create-with-range/createWithRange.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { MAX_UD60x18, UD60x18, ud } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Broker, Lockup, LockupLinear } from "src/types/DataTypes.sol";
 
 import { Linear_Fuzz_Test } from "../Linear.t.sol";
@@ -200,7 +199,7 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
 
         // Expect a {CreateLockupLinearStream} event to be emitted.
         expectEmit();
-        emit Events.CreateLockupLinearStream({
+        emit CreateLockupLinearStream({
             streamId: streamId,
             funder: funder,
             sender: params.sender,

--- a/test/fuzz/lockup/pro/create-with-deltas/createWithDeltas.t.sol
+++ b/test/fuzz/lockup/pro/create-with-deltas/createWithDeltas.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Errors } from "src/libraries/Errors.sol";
 import { Lockup, LockupPro } from "src/types/DataTypes.sol";
 
@@ -90,7 +89,7 @@ contract CreateWithDeltas_Pro_Fuzz_Test is Pro_Fuzz_Test {
 
         // Expect a {CreateLockupProStream} event to be emitted.
         expectEmit();
-        emit Events.CreateLockupProStream({
+        emit CreateLockupProStream({
             streamId: streamId,
             funder: vars.funder,
             sender: defaultParams.createWithDeltas.sender,

--- a/test/fuzz/lockup/pro/create-with-milestones/createWithMilestones.t.sol
+++ b/test/fuzz/lockup/pro/create-with-milestones/createWithMilestones.t.sol
@@ -7,7 +7,6 @@ import { stdError } from "forge-std/StdError.sol";
 
 import { ISablierV2LockupPro } from "src/interfaces/ISablierV2LockupPro.sol";
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Broker, Lockup, LockupPro } from "src/types/DataTypes.sol";
 
 import { Pro_Fuzz_Test } from "../Pro.t.sol";
@@ -305,7 +304,7 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
             start: params.startTime,
             end: params.segments[params.segments.length - 1].milestone
         });
-        emit Events.CreateLockupProStream({
+        emit CreateLockupProStream({
             streamId: streamId,
             funder: funder,
             sender: params.sender,

--- a/test/fuzz/lockup/pro/withdraw/withdraw.t.sol
+++ b/test/fuzz/lockup/pro/withdraw/withdraw.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Broker, Lockup, LockupPro } from "src/types/DataTypes.sol";
 
 import { Withdraw_Fuzz_Test } from "../../shared/withdraw/withdraw.t.sol";
@@ -96,11 +95,7 @@ contract Withdraw_Pro_Fuzz_Test is Pro_Fuzz_Test, Withdraw_Fuzz_Test {
 
         // Expect a {WithdrawFromLockupStream} event to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
-            streamId: vars.streamId,
-            to: users.recipient,
-            amount: vars.withdrawAmount
-        });
+        emit WithdrawFromLockupStream({ streamId: vars.streamId, to: users.recipient, amount: vars.withdrawAmount });
 
         // Make the withdrawal.
         pro.withdraw({ streamId: vars.streamId, to: users.recipient, amount: vars.withdrawAmount });

--- a/test/fuzz/lockup/shared/cancel-multiple/cancelMultiple.t.sol
+++ b/test/fuzz/lockup/shared/cancel-multiple/cancelMultiple.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Fuzz_Test } from "../../../Fuzz.t.sol";
@@ -83,9 +82,9 @@ abstract contract CancelMultiple_Unit_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect two {CancelLockupStream} events to be emitted.
         expectEmit();
-        emit Events.CancelLockupStream(streamIds[0], users.sender, users.recipient, senderAmount0, recipientAmount0);
+        emit CancelLockupStream(streamIds[0], users.sender, users.recipient, senderAmount0, recipientAmount0);
         expectEmit();
-        emit Events.CancelLockupStream(streamIds[1], users.sender, users.recipient, senderAmount1, recipientAmount1);
+        emit CancelLockupStream(streamIds[1], users.sender, users.recipient, senderAmount1, recipientAmount1);
 
         // Cancel the streams.
         lockup.cancelMultiple(streamIds);
@@ -162,9 +161,9 @@ abstract contract CancelMultiple_Unit_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect two {CancelLockupStream} events to be emitted.
         expectEmit();
-        emit Events.CancelLockupStream(streamIds[0], users.sender, users.recipient, senderAmount0, recipientAmount0);
+        emit CancelLockupStream(streamIds[0], users.sender, users.recipient, senderAmount0, recipientAmount0);
         expectEmit();
-        emit Events.CancelLockupStream(streamIds[1], users.sender, users.recipient, senderAmount1, recipientAmount1);
+        emit CancelLockupStream(streamIds[1], users.sender, users.recipient, senderAmount1, recipientAmount1);
 
         // Cancel the streams.
         lockup.cancelMultiple(streamIds);

--- a/test/fuzz/lockup/shared/cancel/cancel.t.sol
+++ b/test/fuzz/lockup/shared/cancel/cancel.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -108,7 +107,7 @@ abstract contract Cancel_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect a {CancelLockupStream} event to be emitted.
         expectEmit();
-        emit Events.CancelLockupStream(streamId, users.sender, address(goodRecipient), senderAmount, recipientAmount);
+        emit CancelLockupStream(streamId, users.sender, address(goodRecipient), senderAmount, recipientAmount);
 
         // Cancel the stream.
         lockup.cancel(streamId);
@@ -201,7 +200,7 @@ abstract contract Cancel_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect a {CancelLockupStream} event to be emitted.
         expectEmit();
-        emit Events.CancelLockupStream(streamId, address(goodSender), users.recipient, senderAmount, recipientAmount);
+        emit CancelLockupStream(streamId, address(goodSender), users.recipient, senderAmount, recipientAmount);
 
         // Cancel the stream.
         lockup.cancel(streamId);

--- a/test/fuzz/lockup/shared/withdraw-max/withdrawMax.t.sol
+++ b/test/fuzz/lockup/shared/withdraw-max/withdrawMax.t.sol
@@ -3,8 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
-import { Events } from "src/libraries/Events.sol";
-
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
 import { Fuzz_Test } from "../../../Fuzz.t.sol";
 
@@ -39,11 +37,7 @@ abstract contract WithdrawMax_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect a {WithdrawFromLockupStream} event to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
-            streamId: defaultStreamId,
-            to: users.recipient,
-            amount: withdrawAmount
-        });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
 
         // Make the max withdrawal.
         lockup.withdrawMax(defaultStreamId, users.recipient);

--- a/test/fuzz/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
+++ b/test/fuzz/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -109,9 +108,9 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect two {WithdrawFromLockupStream} events to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
 
         // Expect the withdrawals to be made.
         expectTransferCall({ to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
@@ -175,9 +174,9 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect two {WithdrawFromLockupStream} events to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: withdrawAmount });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: withdrawAmount });
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: withdrawAmount });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: withdrawAmount });
 
         // Make the withdrawals.
         uint128[] memory amounts = Solarray.uint128s(withdrawAmount, withdrawAmount);
@@ -260,13 +259,13 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect two {WithdrawFromLockupStream} events to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
+        emit WithdrawFromLockupStream({
             streamId: vars.endedStreamId,
             to: params.to,
             amount: vars.endedWithdrawAmount
         });
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
+        emit WithdrawFromLockupStream({
             streamId: vars.ongoingStreamId,
             to: params.to,
             amount: params.ongoingWithdrawAmount

--- a/test/fuzz/lockup/shared/withdraw/withdraw.t.sol
+++ b/test/fuzz/lockup/shared/withdraw/withdraw.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -155,7 +154,7 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect a {WithdrawFromLockupStream} event to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: streamId, to: to, amount: withdrawAmount });
+        emit WithdrawFromLockupStream({ streamId: streamId, to: to, amount: withdrawAmount });
 
         // Make the withdrawal.
         lockup.withdraw({ streamId: streamId, to: to, amount: withdrawAmount });
@@ -222,11 +221,7 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
 
         // Expect a {WithdrawFromLockupStream} event to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
-            streamId: streamId,
-            to: address(goodRecipient),
-            amount: withdrawAmount
-        });
+        emit WithdrawFromLockupStream({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
 
         // Make the withdrawal.
         lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });

--- a/test/unit/adminable/transfer-admin/transferAdmin.t.sol
+++ b/test/unit/adminable/transfer-admin/transferAdmin.t.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Adminable_Unit_Test } from "../Adminable.t.sol";
 
@@ -27,7 +26,7 @@ contract TransferAdmin_Unit_Test is Adminable_Unit_Test {
     function test_TransferAdmin_SameAdmin() external callerAdmin {
         // Expect a {TransferAdmin} event to be emitted.
         expectEmit();
-        emit Events.TransferAdmin({ oldAdmin: users.admin, newAdmin: users.admin });
+        emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.admin });
 
         // Transfer the admin.
         adminable.transferAdmin(users.admin);
@@ -46,7 +45,7 @@ contract TransferAdmin_Unit_Test is Adminable_Unit_Test {
     function test_TransferAdmin_ZeroAddress() external callerAdmin {
         // Expect a {TransferAdmin} event to be emitted.
         expectEmit();
-        emit Events.TransferAdmin({ oldAdmin: users.admin, newAdmin: address(0) });
+        emit TransferAdmin({ oldAdmin: users.admin, newAdmin: address(0) });
 
         // Transfer the admin.
         adminable.transferAdmin(address(0));
@@ -61,7 +60,7 @@ contract TransferAdmin_Unit_Test is Adminable_Unit_Test {
     function test_TransferAdmin_NewAdmin() external callerAdmin notZeroAddress {
         // Expect a {TransferAdmin} event to be emitted.
         expectEmit();
-        emit Events.TransferAdmin({ oldAdmin: users.admin, newAdmin: users.alice });
+        emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.alice });
 
         // Transfer the admin.
         adminable.transferAdmin(users.alice);

--- a/test/unit/comptroller/constructor/constructor.t.sol
+++ b/test/unit/comptroller/constructor/constructor.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { DeployComptroller } from "script/deploy/DeployComptroller.s.sol";
 import { SablierV2Comptroller } from "src/SablierV2Comptroller.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Comptroller_Unit_Test } from "../Comptroller.t.sol";
 
@@ -12,7 +11,7 @@ contract Constructor_Comptroller_Unit_Test is Comptroller_Unit_Test {
     function test_Constructor() external {
         // Expect a {TransferEvent} to be emitted.
         expectEmit();
-        emit Events.TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
+        emit TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
 
         // Construct the comptroller contract.
         SablierV2Comptroller constructedComptroller = new SablierV2Comptroller({ initialAdmin: users.admin });

--- a/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
+++ b/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Comptroller_Unit_Test } from "../Comptroller.t.sol";
 

--- a/test/unit/comptroller/set-flash-fee/setFlashFee.t.sol
+++ b/test/unit/comptroller/set-flash-fee/setFlashFee.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Comptroller_Unit_Test } from "../Comptroller.t.sol";
 
@@ -45,7 +44,7 @@ contract SetFlashFee_Unit_Test is Comptroller_Unit_Test {
 
         // Expect a {SetFlashFee} event to be emitted.
         expectEmit();
-        emit Events.SetFlashFee({ admin: users.admin, oldFlashFee: ZERO, newFlashFee: newFlashFee });
+        emit SetFlashFee({ admin: users.admin, oldFlashFee: ZERO, newFlashFee: newFlashFee });
 
         // She the new flash fee.
         comptroller.setFlashFee(newFlashFee);

--- a/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
+++ b/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Comptroller_Unit_Test } from "../Comptroller.t.sol";
 
@@ -44,7 +43,7 @@ contract SetProtocolFee_Unit_Test is Comptroller_Unit_Test {
 
         // Expect a {SetProtocolFee} event to be emitted.
         expectEmit();
-        emit Events.SetProtocolFee({
+        emit SetProtocolFee({
             admin: users.admin,
             asset: DEFAULT_ASSET,
             oldProtocolFee: ZERO,

--- a/test/unit/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
+++ b/test/unit/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Comptroller_Unit_Test } from "../Comptroller.t.sol";
 
@@ -30,7 +29,7 @@ contract ToggleFlashAsset_Unit_Test is Comptroller_Unit_Test {
     function test_ToggleFlashAsset_FlagNotEnabled() external callerAdmin {
         // Expect a {ToggleFlashAsset} event to be emitted.
         expectEmit();
-        emit Events.ToggleFlashAsset({ admin: users.admin, asset: DEFAULT_ASSET, newFlag: true });
+        emit ToggleFlashAsset({ admin: users.admin, asset: DEFAULT_ASSET, newFlag: true });
 
         // Toggle the flash asset.
         comptroller.toggleFlashAsset(DEFAULT_ASSET);
@@ -49,7 +48,7 @@ contract ToggleFlashAsset_Unit_Test is Comptroller_Unit_Test {
     function test_ToggleFlashAsset() external callerAdmin flagEnabled {
         // Expect a {ToggleFlashAsset} event to be emitted.
         expectEmit();
-        emit Events.ToggleFlashAsset({ admin: users.admin, asset: DEFAULT_ASSET, newFlag: false });
+        emit ToggleFlashAsset({ admin: users.admin, asset: DEFAULT_ASSET, newFlag: false });
 
         // Toggle the flash asset.
         comptroller.toggleFlashAsset(DEFAULT_ASSET);

--- a/test/unit/flash-loan/flash-loan/flashLoan.t.sol
+++ b/test/unit/flash-loan/flash-loan/flashLoan.t.sol
@@ -6,7 +6,6 @@ import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 import { IERC3156FlashBorrower } from "erc3156/interfaces/IERC3156FlashBorrower.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { FlashLoan_Unit_Test } from "../FlashLoan.t.sol";
 
@@ -178,7 +177,7 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
 
         // Expect a {FlashLoan} event to be emitted.
         expectEmit();
-        emit Events.FlashLoan({
+        emit FlashLoan({
             initiator: users.admin,
             receiver: goodFlashLoanReceiver,
             asset: DEFAULT_ASSET,

--- a/test/unit/lockup/linear/constructor/constructor.t.sol
+++ b/test/unit/lockup/linear/constructor/constructor.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 import { SablierV2LockupLinear } from "src/SablierV2LockupLinear.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Linear_Unit_Test } from "../Linear.t.sol";
 
@@ -13,7 +12,7 @@ contract Constructor_Linear_Unit_Test is Linear_Unit_Test {
     function test_Constructor() external {
         // Expect a {TransferEvent} to be emitted.
         expectEmit();
-        emit Events.TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
+        emit TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
 
         // Construct the linear contract.
         SablierV2LockupLinear constructedLinear = new SablierV2LockupLinear({

--- a/test/unit/lockup/linear/create-with-durations/createWithDurations.t.sol
+++ b/test/unit/lockup/linear/create-with-durations/createWithDurations.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { LockupLinear } from "src/types/DataTypes.sol";
 
 import { Linear_Unit_Test } from "../Linear.t.sol";
@@ -109,7 +108,7 @@ contract CreateWithDurations_Linear_Unit_Test is Linear_Unit_Test {
 
         // Expect a {CreateLockupLinearStream} event to be emitted.
         expectEmit();
-        emit Events.CreateLockupLinearStream({
+        emit CreateLockupLinearStream({
             streamId: streamId,
             funder: funder,
             sender: users.sender,

--- a/test/unit/lockup/linear/create-with-range/createWithRange.t.sol
+++ b/test/unit/lockup/linear/create-with-range/createWithRange.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Broker, Lockup, LockupLinear } from "src/types/DataTypes.sol";
 
@@ -211,7 +210,7 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
 
         // Expect a {CreateLockupLinearStream} event to be emitted.
         expectEmit();
-        emit Events.CreateLockupLinearStream({
+        emit CreateLockupLinearStream({
             streamId: streamId,
             funder: funder,
             sender: users.sender,

--- a/test/unit/lockup/pro/constructor/constructor.t.sol
+++ b/test/unit/lockup/pro/constructor/constructor.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 import { SablierV2LockupPro } from "src/SablierV2LockupPro.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Pro_Unit_Test } from "../Pro.t.sol";
 
@@ -13,7 +12,7 @@ contract Constructor_Pro_Unit_Test is Pro_Unit_Test {
     function test_Constructor() external {
         // Expect a {TransferEvent} to be emitted.
         expectEmit();
-        emit Events.TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
+        emit TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
 
         // Construct the pro contract.
         SablierV2LockupPro constructedPro = new SablierV2LockupPro({

--- a/test/unit/lockup/pro/create-with-deltas/createWithDeltas.t.sol
+++ b/test/unit/lockup/pro/create-with-deltas/createWithDeltas.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { ud2x18 } from "@prb/math/UD2x18.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Errors } from "src/libraries/Errors.sol";
 import { LockupPro } from "src/types/DataTypes.sol";
 
@@ -144,7 +143,7 @@ contract CreateWithDeltas_Pro_Unit_Test is Pro_Unit_Test {
 
         // Expect a {CreateLockupProStream} event to be emitted.
         expectEmit();
-        emit Events.CreateLockupProStream({
+        emit CreateLockupProStream({
             streamId: streamId,
             funder: funder,
             sender: users.sender,

--- a/test/unit/lockup/pro/create-with-milestones/createWithMilestones.t.sol
+++ b/test/unit/lockup/pro/create-with-milestones/createWithMilestones.t.sol
@@ -7,7 +7,6 @@ import { UD2x18 } from "@prb/math/UD2x18.sol";
 import { stdError } from "forge-std/StdError.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Broker, Lockup, LockupPro } from "src/types/DataTypes.sol";
 
 import { ISablierV2LockupPro } from "src/interfaces/ISablierV2LockupPro.sol";
@@ -377,7 +376,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
 
         // Expect a {CreateLockupProStream} event to be emitted.
         expectEmit();
-        emit Events.CreateLockupProStream({
+        emit CreateLockupProStream({
             streamId: streamId,
             funder: funder,
             sender: users.sender,

--- a/test/unit/lockup/shared/cancel-multiple/cancelMultiple.t.sol
+++ b/test/unit/lockup/shared/cancel-multiple/cancelMultiple.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Unit_Test } from "../../../Unit.t.sol";
@@ -253,9 +252,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect two {CancelLockupStream} events to be emitted.
         expectEmit();
-        emit Events.CancelLockupStream(streamIds[0], users.sender, users.recipient, senderAmount0, recipientAmount0);
+        emit CancelLockupStream(streamIds[0], users.sender, users.recipient, senderAmount0, recipientAmount0);
         expectEmit();
-        emit Events.CancelLockupStream(streamIds[1], users.sender, users.recipient, senderAmount1, recipientAmount1);
+        emit CancelLockupStream(streamIds[1], users.sender, users.recipient, senderAmount1, recipientAmount1);
 
         // Cancel the streams.
         lockup.cancelMultiple(streamIds);

--- a/test/unit/lockup/shared/cancel/cancel.t.sol
+++ b/test/unit/lockup/shared/cancel/cancel.t.sol
@@ -6,7 +6,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { ISablierV2LockupRecipient } from "src/interfaces/hooks/ISablierV2LockupRecipient.sol";
 import { ISablierV2LockupSender } from "src/interfaces/hooks/ISablierV2LockupSender.sol";
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -271,7 +270,7 @@ abstract contract Cancel_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect a {CancelLockupStream} event to be emitted.
         expectEmit();
-        emit Events.CancelLockupStream(streamId, users.sender, address(goodRecipient), senderAmount, recipientAmount);
+        emit CancelLockupStream(streamId, users.sender, address(goodRecipient), senderAmount, recipientAmount);
 
         // Cancel the stream.
         lockup.cancel(streamId);
@@ -451,7 +450,7 @@ abstract contract Cancel_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect a {CancelLockupStream} event to be emitted.
         expectEmit();
-        emit Events.CancelLockupStream(streamId, address(goodSender), users.recipient, senderAmount, recipientAmount);
+        emit CancelLockupStream(streamId, address(goodSender), users.recipient, senderAmount, recipientAmount);
 
         // Cancel the stream.
         lockup.cancel(streamId);

--- a/test/unit/lockup/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
+++ b/test/unit/lockup/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
 import { Unit_Test } from "../../../Unit.t.sol";
@@ -53,7 +52,7 @@ abstract contract ClaimProtocolRevenues_Unit_Test is Unit_Test, Lockup_Shared_Te
 
         // Expect a {ClaimProtocolRevenues} event to be emitted.
         expectEmit();
-        emit Events.ClaimProtocolRevenues(users.admin, DEFAULT_ASSET, protocolRevenues);
+        emit ClaimProtocolRevenues(users.admin, DEFAULT_ASSET, protocolRevenues);
 
         // Claim the protocol revenues.
         config.claimProtocolRevenues(DEFAULT_ASSET);

--- a/test/unit/lockup/shared/renounce/renounce.t.sol
+++ b/test/unit/lockup/shared/renounce/renounce.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { ISablierV2LockupRecipient } from "src/interfaces/hooks/ISablierV2LockupRecipient.sol";
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
 import { Unit_Test } from "../../../Unit.t.sol";
@@ -197,7 +196,7 @@ abstract contract Renounce_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect a {RenounceLockupStream} event to be emitted.
         expectEmit();
-        emit Events.RenounceLockupStream(streamId);
+        emit RenounceLockupStream(streamId);
 
         // RenounceLockupStream the stream.
         lockup.renounce(streamId);

--- a/test/unit/lockup/shared/set-comptroller/setComptroller.t.sol
+++ b/test/unit/lockup/shared/set-comptroller/setComptroller.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { SablierV2Comptroller } from "src/SablierV2Comptroller.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -34,7 +33,7 @@ abstract contract SetComptroller_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_SetComptroller_SameComptroller() external callerAdmin {
         // Expect a {SetComptroller} event to be emitted.
         expectEmit();
-        emit Events.SetComptroller(users.admin, comptroller, comptroller);
+        emit SetComptroller(users.admin, comptroller, comptroller);
 
         // Re-set the comptroller.
         config.setComptroller(comptroller);
@@ -52,7 +51,7 @@ abstract contract SetComptroller_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect a {SetComptroller} event to be emitted.
         expectEmit();
-        emit Events.SetComptroller(users.admin, comptroller, newComptroller);
+        emit SetComptroller(users.admin, comptroller, newComptroller);
 
         // Set the new comptroller.
         config.setComptroller(newComptroller);

--- a/test/unit/lockup/shared/withdraw-max/withdrawMax.t.sol
+++ b/test/unit/lockup/shared/withdraw-max/withdrawMax.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -57,11 +56,7 @@ abstract contract WithdrawMax_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect a {WithdrawFromLockupStream} event to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
-            streamId: defaultStreamId,
-            to: users.recipient,
-            amount: withdrawAmount
-        });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
 
         // Make the max withdrawal.
         lockup.withdrawMax(defaultStreamId, users.recipient);

--- a/test/unit/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
+++ b/test/unit/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -315,9 +314,9 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect two {WithdrawFromLockupStream} events to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
 
         // Expect the withdrawals to be made.
         expectTransferCall({ to: to, amount: DEFAULT_DEPOSIT_AMOUNT });
@@ -377,9 +376,9 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect two {WithdrawFromLockupStream} events to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: withdrawAmount });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[0], to: to, amount: withdrawAmount });
         expectEmit();
-        emit Events.WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: withdrawAmount });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamIds[1], to: to, amount: withdrawAmount });
 
         // Make the withdrawals.
         uint128[] memory amounts = Solarray.uint128s(withdrawAmount, withdrawAmount);
@@ -454,13 +453,9 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect two {WithdrawFromLockupStream} events to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
-            streamId: vars.endedStreamId,
-            to: vars.to,
-            amount: vars.endedWithdrawAmount
-        });
+        emit WithdrawFromLockupStream({ streamId: vars.endedStreamId, to: vars.to, amount: vars.endedWithdrawAmount });
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
+        emit WithdrawFromLockupStream({
             streamId: vars.ongoingStreamId,
             to: vars.to,
             amount: vars.ongoingWithdrawAmount

--- a/test/unit/lockup/shared/withdraw/withdraw.t.sol
+++ b/test/unit/lockup/shared/withdraw/withdraw.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 
 import { ISablierV2LockupRecipient } from "src/interfaces/hooks/ISablierV2LockupRecipient.sol";
 import { Errors } from "src/libraries/Errors.sol";
-import { Events } from "src/libraries/Events.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
@@ -263,11 +262,7 @@ abstract contract Withdraw_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect a {WithdrawFromLockupStream} event to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
-            streamId: defaultStreamId,
-            to: users.recipient,
-            amount: withdrawAmount
-        });
+        emit WithdrawFromLockupStream({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
 
         // Make the withdrawal.
         lockup.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
@@ -458,11 +453,7 @@ abstract contract Withdraw_Unit_Test is Unit_Test, Lockup_Shared_Test {
 
         // Expect a {WithdrawFromLockupStream} event to be emitted.
         expectEmit();
-        emit Events.WithdrawFromLockupStream({
-            streamId: streamId,
-            to: address(goodRecipient),
-            amount: withdrawAmount
-        });
+        emit WithdrawFromLockupStream({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
 
         // Make the withdrawal.
         lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });


### PR DESCRIPTION
Fixes #215 by moving the events to an abstract contract `SablierV2Events`. This is the solution that [OpenZeppelin resorted to](https://github.com/ethereum/solidity/issues/13086#issuecomment-1445318418).

It's a shame that we have to do this, but I prefer to have our contract ABIs show up correctly on Etherscan.