### PR TITLE
refactor: concat symbol in NFT descriptor

### DIFF
--- a/src/SablierV2NftDescriptor.sol
+++ b/src/SablierV2NftDescriptor.sol
@@ -9,6 +9,7 @@ import { ISablierV2NftDescriptor } from "src/interfaces/ISablierV2NftDescriptor.
 contract SablierV2NftDescriptor is ISablierV2NftDescriptor {
     function tokenURI(ISablierV2Lockup lockup, uint256 streamId) external view override returns (string memory uri) {
         lockup.getStartTime(streamId);
-        uri = "This is an NFT descriptor";
+        string memory symbol = lockup.symbol();
+        uri = string.concat("This is the NFT descriptor for ", symbol);
     }
 }

--- a/src/interfaces/ISablierV2Lockup.sol
+++ b/src/interfaces/ISablierV2Lockup.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/token/ERC20/IERC20.sol";
 import { IERC721Metadata } from "@openzeppelin/token/ERC721/extensions/IERC721Metadata.sol";
 import { UD60x18 } from "@prb/math/UD60x18.sol";
 
-import { ISablierV2NftDescriptor } from "../interfaces/ISablierV2NftDescriptor.sol";
 import { Lockup } from "../types/DataTypes.sol";
 import { ISablierV2Config } from "./ISablierV2Config.sol";
 import { ISablierV2Comptroller } from "./ISablierV2Comptroller.sol";

--- a/test/unit/lockup/shared/token-uri/tokenURI.t.sol
+++ b/test/unit/lockup/shared/token-uri/tokenURI.t.sol
@@ -11,7 +11,7 @@ abstract contract TokenURI_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_TokenURI_StreamNull() external {
         uint256 nullStreamId = 1729;
         string memory actualTokenURI = lockup.tokenURI({ tokenId: nullStreamId });
-        string memory expectedTokenURI = string("This is an NFT descriptor");
+        string memory expectedTokenURI = string.concat("This is the NFT descriptor for ", lockup.symbol());
         assertEq(actualTokenURI, expectedTokenURI, "tokenURI");
     }
 
@@ -23,7 +23,7 @@ abstract contract TokenURI_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_TokenURI() external streamNonNull {
         uint256 streamId = createDefaultStream();
         string memory actualTokenURI = lockup.tokenURI({ tokenId: streamId });
-        string memory expectedTokenURI = string("This is an NFT descriptor");
+        string memory expectedTokenURI = string.concat("This is the NFT descriptor for ", lockup.symbol());
         assertEq(actualTokenURI, expectedTokenURI, "tokenURI");
     }
 }


### PR DESCRIPTION
As explained [here](https://github.com/sablierhq/v2-core/pull/357#issuecomment-1457996984), the contracts have been differentiable all along, since the `ISablierV2Lockup` interface inherits from `IERC721Metadata`.

While the changes introduced by this PR are only for demonstrational purposes, they will serve us as a good foreshadow for what's to come (slightly different token URIs based on the caller contract).