### PR TITLE
test: add "when" prefix to all modifiers

### DIFF
--- a/test/fuzz/adminable/transfer-admin/transferAdmin.t.sol
+++ b/test/fuzz/adminable/transfer-admin/transferAdmin.t.sol
@@ -6,12 +6,12 @@ import { Errors } from "src/libraries/Errors.sol";
 import { Adminable_Fuzz_Test } from "../Adminable.t.sol";
 
 contract TransferAdmin_Fuzz_Test is Adminable_Fuzz_Test {
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         _;
     }
 
     /// @dev it should emit a {TransferAdmin} event and set the new admin.
-    function testFuzz_TransferAdmin(address newAdmin) external callerAdmin {
+    function testFuzz_TransferAdmin(address newAdmin) external whenCallerAdmin {
         vm.assume(newAdmin != address(0) && newAdmin != users.admin);
 
         // Expect a {TransferAdmin} event to be emitted.

--- a/test/fuzz/flash-loan/flash-loan/flashLoan.t.sol
+++ b/test/fuzz/flash-loan/flash-loan/flashLoan.t.sol
@@ -22,12 +22,12 @@ contract FlashLoanFunction_Fuzz_Test is FlashLoan_Fuzz_Test {
         });
     }
 
-    modifier amountNotTooHigh() {
+    modifier whenAmountNotTooHigh() {
         _;
     }
 
     /// @dev it should revert.
-    function testFuzz_RevertWhen_CalculatedFeeTooHigh(UD60x18 flashFee) external amountNotTooHigh {
+    function testFuzz_RevertWhen_CalculatedFeeTooHigh(UD60x18 flashFee) external whenAmountNotTooHigh {
         // Bound the flash fee so that the calculated fee ends up being greater than 2^128.
         flashFee = bound(flashFee, ud(1.1e18), ud(10e18));
         comptroller.setFlashFee(flashFee);
@@ -43,7 +43,7 @@ contract FlashLoanFunction_Fuzz_Test is FlashLoan_Fuzz_Test {
         });
     }
 
-    modifier calculatedFeeNotTooHigh() {
+    modifier whenCalculatedFeeNotTooHigh() {
         _;
     }
 
@@ -59,7 +59,7 @@ contract FlashLoanFunction_Fuzz_Test is FlashLoan_Fuzz_Test {
         UD60x18 comptrollerFlashFee,
         uint128 amount,
         bytes calldata data
-    ) external amountNotTooHigh calculatedFeeNotTooHigh {
+    ) external whenAmountNotTooHigh whenCalculatedFeeNotTooHigh {
         comptrollerFlashFee = bound(comptrollerFlashFee, 0, DEFAULT_MAX_FEE);
         comptroller.setFlashFee(comptrollerFlashFee);
 

--- a/test/fuzz/lockup/linear/create-with-durations/createWithDurations.t.sol
+++ b/test/fuzz/lockup/linear/create-with-durations/createWithDurations.t.sol
@@ -46,14 +46,14 @@ contract CreateWithDurations_Linear_Fuzz_Test is Linear_Fuzz_Test {
         createDefaultStreamWithDurations(LockupLinear.Durations({ cliff: cliffDuration, total: totalDuration }));
     }
 
-    modifier cliffDurationCalculationDoesNotOverflow() {
+    modifier whenCliffDurationCalculationDoesNotOverflow() {
         _;
     }
 
     /// @dev it should revert.
     function testFuzz_RevertWhen_TotalDurationCalculationOverflows(
         LockupLinear.Durations memory durations
-    ) external cliffDurationCalculationDoesNotOverflow {
+    ) external whenCliffDurationCalculationDoesNotOverflow {
         uint40 startTime = getBlockTimestamp();
         durations.cliff = boundUint40(durations.cliff, 0, UINT40_MAX - startTime);
         durations.total = boundUint40(durations.total, UINT40_MAX - startTime + 1, UINT40_MAX);
@@ -79,7 +79,7 @@ contract CreateWithDurations_Linear_Fuzz_Test is Linear_Fuzz_Test {
         createDefaultStreamWithDurations(durations);
     }
 
-    modifier totalDurationCalculationDoesNotOverflow() {
+    modifier whenTotalDurationCalculationDoesNotOverflow() {
         _;
     }
 

--- a/test/fuzz/lockup/linear/create-with-range/createWithRange.t.sol
+++ b/test/fuzz/lockup/linear/create-with-range/createWithRange.t.sol
@@ -20,18 +20,18 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
         streamId = linear.nextStreamId();
     }
 
-    modifier recipientNonZeroAddress() {
+    modifier whenRecipientNonZeroAddress() {
         _;
     }
 
-    modifier depositAmountNotZero() {
+    modifier whenDepositAmountNotZero() {
         _;
     }
 
     /// @dev it should revert.
     function testFuzz_RevertWhen_StartTimeGreaterThanCliffTime(
         uint40 startTime
-    ) external recipientNonZeroAddress depositAmountNotZero {
+    ) external whenRecipientNonZeroAddress whenDepositAmountNotZero {
         startTime = boundUint40(startTime, DEFAULT_CLIFF_TIME + 1, MAX_UNIX_TIMESTAMP);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -43,7 +43,7 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
         createDefaultStreamWithStartTime(startTime);
     }
 
-    modifier startTimeNotGreaterThanCliffTime() {
+    modifier whenStartTimeNotGreaterThanCliffTime() {
         _;
     }
 
@@ -51,7 +51,7 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
     function testFuzz_RevertWhen_CliffTimeNotLessThanEndTime(
         uint40 cliffTime,
         uint40 endTime
-    ) external recipientNonZeroAddress depositAmountNotZero startTimeNotGreaterThanCliffTime {
+    ) external whenRecipientNonZeroAddress whenDepositAmountNotZero whenStartTimeNotGreaterThanCliffTime {
         vm.assume(cliffTime >= endTime);
         vm.assume(endTime > DEFAULT_START_TIME);
 
@@ -65,14 +65,20 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
         createDefaultStreamWithRange(LockupLinear.Range({ start: DEFAULT_START_TIME, cliff: cliffTime, end: endTime }));
     }
 
-    modifier cliffTimeLessThanEndTime() {
+    modifier whenCliffTimeLessThanEndTime() {
         _;
     }
 
     /// @dev it should revert.
     function testFuzz_RevertWhen_ProtocolFeeTooHigh(
         UD60x18 protocolFee
-    ) external recipientNonZeroAddress depositAmountNotZero startTimeNotGreaterThanCliffTime cliffTimeLessThanEndTime {
+    )
+        external
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
+    {
         protocolFee = bound(protocolFee, DEFAULT_MAX_FEE.add(ud(1)), MAX_UD60x18);
 
         // Set the protocol fee.
@@ -86,7 +92,7 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
         createDefaultStream();
     }
 
-    modifier protocolFeeNotTooHigh() {
+    modifier whenProtocolFeeNotTooHigh() {
         _;
     }
 
@@ -95,11 +101,11 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
         Broker memory broker
     )
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
-        cliffTimeLessThanEndTime
-        protocolFeeNotTooHigh
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
+        whenProtocolFeeNotTooHigh
     {
         vm.assume(broker.account != address(0));
         broker.fee = bound(broker.fee, DEFAULT_MAX_FEE.add(ud(1)), MAX_UD60x18);
@@ -109,15 +115,15 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
         createDefaultStreamWithBroker(broker);
     }
 
-    modifier brokerFeeNotTooHigh() {
+    modifier whenBrokerFeeNotTooHigh() {
         _;
     }
 
-    modifier assetContract() {
+    modifier whenAssetContract() {
         _;
     }
 
-    modifier assetERC20Compliant() {
+    modifier whenAssetERC20Compliant() {
         _;
     }
 
@@ -151,13 +157,13 @@ contract CreateWithRange_Linear_Fuzz_Test is Linear_Fuzz_Test {
         UD60x18 protocolFee
     )
         external
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
-        cliffTimeLessThanEndTime
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
-        assetContract
-        assetERC20Compliant
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
+        whenAssetContract
+        whenAssetERC20Compliant
     {
         vm.assume(funder != address(0) && params.recipient != address(0) && params.broker.account != address(0));
         vm.assume(params.totalAmount != 0);

--- a/test/fuzz/lockup/linear/streamed-amount-of/streamedAmountOf.sol
+++ b/test/fuzz/lockup/linear/streamed-amount-of/streamedAmountOf.sol
@@ -11,14 +11,14 @@ import { Linear_Fuzz_Test } from "../Linear.t.sol";
 contract StreamedAmountOf_Linear_Fuzz_Test is Linear_Fuzz_Test {
     uint256 internal defaultStreamId;
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return zero.
-    function testFuzz_StreamedAmountOf_CliffTimeGreaterThanCurrentTime(uint40 timeWarp) external streamActive {
+    function testFuzz_StreamedAmountOf_CliffTimeGreaterThanCurrentTime(uint40 timeWarp) external whenStreamActive {
         timeWarp = boundUint40(timeWarp, 0, DEFAULT_CLIFF_DURATION - 1);
         vm.warp({ timestamp: DEFAULT_START_TIME + timeWarp });
         uint128 actualStreamedAmount = linear.streamedAmountOf(defaultStreamId);
@@ -26,7 +26,7 @@ contract StreamedAmountOf_Linear_Fuzz_Test is Linear_Fuzz_Test {
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier cliffTimeLessThanOrEqualToCurrentTime() {
+    modifier whenCliffTimeLessThanOrEqualToCurrentTime() {
         // Disable the protocol fee so that it doesn't interfere with the calculations.
         changePrank({ msgSender: users.admin });
         comptroller.setProtocolFee({ asset: DEFAULT_ASSET, newProtocolFee: ZERO });
@@ -45,7 +45,7 @@ contract StreamedAmountOf_Linear_Fuzz_Test is Linear_Fuzz_Test {
     function testFuzz_StreamedAmountOf(
         uint40 timeWarp,
         uint128 depositAmount
-    ) external streamActive cliffTimeLessThanOrEqualToCurrentTime {
+    ) external whenStreamActive whenCliffTimeLessThanOrEqualToCurrentTime {
         vm.assume(depositAmount != 0);
         timeWarp = boundUint40(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 

--- a/test/fuzz/lockup/linear/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/test/fuzz/lockup/linear/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -10,14 +10,14 @@ import { Linear_Fuzz_Test } from "../Linear.t.sol";
 
 contract WithdrawableAmountOf_Linear_Fuzz_Test is Linear_Fuzz_Test {
     uint256 internal defaultStreamId;
-    modifier streamActive() {
+    modifier whenStreamActive() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return zero.
-    function testFuzz_WithdrawableAmountOf_CliffTimeGreaterThanCurrentTime(uint40 timeWarp) external streamActive {
+    function testFuzz_WithdrawableAmountOf_CliffTimeGreaterThanCurrentTime(uint40 timeWarp) external whenStreamActive {
         timeWarp = boundUint40(timeWarp, 0, DEFAULT_CLIFF_DURATION - 1);
         vm.warp({ timestamp: DEFAULT_START_TIME + timeWarp });
         uint128 actualWithdrawableAmount = linear.withdrawableAmountOf(defaultStreamId);
@@ -25,7 +25,7 @@ contract WithdrawableAmountOf_Linear_Fuzz_Test is Linear_Fuzz_Test {
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
-    modifier cliffTimeLessThanOrEqualToCurrentTime() {
+    modifier whenCliffTimeLessThanOrEqualToCurrentTime() {
         // Disable the protocol fee so that it doesn't interfere with the calculations.
         changePrank({ msgSender: users.admin });
         comptroller.setProtocolFee({ asset: DEFAULT_ASSET, newProtocolFee: ZERO });
@@ -44,7 +44,7 @@ contract WithdrawableAmountOf_Linear_Fuzz_Test is Linear_Fuzz_Test {
     function testFuzz_WithdrawableAmountOf_NoWithdrawals(
         uint40 timeWarp,
         uint128 depositAmount
-    ) external streamActive cliffTimeLessThanOrEqualToCurrentTime {
+    ) external whenStreamActive whenCliffTimeLessThanOrEqualToCurrentTime {
         vm.assume(depositAmount != 0);
         timeWarp = boundUint40(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 
@@ -80,7 +80,7 @@ contract WithdrawableAmountOf_Linear_Fuzz_Test is Linear_Fuzz_Test {
         uint40 timeWarp,
         uint128 depositAmount,
         uint128 withdrawAmount
-    ) external streamActive cliffTimeLessThanOrEqualToCurrentTime {
+    ) external whenStreamActive whenCliffTimeLessThanOrEqualToCurrentTime {
         timeWarp = boundUint40(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
         depositAmount = boundUint128(depositAmount, 10_000, UINT128_MAX);
 

--- a/test/fuzz/lockup/pro/create-with-deltas/createWithDeltas.t.sol
+++ b/test/fuzz/lockup/pro/create-with-deltas/createWithDeltas.t.sol
@@ -19,15 +19,15 @@ contract CreateWithDeltas_Pro_Fuzz_Test is Pro_Fuzz_Test {
         streamId = pro.nextStreamId();
     }
 
-    modifier loopCalculationsDoNotOverflowBlockGasLimit() {
+    modifier whenLoopCalculationsDoNotOverflowBlockGasLimit() {
         _;
     }
 
-    modifier deltasNotZero() {
+    modifier whenDeltasNotZero() {
         _;
     }
 
-    modifier milestonesCalculationsDoNotOverflow() {
+    modifier whenMilestonesCalculationsDoNotOverflow() {
         _;
     }
 
@@ -49,7 +49,12 @@ contract CreateWithDeltas_Pro_Fuzz_Test is Pro_Fuzz_Test {
     /// record the protocol fee, and emit a {CreateLockupProStream} event.
     function testFuzz_CreateWithDeltas(
         LockupPro.SegmentWithDelta[] memory segments
-    ) external loopCalculationsDoNotOverflowBlockGasLimit deltasNotZero milestonesCalculationsDoNotOverflow {
+    )
+        external
+        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenDeltasNotZero
+        whenMilestonesCalculationsDoNotOverflow
+    {
         vm.assume(segments.length != 0);
 
         // Fuzz the deltas.

--- a/test/fuzz/lockup/pro/create-with-milestones/createWithMilestones.t.sol
+++ b/test/fuzz/lockup/pro/create-with-milestones/createWithMilestones.t.sol
@@ -22,29 +22,29 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         streamId = pro.nextStreamId();
     }
 
-    modifier recipientNonZeroAddress() {
+    modifier whenRecipientNonZeroAddress() {
         _;
     }
 
-    modifier depositAmountNotZero() {
+    modifier whenDepositAmountNotZero() {
         _;
     }
 
-    modifier segmentCountNotZero() {
+    modifier whenSegmentCountNotZero() {
         _;
     }
 
     /// @dev it should revert.
     function testFuzz_RevertWhen_SegmentCountTooHigh(
         uint256 segmentCount
-    ) external recipientNonZeroAddress depositAmountNotZero segmentCountNotZero {
+    ) external whenRecipientNonZeroAddress whenDepositAmountNotZero whenSegmentCountNotZero {
         segmentCount = bound(segmentCount, DEFAULT_MAX_SEGMENT_COUNT + 1, DEFAULT_MAX_SEGMENT_COUNT * 10);
         LockupPro.Segment[] memory segments = new LockupPro.Segment[](segmentCount);
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2LockupPro_SegmentCountTooHigh.selector, segmentCount));
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier segmentCountNotTooHigh() {
+    modifier whenSegmentCountNotTooHigh() {
         _;
     }
 
@@ -52,7 +52,7 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
     function testFuzz_RevertWhen_SegmentAmountsSumOverflows(
         uint128 amount0,
         uint128 amount1
-    ) external recipientNonZeroAddress depositAmountNotZero segmentCountNotZero segmentCountNotTooHigh {
+    ) external whenRecipientNonZeroAddress whenDepositAmountNotZero whenSegmentCountNotZero whenSegmentCountNotTooHigh {
         amount0 = boundUint128(amount0, UINT128_MAX / 2 + 1, UINT128_MAX);
         amount1 = boundUint128(amount0, UINT128_MAX / 2 + 1, UINT128_MAX);
         LockupPro.Segment[] memory segments = DEFAULT_SEGMENTS;
@@ -62,7 +62,7 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier segmentAmountsSumDoesNotOverflow() {
+    modifier whenSegmentAmountsSumDoesNotOverflow() {
         _;
     }
 
@@ -71,11 +71,11 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         uint40 firstMilestone
     )
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
     {
         firstMilestone = boundUint40(firstMilestone, 0, DEFAULT_START_TIME);
 
@@ -96,11 +96,11 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier startTimeLessThanFirstSegmentMilestone() {
+    modifier whenStartTimeLessThanFirstSegmentMilestone() {
         _;
     }
 
-    modifier segmentMilestonesOrdered() {
+    modifier whenSegmentMilestonesOrdered() {
         _;
     }
 
@@ -109,13 +109,13 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         uint128 depositDiff
     )
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
     {
         depositDiff = boundUint128(depositDiff, 100, DEFAULT_TOTAL_AMOUNT);
 
@@ -144,7 +144,7 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         pro.createWithMilestones(params);
     }
 
-    modifier depositAmountEqualToSegmentAmountsSum() {
+    modifier whenDepositAmountEqualToSegmentAmountsSum() {
         _;
     }
 
@@ -153,14 +153,14 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         UD60x18 protocolFee
     )
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
     {
         protocolFee = bound(protocolFee, DEFAULT_MAX_FEE.add(ud(1)), MAX_UD60x18);
 
@@ -175,7 +175,7 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         createDefaultStream();
     }
 
-    modifier protocolFeeNotTooHigh() {
+    modifier whenProtocolFeeNotTooHigh() {
         _;
     }
 
@@ -184,15 +184,15 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         Broker memory broker
     )
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
-        protocolFeeNotTooHigh
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
+        whenProtocolFeeNotTooHigh
     {
         vm.assume(broker.account != address(0));
         broker.fee = bound(broker.fee, DEFAULT_MAX_FEE.add(ud(1)), MAX_UD60x18);
@@ -202,15 +202,15 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         createDefaultStreamWithBroker(broker);
     }
 
-    modifier brokerFeeNotTooHigh() {
+    modifier whenBrokerFeeNotTooHigh() {
         _;
     }
 
-    modifier assetContract() {
+    modifier whenAssetContract() {
         _;
     }
 
-    modifier assetERC20Compliant() {
+    modifier whenAssetERC20Compliant() {
         _;
     }
 
@@ -243,18 +243,18 @@ contract CreateWithMilestones_Pro_Fuzz_Test is Pro_Fuzz_Test {
         UD60x18 protocolFee
     )
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
-        assetContract
-        assetERC20Compliant
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
+        whenAssetContract
+        whenAssetERC20Compliant
     {
         vm.assume(funder != address(0) && params.recipient != address(0) && params.broker.account != address(0));
         vm.assume(params.segments.length != 0);

--- a/test/fuzz/lockup/pro/streamed-amount-of/streamedAmountOf.sol
+++ b/test/fuzz/lockup/pro/streamed-amount-of/streamedAmountOf.sol
@@ -8,13 +8,13 @@ import { Pro_Fuzz_Test } from "../Pro.t.sol";
 contract StreamedAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
     uint256 internal defaultStreamId;
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
-    modifier startTimeLessThanCurrentTime() {
+    modifier whenStartTimeLessThanCurrentTime() {
         _;
     }
 
@@ -25,7 +25,9 @@ contract StreamedAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
     /// - Current time < end time
     /// - Current time = end time
     /// - Current time > end time
-    function testFuzz_StreamedAmountOf_OneSegment(uint40 timeWarp) external streamActive startTimeLessThanCurrentTime {
+    function testFuzz_StreamedAmountOf_OneSegment(
+        uint40 timeWarp
+    ) external whenStreamActive whenStartTimeLessThanCurrentTime {
         timeWarp = boundUint40(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 
         // Warp into the future.
@@ -53,11 +55,11 @@ contract StreamedAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier multipleSegments() {
+    modifier whenMultipleSegments() {
         _;
     }
 
-    modifier currentMilestoneNot1st() {
+    modifier whenCurrentMilestoneNot1st() {
         _;
     }
 
@@ -70,7 +72,7 @@ contract StreamedAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
     /// - Current time > end time
     function testFuzz_StreamedAmountOf_CurrentMilestoneNot1st(
         uint40 timeWarp
-    ) external streamActive startTimeLessThanCurrentTime multipleSegments currentMilestoneNot1st {
+    ) external whenStreamActive whenStartTimeLessThanCurrentTime whenMultipleSegments whenCurrentMilestoneNot1st {
         timeWarp = boundUint40(timeWarp, MAX_SEGMENTS[0].milestone, DEFAULT_TOTAL_DURATION * 2);
 
         // Warp into the future.

--- a/test/fuzz/lockup/pro/withdraw/withdraw.t.sol
+++ b/test/fuzz/lockup/pro/withdraw/withdraw.t.sol
@@ -39,17 +39,17 @@ contract Withdraw_Pro_Fuzz_Test is Pro_Fuzz_Test, Withdraw_Fuzz_Test {
         Params memory params
     )
         external
-        streamActive
-        callerAuthorized
-        toNonZeroAddress
-        withdrawAmountNotZero
-        withdrawAmountLessThanOrEqualToWithdrawableAmount
-        callerSender
-        currentTimeLessThanEndTime
-        recipientContract
-        recipientImplementsHook
-        recipientDoesNotRevert
-        noRecipientReentrancy
+        whenStreamActive
+        whenCallerAuthorized
+        whenToNonZeroAddress
+        whenWithdrawAmountNotZero
+        whenWithdrawAmountLessThanOrEqualToWithdrawableAmount
+        whenCallerSender
+        whenCurrentTimeLessThanEndTime
+        whenRecipientContract
+        whenRecipientImplementsHook
+        whenRecipientDoesNotRevert
+        whenNoRecipientReentrancy
     {
         vm.assume(params.segments.length != 0);
 

--- a/test/fuzz/lockup/pro/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/test/fuzz/lockup/pro/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -10,7 +10,7 @@ import { Pro_Fuzz_Test } from "../Pro.t.sol";
 contract WithdrawableAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
     uint256 internal defaultStreamId;
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
 
@@ -21,7 +21,7 @@ contract WithdrawableAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
         _;
     }
 
-    modifier startTimeLessThanCurrentTime() {
+    modifier whenStartTimeLessThanCurrentTime() {
         _;
     }
 
@@ -34,7 +34,7 @@ contract WithdrawableAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
     /// - Current time > end time
     function testFuzz_WithdrawableAmountOf_WithoutWithdrawals(
         uint40 timeWarp
-    ) external streamActive startTimeLessThanCurrentTime {
+    ) external whenStreamActive whenStartTimeLessThanCurrentTime {
         timeWarp = boundUint40(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 
         // Warp into the future.
@@ -58,7 +58,7 @@ contract WithdrawableAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
-    modifier withWithdrawals() {
+    modifier whenWithWithdrawals() {
         _;
     }
 
@@ -73,7 +73,7 @@ contract WithdrawableAmountOf_Pro_Fuzz_Test is Pro_Fuzz_Test {
     function testFuzz_WithdrawableAmountOf(
         uint40 timeWarp,
         uint128 withdrawAmount
-    ) external streamActive startTimeLessThanCurrentTime withWithdrawals {
+    ) external whenStreamActive whenStartTimeLessThanCurrentTime whenWithWithdrawals {
         timeWarp = boundUint40(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 
         // Warp into the future.

--- a/test/fuzz/lockup/shared/cancel-multiple/cancelMultiple.t.sol
+++ b/test/fuzz/lockup/shared/cancel-multiple/cancelMultiple.t.sol
@@ -21,15 +21,15 @@ abstract contract CancelMultiple_Unit_Test is Fuzz_Test, Lockup_Shared_Test {
         changePrank({ msgSender: users.recipient });
     }
 
-    modifier onlyNonNullStreams() {
+    modifier whenOnlyNonNullStreams() {
         _;
     }
 
-    modifier allStreamsCancelable() {
+    modifier whenAllStreamsCancelable() {
         _;
     }
 
-    modifier callerAuthorizedAllStreams() {
+    modifier whenCallerAuthorizedAllStreams() {
         _;
     }
 
@@ -44,7 +44,7 @@ abstract contract CancelMultiple_Unit_Test is Fuzz_Test, Lockup_Shared_Test {
     function testFuzz_CancelMultiple_Sender(
         uint256 timeWarp,
         uint40 endTime
-    ) external onlyNonNullStreams allStreamsCancelable callerAuthorizedAllStreams {
+    ) external whenOnlyNonNullStreams whenAllStreamsCancelable whenCallerAuthorizedAllStreams {
         timeWarp = bound(timeWarp, 0 seconds, DEFAULT_TOTAL_DURATION * 2);
         endTime = boundUint40(endTime, DEFAULT_CLIFF_TIME + 1, DEFAULT_END_TIME + DEFAULT_TOTAL_DURATION / 2);
 
@@ -123,7 +123,7 @@ abstract contract CancelMultiple_Unit_Test is Fuzz_Test, Lockup_Shared_Test {
     function testFuzz_CancelMultiple_Recipient(
         uint256 timeWarp,
         uint40 endTime
-    ) external onlyNonNullStreams allStreamsCancelable callerAuthorizedAllStreams {
+    ) external whenOnlyNonNullStreams whenAllStreamsCancelable whenCallerAuthorizedAllStreams {
         timeWarp = bound(timeWarp, 0 seconds, DEFAULT_TOTAL_DURATION * 2);
         endTime = boundUint40(endTime, DEFAULT_CLIFF_TIME + 1, DEFAULT_END_TIME + DEFAULT_TOTAL_DURATION / 2);
 

--- a/test/fuzz/lockup/shared/cancel/cancel.t.sol
+++ b/test/fuzz/lockup/shared/cancel/cancel.t.sol
@@ -19,39 +19,39 @@ abstract contract Cancel_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         _;
     }
 
-    modifier streamCancelable() {
+    modifier whenStreamCancelable() {
         _;
     }
 
-    modifier callerAuthorized() {
+    modifier whenCallerAuthorized() {
         _;
     }
 
-    modifier callerSender() {
+    modifier whenCallerSender() {
         // Make the sender the caller in this test suite.
         changePrank({ msgSender: users.sender });
         _;
     }
-    modifier recipientContract() {
+    modifier whenRecipientContract() {
         _;
     }
 
-    modifier recipientImplementsHook() {
+    modifier whenRecipientImplementsHook() {
         _;
     }
-    modifier recipientDoesNotRevert() {
+    modifier whenRecipientDoesNotRevert() {
         _;
     }
 
-    modifier noRecipientReentrancy() {
+    modifier whenNoRecipientReentrancy() {
         _;
     }
 
@@ -67,14 +67,14 @@ abstract contract Cancel_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         uint128 withdrawAmount
     )
         external
-        streamActive
-        streamCancelable
-        callerAuthorized
-        callerSender
-        recipientContract
-        recipientImplementsHook
-        recipientDoesNotRevert
-        noRecipientReentrancy
+        whenStreamActive
+        whenStreamCancelable
+        whenCallerAuthorized
+        whenCallerSender
+        whenRecipientContract
+        whenRecipientImplementsHook
+        whenRecipientDoesNotRevert
+        whenNoRecipientReentrancy
     {
         timeWarp = bound(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 
@@ -128,23 +128,23 @@ abstract contract Cancel_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         assertEq(actualNFTOwner, expectedNFTOwner, "NFT owner");
     }
 
-    modifier callerRecipient() {
+    modifier whenCallerRecipient() {
         _;
     }
 
-    modifier senderContract() {
+    modifier whenSenderContract() {
         _;
     }
 
-    modifier senderImplementsHook() {
+    modifier whenSenderImplementsHook() {
         _;
     }
 
-    modifier senderDoesNotRevert() {
+    modifier whenSenderDoesNotRevert() {
         _;
     }
 
-    modifier noSenderReentrancy() {
+    modifier whenNoSenderReentrancy() {
         _;
     }
 
@@ -160,14 +160,14 @@ abstract contract Cancel_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         uint128 withdrawAmount
     )
         external
-        streamActive
-        streamCancelable
-        callerAuthorized
-        callerRecipient
-        senderContract
-        senderImplementsHook
-        senderDoesNotRevert
-        noSenderReentrancy
+        whenStreamActive
+        whenStreamCancelable
+        whenCallerAuthorized
+        whenCallerRecipient
+        whenSenderContract
+        whenSenderImplementsHook
+        whenSenderDoesNotRevert
+        whenNoSenderReentrancy
     {
         timeWarp = bound(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 

--- a/test/fuzz/lockup/shared/get-withdrawn-amount/getWithdrawnAmount.t.sol
+++ b/test/fuzz/lockup/shared/get-withdrawn-amount/getWithdrawnAmount.t.sol
@@ -12,14 +12,14 @@ abstract contract GetWithdrawnAmount_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test 
         changePrank({ msgSender: users.recipient });
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return zero.
-    function testFuzz_GetWithdrawnAmount_NoWithdrawals(uint256 timeWarp) external streamNonNull {
+    function testFuzz_GetWithdrawnAmount_NoWithdrawals(uint256 timeWarp) external whenStreamNonNull {
         timeWarp = bound(timeWarp, 0, DEFAULT_TOTAL_DURATION * 2);
 
         // Warp into the future.
@@ -35,7 +35,7 @@ abstract contract GetWithdrawnAmount_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test 
     function testFuzz_GetWithdrawnAmount_WithWithdrawals(
         uint256 timeWarp,
         uint128 withdrawAmount
-    ) external streamNonNull {
+    ) external whenStreamNonNull {
         timeWarp = bound(timeWarp, DEFAULT_CLIFF_TIME, DEFAULT_TOTAL_DURATION - 1);
 
         // Warp into the future.

--- a/test/fuzz/lockup/shared/returnable-amount-of/returnableAmountOf.t.sol
+++ b/test/fuzz/lockup/shared/returnable-amount-of/returnableAmountOf.t.sol
@@ -9,14 +9,14 @@ abstract contract ReturnableAmountOf_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test 
 
     function setUp() public virtual override(Fuzz_Test, Lockup_Shared_Test) {}
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return the correct returnable amount.
-    function testFuzz_ReturnableAmountOf(uint256 timeWarp) external streamActive {
+    function testFuzz_ReturnableAmountOf(uint256 timeWarp) external whenStreamActive {
         timeWarp = bound(timeWarp, 0, DEFAULT_TOTAL_DURATION * 2);
 
         // Warp into the future.

--- a/test/fuzz/lockup/shared/withdraw-max/withdrawMax.t.sol
+++ b/test/fuzz/lockup/shared/withdraw-max/withdrawMax.t.sol
@@ -17,13 +17,13 @@ abstract contract WithdrawMax_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         changePrank({ msgSender: users.recipient });
     }
 
-    modifier currentTimeLessThanEndTime() {
+    modifier whenCurrentTimeLessThanEndTime() {
         _;
     }
 
     /// @dev it should make the max withdrawal, update the withdrawn amount, and emit a {WithdrawFromLockupStream}
     /// event.
-    function testFuzz_WithdrawMax(uint256 timeWarp) external currentTimeLessThanEndTime {
+    function testFuzz_WithdrawMax(uint256 timeWarp) external whenCurrentTimeLessThanEndTime {
         timeWarp = bound(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION - 1);
 
         // Warp into the future.

--- a/test/fuzz/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
+++ b/test/fuzz/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
@@ -28,26 +28,26 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         changePrank({ msgSender: users.recipient });
     }
 
-    modifier toNonZeroAddress() {
+    modifier whenToNonZeroAddress() {
         _;
     }
 
-    modifier arraysEqual() {
+    modifier whenArraysEqual() {
         _;
     }
 
-    modifier onlyNonNullStreams() {
+    modifier whenOnlyNonNullStreams() {
         _;
     }
 
-    modifier callerAuthorizedAllStreams() {
+    modifier whenCallerAuthorizedAllStreams() {
         _;
     }
 
     /// @dev it should make the withdrawals and update the withdrawn amounts.
     function testFuzz_WithdrawMultiple_CallerApprovedOperator(
         address to
-    ) external toNonZeroAddress arraysEqual onlyNonNullStreams callerAuthorizedAllStreams {
+    ) external whenToNonZeroAddress whenArraysEqual whenOnlyNonNullStreams whenCallerAuthorizedAllStreams {
         vm.assume(to != address(0));
 
         // Approve the operator for all streams.
@@ -75,14 +75,14 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         assertEq(actualWithdrawnAmount1, expectedWithdrawnAmount, "withdrawnAmount1");
     }
 
-    modifier callerRecipient() {
+    modifier whenCallerRecipient() {
         _;
     }
 
-    modifier allAmountsNotZero() {
+    modifier whenAllAmountsNotZero() {
         _;
     }
-    modifier allAmountsLessThanOrEqualToWithdrawableAmounts() {
+    modifier whenAllAmountsLessThanOrEqualToWithdrawableAmounts() {
         _;
     }
 
@@ -93,13 +93,13 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         address to
     )
         external
-        toNonZeroAddress
-        arraysEqual
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
-        allAmountsNotZero
-        allAmountsLessThanOrEqualToWithdrawableAmounts
+        whenToNonZeroAddress
+        whenArraysEqual
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
+        whenAllAmountsNotZero
+        whenAllAmountsLessThanOrEqualToWithdrawableAmounts
     {
         vm.assume(to != address(0));
         timeWarp = bound(timeWarp, 0 seconds, DEFAULT_TOTAL_DURATION);
@@ -151,13 +151,13 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         uint128 withdrawAmount
     )
         external
-        toNonZeroAddress
-        arraysEqual
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
-        allAmountsNotZero
-        allAmountsLessThanOrEqualToWithdrawableAmounts
+        whenToNonZeroAddress
+        whenArraysEqual
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
+        whenAllAmountsNotZero
+        whenAllAmountsLessThanOrEqualToWithdrawableAmounts
     {
         vm.assume(to != address(0));
         timeWarp = bound(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION - 1);
@@ -231,13 +231,13 @@ abstract contract WithdrawMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         Params memory params
     )
         external
-        toNonZeroAddress
-        arraysEqual
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
-        allAmountsNotZero
-        allAmountsLessThanOrEqualToWithdrawableAmounts
+        whenToNonZeroAddress
+        whenArraysEqual
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
+        whenAllAmountsNotZero
+        whenAllAmountsLessThanOrEqualToWithdrawableAmounts
     {
         vm.assume(params.to != address(0));
         params.timeWarp = bound(params.timeWarp, DEFAULT_TOTAL_DURATION, DEFAULT_TOTAL_DURATION * 2 - 1);

--- a/test/fuzz/lockup/shared/withdraw/withdraw.t.sol
+++ b/test/fuzz/lockup/shared/withdraw/withdraw.t.sol
@@ -19,27 +19,27 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         _;
     }
 
-    modifier callerAuthorized() {
+    modifier whenCallerAuthorized() {
         _;
     }
 
-    modifier toNonZeroAddress() {
+    modifier whenToNonZeroAddress() {
         _;
     }
 
-    modifier withdrawAmountNotZero() {
+    modifier whenWithdrawAmountNotZero() {
         _;
     }
 
-    modifier withdrawAmountLessThanOrEqualToWithdrawableAmount() {
+    modifier whenWithdrawAmountLessThanOrEqualToWithdrawableAmount() {
         _;
     }
 
@@ -48,11 +48,11 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         address to
     )
         external
-        streamActive
-        callerAuthorized
-        toNonZeroAddress
-        withdrawAmountNotZero
-        withdrawAmountLessThanOrEqualToWithdrawableAmount
+        whenStreamActive
+        whenCallerAuthorized
+        whenToNonZeroAddress
+        whenWithdrawAmountNotZero
+        whenWithdrawAmountLessThanOrEqualToWithdrawableAmount
     {
         vm.assume(to != address(0));
 
@@ -78,11 +78,11 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         address to
     )
         external
-        streamActive
-        callerAuthorized
-        toNonZeroAddress
-        withdrawAmountNotZero
-        withdrawAmountLessThanOrEqualToWithdrawableAmount
+        whenStreamActive
+        whenCallerAuthorized
+        whenToNonZeroAddress
+        whenWithdrawAmountNotZero
+        whenWithdrawAmountLessThanOrEqualToWithdrawableAmount
     {
         vm.assume(to != address(0));
 
@@ -109,13 +109,13 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
     }
 
-    modifier callerSender() {
+    modifier whenCallerSender() {
         // Make the sender the caller in this test suite.
         changePrank({ msgSender: users.sender });
         _;
     }
 
-    modifier currentTimeLessThanEndTime() {
+    modifier whenCurrentTimeLessThanEndTime() {
         // Warp to 2,600 seconds after the start time (26% of the default stream duration).
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
         _;
@@ -128,13 +128,13 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         uint128 withdrawAmount
     )
         external
-        streamActive
-        callerAuthorized
-        toNonZeroAddress
-        withdrawAmountNotZero
-        withdrawAmountLessThanOrEqualToWithdrawableAmount
-        callerSender
-        currentTimeLessThanEndTime
+        whenStreamActive
+        whenCallerAuthorized
+        whenToNonZeroAddress
+        whenWithdrawAmountNotZero
+        whenWithdrawAmountLessThanOrEqualToWithdrawableAmount
+        whenCallerSender
+        whenCurrentTimeLessThanEndTime
     {
         timeWarp = bound(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION - 1);
         vm.assume(to != address(0) && to.code.length == 0);
@@ -170,19 +170,19 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
     }
 
-    modifier recipientContract() {
+    modifier whenRecipientContract() {
         _;
     }
 
-    modifier recipientImplementsHook() {
+    modifier whenRecipientImplementsHook() {
         _;
     }
 
-    modifier recipientDoesNotRevert() {
+    modifier whenRecipientDoesNotRevert() {
         _;
     }
 
-    modifier noRecipientReentrancy() {
+    modifier whenNoRecipientReentrancy() {
         _;
     }
 
@@ -192,17 +192,17 @@ abstract contract Withdraw_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
         uint128 withdrawAmount
     )
         external
-        streamActive
-        callerAuthorized
-        toNonZeroAddress
-        withdrawAmountNotZero
-        withdrawAmountLessThanOrEqualToWithdrawableAmount
-        callerSender
-        currentTimeLessThanEndTime
-        recipientContract
-        recipientImplementsHook
-        recipientDoesNotRevert
-        noRecipientReentrancy
+        whenStreamActive
+        whenCallerAuthorized
+        whenToNonZeroAddress
+        whenWithdrawAmountNotZero
+        whenWithdrawAmountLessThanOrEqualToWithdrawableAmount
+        whenCallerSender
+        whenCurrentTimeLessThanEndTime
+        whenRecipientContract
+        whenRecipientImplementsHook
+        whenRecipientDoesNotRevert
+        whenNoRecipientReentrancy
     {
         timeWarp = bound(timeWarp, DEFAULT_CLIFF_DURATION, DEFAULT_TOTAL_DURATION * 2);
 

--- a/test/unit/adminable/transfer-admin/transferAdmin.t.sol
+++ b/test/unit/adminable/transfer-admin/transferAdmin.t.sol
@@ -18,12 +18,12 @@ contract TransferAdmin_Unit_Test is Adminable_Unit_Test {
         adminable.transferAdmin(eve);
     }
 
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         _;
     }
 
     /// @dev it should emit a {TransferAdmin} event and re-set the admin.
-    function test_TransferAdmin_SameAdmin() external callerAdmin {
+    function test_TransferAdmin_SameAdmin() external whenCallerAdmin {
         // Expect a {TransferAdmin} event to be emitted.
         vm.expectEmit();
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.admin });
@@ -37,12 +37,12 @@ contract TransferAdmin_Unit_Test is Adminable_Unit_Test {
         assertEq(actualAdmin, expectedAdmin, "admin");
     }
 
-    modifier notZeroAddress() {
+    modifier whenNotZeroAddress() {
         _;
     }
 
     /// @dev it should emit a {TransferAdmin} event and set the admin to the zero address.
-    function test_TransferAdmin_ZeroAddress() external callerAdmin {
+    function test_TransferAdmin_ZeroAddress() external whenCallerAdmin {
         // Expect a {TransferAdmin} event to be emitted.
         vm.expectEmit();
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: address(0) });
@@ -57,7 +57,7 @@ contract TransferAdmin_Unit_Test is Adminable_Unit_Test {
     }
 
     /// @dev it should emit a {TransferAdmin} event and set the new admin.
-    function test_TransferAdmin_NewAdmin() external callerAdmin notZeroAddress {
+    function test_TransferAdmin_NewAdmin() external whenCallerAdmin whenNotZeroAddress {
         // Expect a {TransferAdmin} event to be emitted.
         vm.expectEmit();
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.alice });

--- a/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
+++ b/test/unit/comptroller/get-protocol-fee/getProtocolFee.t.sol
@@ -22,13 +22,13 @@ contract GetProtocolFee_Unit_Test is Comptroller_Unit_Test {
         assertEq(actualProtocolFee, expectedProtocolFee, "protocolFee");
     }
 
-    modifier protocolFeeSet() {
+    modifier whenProtocolFeeSet() {
         comptroller.setProtocolFee({ asset: DEFAULT_ASSET, newProtocolFee: DEFAULT_PROTOCOL_FEE });
         _;
     }
 
     /// @dev it should return the correct protocol fee.
-    function test_GetProtocolFee() external protocolFeeSet {
+    function test_GetProtocolFee() external whenProtocolFeeSet {
         UD60x18 actualProtocolFee = comptroller.getProtocolFee(DEFAULT_ASSET);
         UD60x18 expectedProtocolFee = DEFAULT_PROTOCOL_FEE;
         assertEq(actualProtocolFee, expectedProtocolFee, "protocolFee");

--- a/test/unit/comptroller/set-flash-fee/setFlashFee.t.sol
+++ b/test/unit/comptroller/set-flash-fee/setFlashFee.t.sol
@@ -21,12 +21,12 @@ contract SetFlashFee_Unit_Test is Comptroller_Unit_Test {
     }
 
     /// @dev The admin is the default caller in the comptroller tests.
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         _;
     }
 
     /// @dev it should re-set the flash fee.
-    function test_SetFlashFee_SameFee() external callerAdmin {
+    function test_SetFlashFee_SameFee() external whenCallerAdmin {
         comptroller.setFlashFee({ newFlashFee: ZERO });
 
         UD60x18 actualFlashFee = comptroller.flashFee();
@@ -34,7 +34,7 @@ contract SetFlashFee_Unit_Test is Comptroller_Unit_Test {
         assertEq(actualFlashFee, expectedFlashFee, "flashFee");
     }
 
-    modifier newFee() {
+    modifier whenNewFee() {
         _;
     }
 

--- a/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
+++ b/test/unit/comptroller/set-protocol-fee/setProtocolFee.t.sol
@@ -21,24 +21,24 @@ contract SetProtocolFee_Unit_Test is Comptroller_Unit_Test {
     }
 
     /// @dev The admin is the default caller in the comptroller tests.
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         _;
     }
 
     /// @dev it should re-set the protocol fee.
-    function test_SetProtocolFee_SameFee() external callerAdmin {
+    function test_SetProtocolFee_SameFee() external whenCallerAdmin {
         comptroller.setProtocolFee({ asset: DEFAULT_ASSET, newProtocolFee: ZERO });
         UD60x18 actualProtocolFee = comptroller.getProtocolFee(DEFAULT_ASSET);
         UD60x18 expectedProtocolFee = ZERO;
         assertEq(actualProtocolFee, expectedProtocolFee, "protocolFee");
     }
 
-    modifier newFee() {
+    modifier whenNewFee() {
         _;
     }
 
     /// @dev it should set the new protocol fee and emit a {SetProtocolFee} event.
-    function test_SetProtocolFee() external callerAdmin newFee {
+    function test_SetProtocolFee() external whenCallerAdmin whenNewFee {
         UD60x18 newProtocolFee = DEFAULT_FLASH_FEE;
 
         // Expect a {SetProtocolFee} event to be emitted.

--- a/test/unit/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
+++ b/test/unit/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
@@ -21,12 +21,12 @@ contract ToggleFlashAsset_Unit_Test is Comptroller_Unit_Test {
     }
 
     /// @dev The admin is the default caller in the comptroller tests.
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         _;
     }
 
     /// @dev it should toggle the flash asset.
-    function test_ToggleFlashAsset_FlagNotEnabled() external callerAdmin {
+    function test_ToggleFlashAsset_FlagNotEnabled() external whenCallerAdmin {
         // Expect a {ToggleFlashAsset} event to be emitted.
         vm.expectEmit();
         emit ToggleFlashAsset({ admin: users.admin, asset: DEFAULT_ASSET, newFlag: true });
@@ -39,13 +39,13 @@ contract ToggleFlashAsset_Unit_Test is Comptroller_Unit_Test {
         assertTrue(isFlashLoanable, "isFlashLoanable");
     }
 
-    modifier flagEnabled() {
+    modifier whenFlagEnabled() {
         comptroller.toggleFlashAsset(DEFAULT_ASSET);
         _;
     }
 
     /// @dev it should toggle the flash asset and emit a {ToggleFlashAsset} event.
-    function test_ToggleFlashAsset() external callerAdmin flagEnabled {
+    function test_ToggleFlashAsset() external whenCallerAdmin whenFlagEnabled {
         // Expect a {ToggleFlashAsset} event to be emitted.
         vm.expectEmit();
         emit ToggleFlashAsset({ admin: users.admin, asset: DEFAULT_ASSET, newFlag: false });

--- a/test/unit/flash-loan/flash-fee/flashFee.t.sol
+++ b/test/unit/flash-loan/flash-fee/flashFee.t.sol
@@ -17,13 +17,13 @@ contract FlashFee_Unit_Test is FlashLoan_Unit_Test {
         flashLoan.flashFee({ asset: address(DEFAULT_ASSET), amount: 0 });
     }
 
-    modifier assetFlashLoanable() {
+    modifier whenAssetFlashLoanable() {
         comptroller.toggleFlashAsset(DEFAULT_ASSET);
         _;
     }
 
     /// @dev it should return the correct flash fee.
-    function test_FlashFee() external assetFlashLoanable {
+    function test_FlashFee() external whenAssetFlashLoanable {
         uint256 amount = 782.23e18;
         uint256 actualFlashFee = flashLoan.flashFee({ asset: address(DEFAULT_ASSET), amount: amount });
         uint256 expectedFlashFee = ud(amount).mul(DEFAULT_FLASH_FEE).intoUint256();

--- a/test/unit/flash-loan/flash-loan/flashLoan.t.sol
+++ b/test/unit/flash-loan/flash-loan/flashLoan.t.sol
@@ -37,12 +37,12 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
         });
     }
 
-    modifier amountNotTooHigh() {
+    modifier whenAmountNotTooHigh() {
         _;
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_AssetNotFlashLoanable() external whenNoDelegateCall amountNotTooHigh {
+    function test_RevertWhen_AssetNotFlashLoanable() external whenNoDelegateCall whenAmountNotTooHigh {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2FlashLoan_AssetNotFlashLoanable.selector, DEFAULT_ASSET)
         );
@@ -54,13 +54,18 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
         });
     }
 
-    modifier assetFlashLoanable() {
+    modifier whenAssetFlashLoanable() {
         comptroller.toggleFlashAsset(DEFAULT_ASSET);
         _;
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_CalculatedFeeTooHigh() external whenNoDelegateCall amountNotTooHigh assetFlashLoanable {
+    function test_RevertWhen_CalculatedFeeTooHigh()
+        external
+        whenNoDelegateCall
+        whenAmountNotTooHigh
+        whenAssetFlashLoanable
+    {
         // Set the comptroller flash fee so that the calculated fee ends up being greater than 2^128.
         comptroller.setFlashFee({ newFlashFee: ud(1.1e18) });
 
@@ -74,14 +79,14 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
         });
     }
 
-    modifier calculatedFeeNotTooHigh() {
+    modifier whenCalculatedFeeNotTooHigh() {
         _;
     }
 
     /// @dev it should revert.
     function test_RevertWhen_InsufficientAssetLiquidity(
         uint128 amount
-    ) external whenNoDelegateCall amountNotTooHigh assetFlashLoanable calculatedFeeNotTooHigh {
+    ) external whenNoDelegateCall whenAmountNotTooHigh whenAssetFlashLoanable whenCalculatedFeeNotTooHigh {
         vm.assume(amount != 0);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -99,7 +104,7 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
         });
     }
 
-    modifier sufficientAssetLiquidity() {
+    modifier whenSufficientAssetLiquidity() {
         _;
     }
 
@@ -107,10 +112,10 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
     function test_RevertWhen_BorrowFailed()
         external
         whenNoDelegateCall
-        amountNotTooHigh
-        assetFlashLoanable
-        calculatedFeeNotTooHigh
-        sufficientAssetLiquidity
+        whenAmountNotTooHigh
+        whenAssetFlashLoanable
+        whenCalculatedFeeNotTooHigh
+        whenSufficientAssetLiquidity
     {
         uint256 amount = 100e18;
         deal({ token: address(DEFAULT_ASSET), to: address(flashLoan), give: amount });
@@ -123,7 +128,7 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
         });
     }
 
-    modifier borrowDoesNotFail() {
+    modifier whenBorrowDoesNotFail() {
         _;
     }
 
@@ -131,11 +136,11 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
     function test_RevertWhen_Reentrancy()
         external
         whenNoDelegateCall
-        amountNotTooHigh
-        assetFlashLoanable
-        calculatedFeeNotTooHigh
-        sufficientAssetLiquidity
-        borrowDoesNotFail
+        whenAmountNotTooHigh
+        whenAssetFlashLoanable
+        whenCalculatedFeeNotTooHigh
+        whenSufficientAssetLiquidity
+        whenBorrowDoesNotFail
     {
         uint256 amount = 100e18;
         deal({ token: address(DEFAULT_ASSET), to: address(flashLoan), give: amount * 2 });
@@ -155,7 +160,7 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
         });
     }
 
-    modifier noReentrancy() {
+    modifier whenNoReentrancy() {
         _;
     }
 
@@ -164,12 +169,12 @@ contract FlashLoanFunction_Unit_Test is FlashLoan_Unit_Test {
     function test_FlashLoan()
         external
         whenNoDelegateCall
-        amountNotTooHigh
-        assetFlashLoanable
-        calculatedFeeNotTooHigh
-        sufficientAssetLiquidity
-        borrowDoesNotFail
-        noReentrancy
+        whenAmountNotTooHigh
+        whenAssetFlashLoanable
+        whenCalculatedFeeNotTooHigh
+        whenSufficientAssetLiquidity
+        whenBorrowDoesNotFail
+        whenNoReentrancy
     {
         uint128 amount = 8_755_001e18;
         bytes memory data = bytes("Hello World");

--- a/test/unit/flash-loan/max-flash-loan/maxFlashLoan.t.sol
+++ b/test/unit/flash-loan/max-flash-loan/maxFlashLoan.t.sol
@@ -16,13 +16,13 @@ contract MaxFlashLoan_Unit_Test is FlashLoan_Unit_Test {
         assertEq(actualAmount, expectedAmount, "maxFlashLoan amount");
     }
 
-    modifier assetFlashLoanable() {
+    modifier whenAssetFlashLoanable() {
         comptroller.toggleFlashAsset(DEFAULT_ASSET);
         _;
     }
 
     /// @dev it should return the correct flash fee.
-    function test_MaxFlashLoan() external assetFlashLoanable {
+    function test_MaxFlashLoan() external whenAssetFlashLoanable {
         uint256 dealAmount = 14_607_904e18;
         deal({ token: address(DEFAULT_ASSET), to: address(flashLoan), give: dealAmount });
         uint256 actualAmount = flashLoan.maxFlashLoan(address(DEFAULT_ASSET));

--- a/test/unit/lockup/linear/create-with-durations/createWithDurations.t.sol
+++ b/test/unit/lockup/linear/create-with-durations/createWithDurations.t.sol
@@ -58,7 +58,7 @@ contract CreateWithDurations_Linear_Unit_Test is Linear_Unit_Test {
         createDefaultStreamWithDurations(LockupLinear.Durations({ cliff: cliffDuration, total: totalDuration }));
     }
 
-    modifier cliffDurationCalculationDoesNotOverflow() {
+    modifier whenCliffDurationCalculationDoesNotOverflow() {
         _;
     }
 
@@ -66,7 +66,7 @@ contract CreateWithDurations_Linear_Unit_Test is Linear_Unit_Test {
     function test_RevertWhen_TotalDurationCalculationOverflows()
         external
         whenNoDelegateCall
-        cliffDurationCalculationDoesNotOverflow
+        whenCliffDurationCalculationDoesNotOverflow
     {
         uint40 startTime = getBlockTimestamp();
         LockupLinear.Durations memory durations = LockupLinear.Durations({
@@ -95,7 +95,7 @@ contract CreateWithDurations_Linear_Unit_Test is Linear_Unit_Test {
         createDefaultStreamWithDurations(durations);
     }
 
-    modifier totalDurationCalculationDoesNotOverflow() {
+    modifier whenTotalDurationCalculationDoesNotOverflow() {
         _;
     }
 
@@ -104,8 +104,8 @@ contract CreateWithDurations_Linear_Unit_Test is Linear_Unit_Test {
     function test_CreateWithDurations()
         external
         whenNoDelegateCall
-        cliffDurationCalculationDoesNotOverflow
-        totalDurationCalculationDoesNotOverflow
+        whenCliffDurationCalculationDoesNotOverflow
+        whenTotalDurationCalculationDoesNotOverflow
     {
         // Make the sender the funder of the stream.
         address funder = users.sender;

--- a/test/unit/lockup/linear/create-with-range/createWithRange.t.sol
+++ b/test/unit/lockup/linear/create-with-range/createWithRange.t.sol
@@ -37,7 +37,7 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
         createDefaultStreamWithRecipient({ recipient: address(0) });
     }
 
-    modifier recipientNonZeroAddress() {
+    modifier whenRecipientNonZeroAddress() {
         _;
     }
 
@@ -45,12 +45,12 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
     ///
     /// It is not possible to obtain a zero deposit amount from a non-zero total amount, because the
     /// `MAX_FEE` is hard coded to 10%.
-    function test_RevertWhen_DepositAmountZero() external whenNoDelegateCall recipientNonZeroAddress {
+    function test_RevertWhen_DepositAmountZero() external whenNoDelegateCall whenRecipientNonZeroAddress {
         vm.expectRevert(Errors.SablierV2Lockup_DepositAmountZero.selector);
         createDefaultStreamWithTotalAmount(0);
     }
 
-    modifier depositAmountNotZero() {
+    modifier whenDepositAmountNotZero() {
         _;
     }
 
@@ -58,8 +58,8 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
     function test_RevertWhen_StartTimeGreaterThanCliffTime()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
     {
         uint40 startTime = DEFAULT_CLIFF_TIME;
         uint40 cliffTime = DEFAULT_START_TIME;
@@ -73,16 +73,16 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
         createDefaultStreamWithRange(LockupLinear.Range({ start: startTime, cliff: cliffTime, end: DEFAULT_END_TIME }));
     }
 
-    modifier startTimeNotGreaterThanCliffTime() {
+    modifier whenStartTimeNotGreaterThanCliffTime() {
         _;
     }
 
     /// @dev it should revert.
     function test_RevertWhen_CliffTimeNotLessThanEndTime()
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
     {
         uint40 cliffTime = DEFAULT_END_TIME;
         uint40 endTime = DEFAULT_CLIFF_TIME;
@@ -96,17 +96,17 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
         createDefaultStreamWithRange(LockupLinear.Range({ start: DEFAULT_START_TIME, cliff: cliffTime, end: endTime }));
     }
 
-    modifier cliffTimeLessThanEndTime() {
+    modifier whenCliffTimeLessThanEndTime() {
         _;
     }
 
     /// @dev it should revert.
     function test_RevertWhen_ProtocolFeeTooHigh()
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
-        cliffTimeLessThanEndTime
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
     {
         UD60x18 protocolFee = DEFAULT_MAX_FEE.add(ud(1));
 
@@ -121,18 +121,18 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
         createDefaultStream();
     }
 
-    modifier protocolFeeNotTooHigh() {
+    modifier whenProtocolFeeNotTooHigh() {
         _;
     }
 
     /// @dev it should revert.
     function test_RevertWhen_BrokerFeeTooHigh()
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
-        cliffTimeLessThanEndTime
-        protocolFeeNotTooHigh
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
+        whenProtocolFeeNotTooHigh
     {
         UD60x18 brokerFee = DEFAULT_MAX_FEE.add(ud(1));
         vm.expectRevert(
@@ -141,44 +141,44 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
         createDefaultStreamWithBroker(Broker({ account: users.broker, fee: brokerFee }));
     }
 
-    modifier brokerFeeNotTooHigh() {
+    modifier whenBrokerFeeNotTooHigh() {
         _;
     }
 
     /// @dev it should revert.
     function test_RevertWhen_AssetNotContract()
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
-        cliffTimeLessThanEndTime
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
     {
         address nonContract = address(8128);
         vm.expectRevert("Address: call to non-contract");
         createDefaultStreamWithAsset(IERC20(nonContract));
     }
 
-    modifier assetContract() {
+    modifier whenAssetContract() {
         _;
     }
 
     /// @dev it should perform the ERC-20 transfers, create the stream, bump the next stream id, and mint the NFT.
     function test_CreateWithRange_AssetMissingReturnValue()
         external
-        recipientNonZeroAddress
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
-        cliffTimeLessThanEndTime
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
-        assetContract
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
+        whenAssetContract
     {
         test_createWithRange(address(nonCompliantAsset));
     }
 
-    modifier assetERC20Compliant() {
+    modifier whenAssetERC20Compliant() {
         _;
     }
 
@@ -192,13 +192,13 @@ contract CreateWithRange_Linear_Unit_Test is Linear_Unit_Test {
     /// - Emit a {CreateLockupLinearStream} event.
     function test_CreateWithRange()
         external
-        depositAmountNotZero
-        startTimeNotGreaterThanCliffTime
-        cliffTimeLessThanEndTime
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
-        assetContract
-        assetERC20Compliant
+        whenDepositAmountNotZero
+        whenStartTimeNotGreaterThanCliffTime
+        whenCliffTimeLessThanEndTime
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
+        whenAssetContract
+        whenAssetERC20Compliant
     {
         test_createWithRange(address(DEFAULT_ASSET));
     }

--- a/test/unit/lockup/linear/get-cliff-time/getCliffTime.t.sol
+++ b/test/unit/lockup/linear/get-cliff-time/getCliffTime.t.sol
@@ -12,12 +12,12 @@ contract GetCliffTime_Linear_Unit_Test is Linear_Unit_Test {
         assertEq(actualCliffTime, expectedCliffTime, "cliffTime");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct cliff time.
-    function test_GetCliffTime() external streamNonNull {
+    function test_GetCliffTime() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         uint40 actualCliffTime = linear.getCliffTime(streamId);
         uint40 expectedCliffTime = DEFAULT_CLIFF_TIME;

--- a/test/unit/lockup/linear/get-range/getRange.t.sol
+++ b/test/unit/lockup/linear/get-range/getRange.t.sol
@@ -14,12 +14,12 @@ contract GetRange_Linear_Unit_Test is Linear_Unit_Test {
         assertEq(actualRange, expectedRange);
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct range.
-    function test_GetRange() external streamNonNull {
+    function test_GetRange() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         LockupLinear.Range memory actualRange = linear.getRange(streamId);
         LockupLinear.Range memory expectedRange = DEFAULT_LINEAR_RANGE;

--- a/test/unit/lockup/linear/get-stream/getStream.t.sol
+++ b/test/unit/lockup/linear/get-stream/getStream.t.sol
@@ -14,12 +14,12 @@ contract GetStream_Linear_Unit_Test is Linear_Unit_Test {
         assertEq(actualStream, expectedStream);
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the stream.
-    function test_GetStream() external streamNonNull {
+    function test_GetStream() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         LockupLinear.Stream memory actualStream = linear.getStream(streamId);
         LockupLinear.Stream memory expectedStream = defaultStream;

--- a/test/unit/lockup/linear/streamed-amount-of/streamedAmountOf.t.sol
+++ b/test/unit/lockup/linear/streamed-amount-of/streamedAmountOf.t.sol
@@ -13,12 +13,12 @@ contract StreamedAmountOf_Linear_Unit_Test is Linear_Unit_Test {
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
     /// @dev it should return zero.
-    function test_StreamedAmountOf_StreamNull() external streamNotActive {
+    function test_StreamedAmountOf_StreamNull() external whenStreamNotActive {
         uint256 nullStreamId = 1729;
         uint128 actualStreamedAmount = linear.streamedAmountOf(nullStreamId);
         uint128 expectedStreamedAmount = 0;
@@ -26,7 +26,7 @@ contract StreamedAmountOf_Linear_Unit_Test is Linear_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_StreamedAmountOf_StreamCanceled() external streamNotActive {
+    function test_StreamedAmountOf_StreamCanceled() external whenStreamNotActive {
         lockup.cancel(defaultStreamId);
         uint256 actualStreamedAmount = linear.streamedAmountOf(defaultStreamId);
         uint256 expectedStreamedAmount = linear.getWithdrawnAmount(defaultStreamId);
@@ -34,7 +34,7 @@ contract StreamedAmountOf_Linear_Unit_Test is Linear_Unit_Test {
     }
 
     /// @dev it should return the withdrawn amount.
-    function test_StreamedAmountOf_StreamDepleted() external streamNotActive {
+    function test_StreamedAmountOf_StreamDepleted() external whenStreamNotActive {
         vm.warp({ timestamp: DEFAULT_END_TIME });
         uint128 withdrawAmount = DEFAULT_DEPOSIT_AMOUNT;
         lockup.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
@@ -43,23 +43,23 @@ contract StreamedAmountOf_Linear_Unit_Test is Linear_Unit_Test {
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         _;
     }
 
     /// @dev it should return zero.
-    function test_StreamedAmountOf_CliffTimeGreaterThanCurrentTime() external streamActive {
+    function test_StreamedAmountOf_CliffTimeGreaterThanCurrentTime() external whenStreamActive {
         uint128 actualStreamedAmount = linear.streamedAmountOf(defaultStreamId);
         uint128 expectedStreamedAmount = 0;
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier cliffTimeLessThanOrEqualToCurrentTime() {
+    modifier whenCliffTimeLessThanOrEqualToCurrentTime() {
         _;
     }
 
     /// @dev it should return the correct streamed amount.
-    function test_StreamedAmountOf() external streamActive cliffTimeLessThanOrEqualToCurrentTime {
+    function test_StreamedAmountOf() external whenStreamActive whenCliffTimeLessThanOrEqualToCurrentTime {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
 

--- a/test/unit/lockup/linear/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/test/unit/lockup/linear/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -13,12 +13,12 @@ contract WithdrawableAmountOf_Linear_Unit_Test is Linear_Unit_Test {
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StreamNull() external streamNotActive {
+    function test_WithdrawableAmountOf_StreamNull() external whenStreamNotActive {
         uint256 nullStreamId = 1729;
         uint128 actualWithdrawableAmount = linear.withdrawableAmountOf(nullStreamId);
         uint128 expectedWithdrawableAmount = 0;
@@ -26,7 +26,7 @@ contract WithdrawableAmountOf_Linear_Unit_Test is Linear_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StreamCanceled() external streamNotActive {
+    function test_WithdrawableAmountOf_StreamCanceled() external whenStreamNotActive {
         lockup.cancel(defaultStreamId);
         uint256 actualWithdrawableAmount = linear.withdrawableAmountOf(defaultStreamId);
         uint256 expectedWithdrawableAmount = 0;
@@ -34,7 +34,7 @@ contract WithdrawableAmountOf_Linear_Unit_Test is Linear_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StreamDepleted() external streamNotActive {
+    function test_WithdrawableAmountOf_StreamDepleted() external whenStreamNotActive {
         vm.warp({ timestamp: DEFAULT_END_TIME });
         lockup.withdrawMax({ streamId: defaultStreamId, to: users.recipient });
         uint256 actualWithdrawableAmount = linear.withdrawableAmountOf(defaultStreamId);
@@ -42,34 +42,34 @@ contract WithdrawableAmountOf_Linear_Unit_Test is Linear_Unit_Test {
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_CliffTimeGreaterThanCurrentTime() external streamActive {
+    function test_WithdrawableAmountOf_CliffTimeGreaterThanCurrentTime() external whenStreamActive {
         uint128 actualWithdrawableAmount = linear.withdrawableAmountOf(defaultStreamId);
         uint128 expectedWithdrawableAmount = 0;
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
-    modifier cliffTimeLessThanOrEqualToCurrentTime() {
+    modifier whenCliffTimeLessThanOrEqualToCurrentTime() {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
         _;
     }
 
     /// @dev it should return the correct withdrawable amount.
-    function test_WithdrawableAmountOf_NoWithdrawals() external streamActive cliffTimeLessThanOrEqualToCurrentTime {
+    function test_WithdrawableAmountOf_NoWithdrawals() external whenStreamActive whenCliffTimeLessThanOrEqualToCurrentTime {
         uint128 actualWithdrawableAmount = linear.withdrawableAmountOf(defaultStreamId);
         uint128 expectedWithdrawableAmount = DEFAULT_WITHDRAW_AMOUNT;
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
     /// @dev it should return the correct withdrawable amount.
-    function test_WithdrawableAmountOf_WithWithdrawals() external streamActive cliffTimeLessThanOrEqualToCurrentTime {
+    function test_WithdrawableAmountOf_WithWithdrawals() external whenStreamActive whenCliffTimeLessThanOrEqualToCurrentTime {
         // Make the withdrawal.
         linear.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: DEFAULT_WITHDRAW_AMOUNT });
 

--- a/test/unit/lockup/pro/create-with-deltas/createWithDeltas.t.sol
+++ b/test/unit/lockup/pro/create-with-deltas/createWithDeltas.t.sol
@@ -27,12 +27,12 @@ contract CreateWithDeltas_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithDeltas(segments);
     }
 
-    modifier loopCalculationsDoNotOverflowBlockGasLimit() {
+    modifier whenLoopCalculationsDoNotOverflowBlockGasLimit() {
         _;
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_DeltasZero() external loopCalculationsDoNotOverflowBlockGasLimit {
+    function test_RevertWhen_DeltasZero() external whenLoopCalculationsDoNotOverflowBlockGasLimit {
         uint40 startTime = getBlockTimestamp();
         LockupPro.SegmentWithDelta[] memory segments = defaultParams.createWithDeltas.segments;
         segments[1].delta = 0;
@@ -48,15 +48,15 @@ contract CreateWithDeltas_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithDeltas(segments);
     }
 
-    modifier deltasNotZero() {
+    modifier whenDeltasNotZero() {
         _;
     }
 
     /// @dev it should revert.
     function test_RevertWhen_MilestonesCalculationsOverflows_StartTimeNotLessThanFirstSegmentMilestone()
         external
-        loopCalculationsDoNotOverflowBlockGasLimit
-        deltasNotZero
+        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenDeltasNotZero
     {
         unchecked {
             uint40 startTime = getBlockTimestamp();
@@ -77,8 +77,8 @@ contract CreateWithDeltas_Pro_Unit_Test is Pro_Unit_Test {
     /// @dev it should revert.
     function test_RevertWhen_MilestonesCalculationsOverflows_SegmentMilestonesNotOrdered()
         external
-        loopCalculationsDoNotOverflowBlockGasLimit
-        deltasNotZero
+        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenDeltasNotZero
     {
         unchecked {
             uint40 startTime = getBlockTimestamp();
@@ -113,7 +113,7 @@ contract CreateWithDeltas_Pro_Unit_Test is Pro_Unit_Test {
         }
     }
 
-    modifier milestonesCalculationsDoNotOverflow() {
+    modifier whenMilestonesCalculationsDoNotOverflow() {
         _;
     }
 
@@ -121,9 +121,9 @@ contract CreateWithDeltas_Pro_Unit_Test is Pro_Unit_Test {
     /// record the protocol fee, and emit a {CreateLockupProStream} event.
     function test_CreateWithDeltas()
         external
-        loopCalculationsDoNotOverflowBlockGasLimit
-        deltasNotZero
-        milestonesCalculationsDoNotOverflow
+        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenDeltasNotZero
+        whenMilestonesCalculationsDoNotOverflow
     {
         // Make the sender the funder of the stream.
         address funder = users.sender;

--- a/test/unit/lockup/pro/create-with-milestones/createWithMilestones.t.sol
+++ b/test/unit/lockup/pro/create-with-milestones/createWithMilestones.t.sol
@@ -42,7 +42,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithRecipient(recipient);
     }
 
-    modifier recipientNonZeroAddress() {
+    modifier whenRecipientNonZeroAddress() {
         _;
     }
 
@@ -50,13 +50,13 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     ///
     /// It is not possible (in principle) to obtain a zero deposit amount from a non-zero total amount,
     /// because we hard-code the `MAX_FEE` to 10%.
-    function test_RevertWhen_DepositAmountZero() external whenNoDelegateCall recipientNonZeroAddress {
+    function test_RevertWhen_DepositAmountZero() external whenNoDelegateCall whenRecipientNonZeroAddress {
         vm.expectRevert(Errors.SablierV2Lockup_DepositAmountZero.selector);
         uint128 totalAmount = 0;
         createDefaultStreamWithTotalAmount(totalAmount);
     }
 
-    modifier depositAmountNotZero() {
+    modifier whenDepositAmountNotZero() {
         _;
     }
 
@@ -64,15 +64,15 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_SegmentCountZero()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
     {
         LockupPro.Segment[] memory segments;
         vm.expectRevert(Errors.SablierV2LockupPro_SegmentCountZero.selector);
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier segmentCountNotZero() {
+    modifier whenSegmentCountNotZero() {
         _;
     }
 
@@ -80,9 +80,9 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_SegmentCountTooHigh()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
     {
         uint256 segmentCount = DEFAULT_MAX_SEGMENT_COUNT + 1;
         LockupPro.Segment[] memory segments = new LockupPro.Segment[](segmentCount);
@@ -90,7 +90,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier segmentCountNotTooHigh() {
+    modifier whenSegmentCountNotTooHigh() {
         _;
     }
 
@@ -98,10 +98,10 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_SegmentAmountsSumOverflows()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
     {
         LockupPro.Segment[] memory segments = defaultParams.createWithMilestones.segments;
         segments[0].amount = UINT128_MAX;
@@ -110,7 +110,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier segmentAmountsSumDoesNotOverflow() {
+    modifier whenSegmentAmountsSumDoesNotOverflow() {
         _;
     }
 
@@ -118,11 +118,11 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_StartTimeGreaterThanFirstSegmentMilestone()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
     {
         // Change the milestone of the first segment.
         LockupPro.Segment[] memory segments = defaultParams.createWithMilestones.segments;
@@ -145,11 +145,11 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_StartTimeEqualToFirstSegmentMilestone()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
     {
         // Change the milestone of the first segment.
         LockupPro.Segment[] memory segments = defaultParams.createWithMilestones.segments;
@@ -168,7 +168,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier startTimeLessThanFirstSegmentMilestone() {
+    modifier whenStartTimeLessThanFirstSegmentMilestone() {
         _;
     }
 
@@ -176,12 +176,12 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_SegmentMilestonesNotOrdered()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        startTimeLessThanFirstSegmentMilestone
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenStartTimeLessThanFirstSegmentMilestone
     {
         // Swap the segment milestones.
         LockupPro.Segment[] memory segments = defaultParams.createWithMilestones.segments;
@@ -202,7 +202,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithSegments(segments);
     }
 
-    modifier segmentMilestonesOrdered() {
+    modifier whenSegmentMilestonesOrdered() {
         _;
     }
 
@@ -210,13 +210,13 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_DepositAmountNotEqualToSegmentAmountsSum()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        startTimeLessThanFirstSegmentMilestone
-        segmentMilestonesOrdered
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenSegmentMilestonesOrdered
     {
         // Disable both the protocol and the broker fee so that they don't interfere with the calculations.
         changePrank({ msgSender: users.admin });
@@ -243,7 +243,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         pro.createWithMilestones(params);
     }
 
-    modifier depositAmountEqualToSegmentAmountsSum() {
+    modifier whenDepositAmountEqualToSegmentAmountsSum() {
         _;
     }
 
@@ -251,15 +251,15 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_ProtocolFeeTooHigh()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        startTimeLessThanFirstSegmentMilestone
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
     {
         UD60x18 protocolFee = DEFAULT_MAX_FEE.add(ud(1));
 
@@ -274,7 +274,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStream();
     }
 
-    modifier protocolFeeNotTooHigh() {
+    modifier whenProtocolFeeNotTooHigh() {
         _;
     }
 
@@ -282,16 +282,16 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_BrokerFeeTooHigh()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        startTimeLessThanFirstSegmentMilestone
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
-        protocolFeeNotTooHigh
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
+        whenProtocolFeeNotTooHigh
     {
         UD60x18 brokerFee = DEFAULT_MAX_FEE.add(ud(1));
         vm.expectRevert(
@@ -300,7 +300,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithBroker(Broker({ account: users.broker, fee: brokerFee }));
     }
 
-    modifier brokerFeeNotTooHigh() {
+    modifier whenBrokerFeeNotTooHigh() {
         _;
     }
 
@@ -308,17 +308,17 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_RevertWhen_AssetNotContract()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        startTimeLessThanFirstSegmentMilestone
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
     {
         address nonContract = address(8128);
 
@@ -333,7 +333,7 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
         createDefaultStreamWithAsset(IERC20(nonContract));
     }
 
-    modifier assetContract() {
+    modifier whenAssetContract() {
         _;
     }
 
@@ -341,23 +341,23 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_CreateWithMilestones_AssetMissingReturnValue()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        startTimeLessThanFirstSegmentMilestone
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
-        assetContract
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
+        whenAssetContract
     {
         test_createWithMilestones(address(nonCompliantAsset));
     }
 
-    modifier assetERC20Compliant() {
+    modifier whenAssetERC20Compliant() {
         _;
     }
 
@@ -366,19 +366,19 @@ contract CreateWithMilestones_Pro_Unit_Test is Pro_Unit_Test {
     function test_CreateWithMilestones()
         external
         whenNoDelegateCall
-        recipientNonZeroAddress
-        depositAmountNotZero
-        segmentCountNotZero
-        segmentCountNotTooHigh
-        segmentAmountsSumDoesNotOverflow
-        startTimeLessThanFirstSegmentMilestone
-        segmentMilestonesOrdered
-        startTimeLessThanFirstSegmentMilestone
-        depositAmountEqualToSegmentAmountsSum
-        protocolFeeNotTooHigh
-        brokerFeeNotTooHigh
-        assetContract
-        assetERC20Compliant
+        whenRecipientNonZeroAddress
+        whenDepositAmountNotZero
+        whenSegmentCountNotZero
+        whenSegmentCountNotTooHigh
+        whenSegmentAmountsSumDoesNotOverflow
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenSegmentMilestonesOrdered
+        whenStartTimeLessThanFirstSegmentMilestone
+        whenDepositAmountEqualToSegmentAmountsSum
+        whenProtocolFeeNotTooHigh
+        whenBrokerFeeNotTooHigh
+        whenAssetContract
+        whenAssetERC20Compliant
     {
         test_createWithMilestones(address(DEFAULT_ASSET));
     }

--- a/test/unit/lockup/pro/get-range/getRange.t.sol
+++ b/test/unit/lockup/pro/get-range/getRange.t.sol
@@ -14,12 +14,12 @@ contract GetRange_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualRange, expectedRange);
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct range.
-    function test_GetRange() external streamNonNull {
+    function test_GetRange() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         LockupPro.Range memory actualRange = pro.getRange(streamId);
         LockupPro.Range memory expectedRange = DEFAULT_PRO_RANGE;

--- a/test/unit/lockup/pro/get-segments/getSegments.t.sol
+++ b/test/unit/lockup/pro/get-segments/getSegments.t.sol
@@ -14,12 +14,12 @@ contract GetSegments_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualSegments, expectedSegments, "segments");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct segments.
-    function test_GetSegments() external streamNonNull {
+    function test_GetSegments() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         LockupPro.Segment[] memory actualSegments = pro.getSegments(streamId);
         LockupPro.Segment[] memory expectedSegments = DEFAULT_SEGMENTS;

--- a/test/unit/lockup/pro/get-stream/getStream.t.sol
+++ b/test/unit/lockup/pro/get-stream/getStream.t.sol
@@ -14,12 +14,12 @@ contract GetStream_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualStream, expectedStream);
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the stream.
-    function test_GetStream() external streamNonNull {
+    function test_GetStream() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         LockupPro.Stream memory actualStream = pro.getStream(streamId);
         LockupPro.Stream memory expectedStream = defaultStream;

--- a/test/unit/lockup/pro/streamed-amount-of/streamedAmountOf.t.sol
+++ b/test/unit/lockup/pro/streamed-amount-of/streamedAmountOf.t.sol
@@ -15,12 +15,12 @@ contract StreamedAmountOf_Pro_Unit_Test is Pro_Unit_Test {
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
     /// @dev it should return zero.
-    function test_StreamedAmountOf_StreamNull() external streamNotActive {
+    function test_StreamedAmountOf_StreamNull() external whenStreamNotActive {
         uint256 nullStreamId = 1729;
         uint128 actualStreamedAmount = pro.streamedAmountOf(nullStreamId);
         uint128 expectedStreamedAmount = 0;
@@ -28,7 +28,7 @@ contract StreamedAmountOf_Pro_Unit_Test is Pro_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_StreamedAmountOf_StreamCanceled() external streamNotActive {
+    function test_StreamedAmountOf_StreamCanceled() external whenStreamNotActive {
         lockup.cancel(defaultStreamId);
         uint256 actualStreamedAmount = pro.streamedAmountOf(defaultStreamId);
         uint256 expectedStreamedAmount = pro.getWithdrawnAmount(defaultStreamId);
@@ -36,7 +36,7 @@ contract StreamedAmountOf_Pro_Unit_Test is Pro_Unit_Test {
     }
 
     /// @dev it should return the withdrawn amount.
-    function test_StreamedAmountOf_StreamDepleted() external streamNotActive {
+    function test_StreamedAmountOf_StreamDepleted() external whenStreamNotActive {
         vm.warp({ timestamp: DEFAULT_END_TIME });
         uint128 withdrawAmount = DEFAULT_DEPOSIT_AMOUNT;
         lockup.withdraw({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
@@ -45,12 +45,12 @@ contract StreamedAmountOf_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         _;
     }
 
     /// @dev it should return zero.
-    function test_StreamedAmountOf_StartTimeGreaterThanCurrentTime() external streamActive {
+    function test_StreamedAmountOf_StartTimeGreaterThanCurrentTime() external whenStreamActive {
         vm.warp({ timestamp: 0 });
         uint128 actualStreamedAmount = pro.streamedAmountOf(defaultStreamId);
         uint128 expectedStreamedAmount = 0;
@@ -58,19 +58,19 @@ contract StreamedAmountOf_Pro_Unit_Test is Pro_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_StreamedAmountOf_StartTimeEqualToCurrentTime() external streamActive {
+    function test_StreamedAmountOf_StartTimeEqualToCurrentTime() external whenStreamActive {
         vm.warp({ timestamp: DEFAULT_START_TIME });
         uint128 actualStreamedAmount = pro.streamedAmountOf(defaultStreamId);
         uint128 expectedStreamedAmount = 0;
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier startTimeLessThanCurrentTime() {
+    modifier whenStartTimeLessThanCurrentTime() {
         _;
     }
 
     /// @dev it should return the correct streamed amount.
-    function test_StreamedAmountOf_OneSegment() external streamActive startTimeLessThanCurrentTime {
+    function test_StreamedAmountOf_OneSegment() external whenStreamActive whenStartTimeLessThanCurrentTime {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + 2_000 seconds });
 
@@ -91,16 +91,16 @@ contract StreamedAmountOf_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier multipleSegments() {
+    modifier whenMultipleSegments() {
         _;
     }
 
     /// @dev it should return the correct streamed amount.
     function test_StreamedAmountOf_CurrentMilestone1st()
         external
-        streamActive
-        multipleSegments
-        startTimeLessThanCurrentTime
+        whenStreamActive
+        whenMultipleSegments
+        whenStartTimeLessThanCurrentTime
     {
         // Warp one second into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + 1 });
@@ -111,17 +111,17 @@ contract StreamedAmountOf_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualStreamedAmount, expectedStreamedAmount, "streamedAmount");
     }
 
-    modifier currentMilestoneNot1st() {
+    modifier whenCurrentMilestoneNot1st() {
         _;
     }
 
     /// @dev it should return the correct streamed amount.
     function test_StreamedAmountOf_CurrentMilestoneNot1st()
         external
-        streamActive
-        startTimeLessThanCurrentTime
-        multipleSegments
-        currentMilestoneNot1st
+        whenStreamActive
+        whenStartTimeLessThanCurrentTime
+        whenMultipleSegments
+        whenCurrentMilestoneNot1st
     {
         // Warp into the future. 750 seconds is ~10% of the way in the second segment.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_CLIFF_DURATION + 750 seconds });

--- a/test/unit/lockup/pro/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/test/unit/lockup/pro/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -13,12 +13,12 @@ contract WithdrawableAmountOf_Pro_Unit_Test is Pro_Unit_Test {
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StreamNull() external streamNotActive {
+    function test_WithdrawableAmountOf_StreamNull() external whenStreamNotActive {
         uint256 nullStreamId = 1729;
         uint128 actualWithdrawableAmount = pro.withdrawableAmountOf(nullStreamId);
         uint128 expectedWithdrawableAmount = 0;
@@ -26,7 +26,7 @@ contract WithdrawableAmountOf_Pro_Unit_Test is Pro_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StreamCanceled() external streamNotActive {
+    function test_WithdrawableAmountOf_StreamCanceled() external whenStreamNotActive {
         lockup.cancel(defaultStreamId);
         uint256 actualWithdrawableAmount = linear.withdrawableAmountOf(defaultStreamId);
         uint256 expectedWithdrawableAmount = 0;
@@ -34,7 +34,7 @@ contract WithdrawableAmountOf_Pro_Unit_Test is Pro_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StreamDepleted() external streamNotActive {
+    function test_WithdrawableAmountOf_StreamDepleted() external whenStreamNotActive {
         vm.warp({ timestamp: DEFAULT_END_TIME });
         lockup.withdrawMax({ streamId: defaultStreamId, to: users.recipient });
         uint256 actualWithdrawableAmount = linear.withdrawableAmountOf(defaultStreamId);
@@ -42,14 +42,14 @@ contract WithdrawableAmountOf_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StartTimeGreaterThanCurrentTime() external streamActive {
+    function test_WithdrawableAmountOf_StartTimeGreaterThanCurrentTime() external whenStreamActive {
         vm.warp({ timestamp: 0 });
         uint128 actualWithdrawableAmount = pro.withdrawableAmountOf(defaultStreamId);
         uint128 expectedWithdrawableAmount = 0;
@@ -57,19 +57,19 @@ contract WithdrawableAmountOf_Pro_Unit_Test is Pro_Unit_Test {
     }
 
     /// @dev it should return zero.
-    function test_WithdrawableAmountOf_StartTimeEqualToCurrentTime() external streamActive {
+    function test_WithdrawableAmountOf_StartTimeEqualToCurrentTime() external whenStreamActive {
         vm.warp({ timestamp: DEFAULT_START_TIME });
         uint128 actualWithdrawableAmount = pro.withdrawableAmountOf(defaultStreamId);
         uint128 expectedWithdrawableAmount = 0;
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
-    modifier startTimeLessThanCurrentTime() {
+    modifier whenStartTimeLessThanCurrentTime() {
         _;
     }
 
     /// @dev it should return the correct withdrawable amount.
-    function test_WithdrawableAmountOf_WithoutWithdrawals() external streamActive startTimeLessThanCurrentTime {
+    function test_WithdrawableAmountOf_WithoutWithdrawals() external whenStreamActive whenStartTimeLessThanCurrentTime {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_CLIFF_DURATION + 3_750 seconds });
 
@@ -80,12 +80,17 @@ contract WithdrawableAmountOf_Pro_Unit_Test is Pro_Unit_Test {
         assertEq(actualWithdrawableAmount, expectedWithdrawableAmount, "withdrawableAmount");
     }
 
-    modifier withWithdrawals() {
+    modifier whenWithWithdrawals() {
         _;
     }
 
     /// @dev it should return the correct withdrawable amount.
-    function test_WithdrawableAmountOf() external streamActive startTimeLessThanCurrentTime withWithdrawals {
+    function test_WithdrawableAmountOf()
+        external
+        whenStreamActive
+        whenStartTimeLessThanCurrentTime
+        whenWithWithdrawals
+    {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_CLIFF_DURATION + 3_750 seconds });
 

--- a/test/unit/lockup/shared/burn/burn.t.sol
+++ b/test/unit/lockup/shared/burn/burn.t.sol
@@ -45,7 +45,7 @@ abstract contract Burn_Unit_Test is Unit_Test, Lockup_Shared_Test {
     }
 
     /// @dev This modifier runs the test twice, once with a canceled stream, and once with a depleted stream.
-    modifier streamCanceledOrDepleted() {
+    modifier whenStreamCanceledOrDepleted() {
         lockup.cancel(streamId);
         _;
         changePrank({ msgSender: users.recipient });
@@ -56,7 +56,7 @@ abstract contract Burn_Unit_Test is Unit_Test, Lockup_Shared_Test {
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_CallerUnauthorized() external whenNoDelegateCall streamCanceledOrDepleted {
+    function test_RevertWhen_CallerUnauthorized() external whenNoDelegateCall whenStreamCanceledOrDepleted {
         // Make Eve the caller in the rest of this test.
         changePrank({ msgSender: users.eve });
 
@@ -65,12 +65,12 @@ abstract contract Burn_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.burn(streamId);
     }
 
-    modifier callerAuthorized() {
+    modifier whenCallerAuthorized() {
         _;
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_NFTNonExistent() external whenNoDelegateCall streamCanceledOrDepleted callerAuthorized {
+    function test_RevertWhen_NFTNonExistent() external whenNoDelegateCall whenStreamCanceledOrDepleted whenCallerAuthorized {
         // Burn the NFT so that it no longer exists.
         lockup.burn(streamId);
 
@@ -79,7 +79,7 @@ abstract contract Burn_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.burn(streamId);
     }
 
-    modifier nftExistent() {
+    modifier whenNFTExistent() {
         _;
     }
 
@@ -87,9 +87,9 @@ abstract contract Burn_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_Burn_CallerApprovedOperator()
         external
         whenNoDelegateCall
-        streamCanceledOrDepleted
-        callerAuthorized
-        nftExistent
+        whenStreamCanceledOrDepleted
+        whenCallerAuthorized
+        whenNFTExistent
     {
         // Approve the operator to handle the stream.
         lockup.approve({ to: users.operator, tokenId: streamId });
@@ -110,9 +110,9 @@ abstract contract Burn_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_Burn_CallerNFTOwner()
         external
         whenNoDelegateCall
-        streamCanceledOrDepleted
-        callerAuthorized
-        nftExistent
+        whenStreamCanceledOrDepleted
+        whenCallerAuthorized
+        whenNFTExistent
     {
         lockup.burn(streamId);
         address actualNFTOwner = lockup.getRecipient(streamId);

--- a/test/unit/lockup/shared/cancel-multiple/cancelMultiple.t.sol
+++ b/test/unit/lockup/shared/cancel-multiple/cancelMultiple.t.sol
@@ -39,19 +39,19 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.cancelMultiple(streamIds);
     }
 
-    modifier arrayCountNotZero() {
+    modifier whenArrayCountNotZero() {
         _;
     }
 
     /// @dev it should do nothing.
-    function test_RevertWhen_OnlyNullStreams() external whenNoDelegateCall arrayCountNotZero {
+    function test_RevertWhen_OnlyNullStreams() external whenNoDelegateCall whenArrayCountNotZero {
         uint256 nullStreamId = 1729;
         uint256[] memory streamIds = Solarray.uint256s(nullStreamId);
         lockup.cancelMultiple(streamIds);
     }
 
     /// @dev it should ignore the null streams and cancel the non-null ones.
-    function test_RevertWhen_SomeNullStreams() external whenNoDelegateCall arrayCountNotZero {
+    function test_RevertWhen_SomeNullStreams() external whenNoDelegateCall whenArrayCountNotZero {
         uint256 nullStreamId = 1729;
         uint256[] memory streamIds = Solarray.uint256s(defaultStreamIds[0], nullStreamId);
         lockup.cancelMultiple(streamIds);
@@ -60,7 +60,7 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualStatus, expectedStatus);
     }
 
-    modifier onlyNonNullStreams() {
+    modifier whenOnlyNonNullStreams() {
         _;
     }
 
@@ -68,8 +68,8 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_AllStreamsNonCancelable()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
     {
         // Create the non-cancelable stream.
         uint256 nonCancelableStreamId = createDefaultStreamNonCancelable();
@@ -82,8 +82,8 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_SomeStreamsNonCancelable()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
     {
         // Create the non-cancelable stream.
         uint256 nonCancelableStreamId = createDefaultStreamNonCancelable();
@@ -101,7 +101,7 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(status, Lockup.Status.ACTIVE, "status1");
     }
 
-    modifier allStreamsCancelable() {
+    modifier whenAllStreamsCancelable() {
         _;
     }
 
@@ -109,9 +109,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedAllStreams_MaliciousThirdParty()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
-        allStreamsCancelable
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
     {
         // Make Eve the caller in this test.
         changePrank({ msgSender: users.eve });
@@ -127,9 +127,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedAllStreams_ApprovedOperator()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
-        allStreamsCancelable
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
     {
         // Approve the operator for all streams.
         lockup.setApprovalForAll({ operator: users.operator, _approved: true });
@@ -148,9 +148,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedAllStreams_FormerRecipient()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
-        allStreamsCancelable
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
     {
         // Transfer the streams to Alice.
         lockup.transferFrom({ from: users.recipient, to: users.alice, tokenId: defaultStreamIds[0] });
@@ -167,9 +167,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedSomeStreams_MaliciousThirdParty()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
-        allStreamsCancelable
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
     {
         changePrank({ msgSender: users.eve });
 
@@ -188,9 +188,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedSomeStreams_ApprovedOperator()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
-        allStreamsCancelable
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
     {
         // Approve the operator to handle the first stream.
         lockup.approve({ to: users.operator, tokenId: defaultStreamIds[0] });
@@ -209,9 +209,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedSomeStreams_FormerRecipient()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
-        allStreamsCancelable
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
     {
         // Transfer the first stream to Eve.
         lockup.transferFrom({ from: users.recipient, to: users.alice, tokenId: defaultStreamIds[0] });
@@ -223,7 +223,7 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.cancelMultiple(defaultStreamIds);
     }
 
-    modifier callerAuthorizedAllStreams() {
+    modifier whenCallerAuthorizedAllStreams() {
         _;
     }
 
@@ -232,10 +232,10 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_CancelMultiple_Sender()
         external
         whenNoDelegateCall
-        arrayCountNotZero
-        onlyNonNullStreams
-        allStreamsCancelable
-        callerAuthorizedAllStreams
+        whenArrayCountNotZero
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
+        whenCallerAuthorizedAllStreams
     {
         changePrank({ msgSender: users.sender });
         test_CancelMultiple();
@@ -246,9 +246,9 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_CancelMultiple_Recipient()
         external
         whenNoDelegateCall
-        onlyNonNullStreams
-        allStreamsCancelable
-        callerAuthorizedAllStreams
+        whenOnlyNonNullStreams
+        whenAllStreamsCancelable
+        whenCallerAuthorizedAllStreams
     {
         test_CancelMultiple();
     }

--- a/test/unit/lockup/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
+++ b/test/unit/lockup/shared/claim-protocol-revenues/claimProtocolRevenues.t.sol
@@ -23,19 +23,19 @@ abstract contract ClaimProtocolRevenues_Unit_Test is Unit_Test, Lockup_Shared_Te
         config.claimProtocolRevenues(DEFAULT_ASSET);
     }
 
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         // Make the admin the caller in the rest of this test suite.
         changePrank({ msgSender: users.admin });
         _;
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_ProtocolRevenuesZero() external callerAdmin {
+    function test_RevertWhen_ProtocolRevenuesZero() external whenCallerAdmin {
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2Config_NoProtocolRevenues.selector, DEFAULT_ASSET));
         config.claimProtocolRevenues(DEFAULT_ASSET);
     }
 
-    modifier protocolRevenuesNotZero() {
+    modifier whenProtocolRevenuesNotZero() {
         // Create the default stream, which will accrue revenues for the protocol.
         changePrank({ msgSender: users.sender });
         createDefaultStream();
@@ -45,7 +45,7 @@ abstract contract ClaimProtocolRevenues_Unit_Test is Unit_Test, Lockup_Shared_Te
 
     /// @dev it should claim the protocol revenues, update the protocol revenues, and emit a {ClaimProtocolRevenues}
     /// event.
-    function test_ClaimProtocolRevenues() external callerAdmin protocolRevenuesNotZero {
+    function test_ClaimProtocolRevenues() external whenCallerAdmin whenProtocolRevenuesNotZero {
         // Expect the protocol revenues to be claimed.
         uint128 protocolRevenues = DEFAULT_PROTOCOL_FEE_AMOUNT;
         expectTransferCall({ to: users.admin, amount: protocolRevenues });

--- a/test/unit/lockup/shared/get-asset/getAsset.t.sol
+++ b/test/unit/lockup/shared/get-asset/getAsset.t.sol
@@ -17,12 +17,12 @@ abstract contract GetAsset_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualAsset, expectedAsset, "asset");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct address of the ERC-20 asset.
-    function test_GetAsset() external streamNonNull {
+    function test_GetAsset() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         IERC20 actualAsset = lockup.getAsset(streamId);
         IERC20 expectedAsset = DEFAULT_ASSET;

--- a/test/unit/lockup/shared/get-deposit-amount/getDepositAmount.t.sol
+++ b/test/unit/lockup/shared/get-deposit-amount/getDepositAmount.t.sol
@@ -15,12 +15,12 @@ abstract contract GetDepositAmount_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualDepositAmount, expectedDepositAmount, "depositAmount");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct deposit amount.
-    function test_GetDepositAmount() external streamNonNull {
+    function test_GetDepositAmount() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         uint128 actualDepositAmount = lockup.getDepositAmount(streamId);
         uint128 expectedDepositAmount = DEFAULT_DEPOSIT_AMOUNT;

--- a/test/unit/lockup/shared/get-end-time/getEndTime.t.sol
+++ b/test/unit/lockup/shared/get-end-time/getEndTime.t.sol
@@ -15,12 +15,12 @@ abstract contract GetEndTime_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualEndTime, expectedEndTime, "endTime");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct end time.
-    function test_GetEndTime() external streamNonNull {
+    function test_GetEndTime() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         uint40 actualEndTime = lockup.getEndTime(streamId);
         uint40 expectedEndTime = DEFAULT_END_TIME;

--- a/test/unit/lockup/shared/get-recipient/getRecipient.t.sol
+++ b/test/unit/lockup/shared/get-recipient/getRecipient.t.sol
@@ -15,12 +15,12 @@ abstract contract GetRecipient_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualRecipient, expectedRecipient, "recipient");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct recipient.
-    function test_GetRecipient() external streamNonNull {
+    function test_GetRecipient() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         address actualRecipient = lockup.getRecipient(streamId);
         address expectedRecipient = users.recipient;

--- a/test/unit/lockup/shared/get-sender/getSender.t.sol
+++ b/test/unit/lockup/shared/get-sender/getSender.t.sol
@@ -15,12 +15,12 @@ abstract contract GetSender_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualSender, expectedSender, "sender");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct sender.
-    function test_GetSender() external streamNonNull {
+    function test_GetSender() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         address actualSender = lockup.getSender(streamId);
         address expectedSender = users.sender;

--- a/test/unit/lockup/shared/get-start-time/getStartTime.t.sol
+++ b/test/unit/lockup/shared/get-start-time/getStartTime.t.sol
@@ -15,12 +15,12 @@ abstract contract GetStartTime_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualStartTime, expectedStartTime, "startTime");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the correct start time.
-    function test_GetStartTime() external streamNonNull {
+    function test_GetStartTime() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         uint40 actualStartTime = lockup.getStartTime(streamId);
         uint40 expectedStartTime = DEFAULT_START_TIME;

--- a/test/unit/lockup/shared/get-status/getStatus.t.sol
+++ b/test/unit/lockup/shared/get-status/getStatus.t.sol
@@ -19,38 +19,38 @@ abstract contract GetStatus_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualStatus, expectedStatus);
     }
 
-    modifier streamCreated() {
+    modifier whenStreamCreated() {
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return the ACTIVE status.
-    function test_GetStatus_Active() external streamCreated {
+    function test_GetStatus_Active() external whenStreamCreated {
         Lockup.Status actualStatus = lockup.getStatus(defaultStreamId);
         Lockup.Status expectedStatus = Lockup.Status.ACTIVE;
         assertEq(actualStatus, expectedStatus);
     }
 
-    modifier streamCanceled() {
+    modifier whenStreamCanceled() {
         lockup.cancel(defaultStreamId);
         _;
     }
 
     /// @dev it should return the CANCELED status.
-    function test_GetStatus_Canceled() external streamCreated streamCanceled {
+    function test_GetStatus_Canceled() external whenStreamCreated whenStreamCanceled {
         Lockup.Status actualStatus = lockup.getStatus(defaultStreamId);
         Lockup.Status expectedStatus = Lockup.Status.CANCELED;
         assertEq(actualStatus, expectedStatus);
     }
 
-    modifier streamDepleted() {
+    modifier whenStreamDepleted() {
         vm.warp({ timestamp: DEFAULT_END_TIME });
         lockup.withdrawMax({ streamId: defaultStreamId, to: users.recipient });
         _;
     }
 
     /// @dev it should return the DEPLETED status.
-    function test_GetStatus_Depleted() external streamCreated streamDepleted {
+    function test_GetStatus_Depleted() external whenStreamCreated whenStreamDepleted {
         Lockup.Status actualStatus = lockup.getStatus(defaultStreamId);
         Lockup.Status expectedStatus = Lockup.Status.DEPLETED;
         assertEq(actualStatus, expectedStatus);

--- a/test/unit/lockup/shared/get-withdrawn-amount/getWithdrawnAmount.t.sol
+++ b/test/unit/lockup/shared/get-withdrawn-amount/getWithdrawnAmount.t.sol
@@ -20,14 +20,14 @@ abstract contract GetWithdrawnAmount_Unit_Test is Unit_Test, Lockup_Shared_Test 
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         // Create the default stream.
         defaultStreamId = createDefaultStream();
         _;
     }
 
     /// @dev it should return zero.
-    function test_GetWithdrawnAmount_NoWithdrawals() external streamNonNull {
+    function test_GetWithdrawnAmount_NoWithdrawals() external whenStreamNonNull {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
 
@@ -38,7 +38,7 @@ abstract contract GetWithdrawnAmount_Unit_Test is Unit_Test, Lockup_Shared_Test 
     }
 
     /// @dev it should return the correct withdrawn amount.
-    function test_GetWithdrawnAmount_WithWithdrawals() external streamNonNull {
+    function test_GetWithdrawnAmount_WithWithdrawals() external whenStreamNonNull {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
 

--- a/test/unit/lockup/shared/is-cancelable/isCancelable.t.sol
+++ b/test/unit/lockup/shared/is-cancelable/isCancelable.t.sol
@@ -12,48 +12,48 @@ abstract contract IsCancelable_Unit_Test is Unit_Test, Lockup_Shared_Test {
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
     /// @dev it should return false.
-    function test_IsCancelable_StreamNull() external streamNotActive {
+    function test_IsCancelable_StreamNull() external whenStreamNotActive {
         uint256 nullStreamId = 1729;
         bool isCancelable = lockup.isCancelable(nullStreamId);
         assertFalse(isCancelable, "isCancelable");
     }
 
     /// @dev it should return false.
-    function test_IsCancelable_StreamCanceled() external streamNotActive {
+    function test_IsCancelable_StreamCanceled() external whenStreamNotActive {
         lockup.cancel(defaultStreamId);
         bool isCancelable = lockup.isCancelable(defaultStreamId);
         assertFalse(isCancelable, "isCancelable");
     }
 
     /// @dev it should return false.
-    function test_IsCancelable_StreamDepleted() external streamNotActive {
+    function test_IsCancelable_StreamDepleted() external whenStreamNotActive {
         vm.warp({ timestamp: DEFAULT_END_TIME });
         lockup.withdrawMax({ streamId: defaultStreamId, to: users.recipient });
         bool isCancelable = lockup.isCancelable(defaultStreamId);
         assertFalse(isCancelable, "isCancelable");
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         _;
     }
 
     /// @dev it should return true.
-    function test_IsCancelable_CancelableStream() external streamActive {
+    function test_IsCancelable_CancelableStream() external whenStreamActive {
         bool isCancelable = lockup.isCancelable(defaultStreamId);
         assertTrue(isCancelable, "isCancelable");
     }
 
-    modifier nonCancelableStream() {
+    modifier whenStreamIsNonCancelable() {
         _;
     }
 
     /// @dev it should return false.
-    function test_IsCancelable() external streamActive nonCancelableStream {
+    function test_IsCancelable() external whenStreamActive whenStreamIsNonCancelable {
         uint256 streamId = createDefaultStreamNonCancelable();
         bool isCancelable = lockup.isCancelable(streamId);
         assertFalse(isCancelable, "isCancelable");

--- a/test/unit/lockup/shared/protocol-revenues/protocolRevenues.t.sol
+++ b/test/unit/lockup/shared/protocol-revenues/protocolRevenues.t.sol
@@ -14,7 +14,7 @@ abstract contract ProtocolRevenues_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualProtocolRevenues, expectedProtocolRevenues, "protocolRevenues");
     }
 
-    modifier protocolRevenuesNotZero() {
+    modifier whenProtocolRevenuesNotZero() {
         // Create the default stream, which will accrue revenues for the protocol.
         changePrank({ msgSender: users.sender });
         createDefaultStream();
@@ -23,7 +23,7 @@ abstract contract ProtocolRevenues_Unit_Test is Unit_Test, Lockup_Shared_Test {
     }
 
     /// @dev it should return the correct protocol revenues.
-    function test_ProtocolRevenues() external protocolRevenuesNotZero {
+    function test_ProtocolRevenues() external whenProtocolRevenuesNotZero {
         uint128 actualProtocolRevenues = config.protocolRevenues(DEFAULT_ASSET);
         uint128 expectedProtocolRevenues = DEFAULT_PROTOCOL_FEE_AMOUNT;
         assertEq(actualProtocolRevenues, expectedProtocolRevenues, "protocolRevenues");

--- a/test/unit/lockup/shared/returnable-amount-of/returnableAmountOf.t.sol
+++ b/test/unit/lockup/shared/returnable-amount-of/returnableAmountOf.t.sol
@@ -12,12 +12,12 @@ abstract contract ReturnableAmountOf_Unit_Test is Unit_Test, Lockup_Shared_Test 
         defaultStreamId = createDefaultStream();
     }
 
-    modifier streamNotActive() {
+    modifier whenStreamNotActive() {
         _;
     }
 
     /// @dev it should return zero.
-    function test_ReturnableAmountOf_StreamNull() external streamNotActive {
+    function test_ReturnableAmountOf_StreamNull() external whenStreamNotActive {
         uint256 nullStreamId = 1729;
         uint256 actualReturnableAmount = lockup.returnableAmountOf(nullStreamId);
         uint256 expectedReturnableAmount = 0;
@@ -25,7 +25,7 @@ abstract contract ReturnableAmountOf_Unit_Test is Unit_Test, Lockup_Shared_Test 
     }
 
     /// @dev it should return zero.
-    function test_ReturnableAmountOf_StreamCanceled() external streamNotActive {
+    function test_ReturnableAmountOf_StreamCanceled() external whenStreamNotActive {
         lockup.cancel(defaultStreamId);
         uint256 actualReturnableAmount = lockup.returnableAmountOf(defaultStreamId);
         uint256 expectedReturnableAmount = 0;
@@ -33,7 +33,7 @@ abstract contract ReturnableAmountOf_Unit_Test is Unit_Test, Lockup_Shared_Test 
     }
 
     /// @dev it should return zero.
-    function test_ReturnableAmountOf_StreamDepleted() external streamNotActive {
+    function test_ReturnableAmountOf_StreamDepleted() external whenStreamNotActive {
         vm.warp({ timestamp: DEFAULT_END_TIME });
         lockup.withdrawMax({ streamId: defaultStreamId, to: users.recipient });
         uint256 actualReturnableAmount = lockup.returnableAmountOf(defaultStreamId);
@@ -41,12 +41,12 @@ abstract contract ReturnableAmountOf_Unit_Test is Unit_Test, Lockup_Shared_Test 
         assertEq(actualReturnableAmount, expectedReturnableAmount, "returnableAmount");
     }
 
-    modifier streamActive() {
+    modifier whenStreamActive() {
         _;
     }
 
     /// @dev it should return the correct returnable amount.
-    function test_ReturnableAmountOf() external streamActive {
+    function test_ReturnableAmountOf() external whenStreamActive {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
 

--- a/test/unit/lockup/shared/set-comptroller/setComptroller.t.sol
+++ b/test/unit/lockup/shared/set-comptroller/setComptroller.t.sol
@@ -23,14 +23,14 @@ abstract contract SetComptroller_Unit_Test is Unit_Test, Lockup_Shared_Test {
         config.setComptroller(ISablierV2Comptroller(users.eve));
     }
 
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         // Make the admin the caller in the rest of this test suite.
         changePrank({ msgSender: users.admin });
         _;
     }
 
     /// @dev it should re-set the comptroller and emit a {SetComptroller} event.
-    function test_SetComptroller_SameComptroller() external callerAdmin {
+    function test_SetComptroller_SameComptroller() external whenCallerAdmin {
         // Expect a {SetComptroller} event to be emitted.
         vm.expectEmit();
         emit SetComptroller(users.admin, comptroller, comptroller);
@@ -45,7 +45,7 @@ abstract contract SetComptroller_Unit_Test is Unit_Test, Lockup_Shared_Test {
     }
 
     /// @dev it should set the new comptroller and emit a {SetComptroller} event.
-    function test_SetComptroller_NewComptroller() external callerAdmin {
+    function test_SetComptroller_NewComptroller() external whenCallerAdmin {
         // Deploy the new comptroller.
         ISablierV2Comptroller newComptroller = new SablierV2Comptroller({ initialAdmin: users.admin });
 

--- a/test/unit/lockup/shared/set-nft-descriptor/setNFTDescriptor.t.sol
+++ b/test/unit/lockup/shared/set-nft-descriptor/setNFTDescriptor.t.sol
@@ -23,14 +23,14 @@ abstract contract SetNFTDescriptor_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.setNFTDescriptor(ISablierV2NFTDescriptor(users.eve));
     }
 
-    modifier callerAdmin() {
+    modifier whenCallerAdmin() {
         // Make the admin the caller in the rest of this test suite.
         changePrank({ msgSender: users.admin });
         _;
     }
 
     /// @dev it should re-set the NFT descriptor and emit a {SetNFTDescriptor} event.
-    function test_SetNFTDescriptor_SameNFTDescriptor() external callerAdmin {
+    function test_SetNFTDescriptor_SameNFTDescriptor() external whenCallerAdmin {
         // Expect a {SetNFTDescriptor} event to be emitted.
         vm.expectEmit();
         emit SetNFTDescriptor(users.admin, nftDescriptor, nftDescriptor);
@@ -44,7 +44,7 @@ abstract contract SetNFTDescriptor_Unit_Test is Unit_Test, Lockup_Shared_Test {
     }
 
     /// @dev it should set the new NFT descriptor and emit a {SetNFTDescriptor} event.
-    function test_SetNFTDescriptor_NewNFTDescriptor() external callerAdmin {
+    function test_SetNFTDescriptor_NewNFTDescriptor() external whenCallerAdmin {
         // Deploy the new NFT descriptor.
         ISablierV2NFTDescriptor newNFTDescriptor = new SablierV2NFTDescriptor();
 

--- a/test/unit/lockup/shared/token-uri/tokenURI.t.sol
+++ b/test/unit/lockup/shared/token-uri/tokenURI.t.sol
@@ -15,12 +15,12 @@ abstract contract TokenURI_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualTokenURI, expectedTokenURI, "tokenURI");
     }
 
-    modifier streamNonNull() {
+    modifier whenStreamNonNull() {
         _;
     }
 
     /// @dev it should return the descriptor URI.
-    function test_TokenURI() external streamNonNull {
+    function test_TokenURI() external whenStreamNonNull {
         uint256 streamId = createDefaultStream();
         string memory actualTokenURI = lockup.tokenURI({ tokenId: streamId });
         string memory expectedTokenURI = string.concat("This is the NFT descriptor for ", lockup.symbol());

--- a/test/unit/lockup/shared/withdraw-max/withdrawMax.t.sol
+++ b/test/unit/lockup/shared/withdraw-max/withdrawMax.t.sol
@@ -36,13 +36,13 @@ abstract contract WithdrawMax_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualNFTowner, expectedNFTOwner, "NFT owner");
     }
 
-    modifier currentTimeLessThanEndTime() {
+    modifier whenCurrentTimeLessThanEndTime() {
         _;
     }
 
     /// @dev it should make the max withdrawal, update the withdrawn amount, and emit a {WithdrawFromLockupStream}
     /// event.
-    function test_WithdrawMax() external currentTimeLessThanEndTime {
+    function test_WithdrawMax() external whenCurrentTimeLessThanEndTime {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
 

--- a/test/unit/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
+++ b/test/unit/lockup/shared/withdraw-multiple/withdrawMultiple.t.sol
@@ -47,12 +47,12 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.withdrawMultiple({ streamIds: defaultStreamIds, to: address(0), amounts: defaultAmounts });
     }
 
-    modifier toNonZeroAddress() {
+    modifier whenToNonZeroAddress() {
         _;
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_ArrayCountsNotEqual() external whenNoDelegateCall toNonZeroAddress {
+    function test_RevertWhen_ArrayCountsNotEqual() external whenNoDelegateCall whenToNonZeroAddress {
         uint256[] memory streamIds = new uint256[](2);
         uint128[] memory amounts = new uint128[](1);
         vm.expectRevert(
@@ -65,18 +65,18 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.withdrawMultiple({ streamIds: streamIds, to: users.recipient, amounts: amounts });
     }
 
-    modifier arrayCountsNotEqual() {
+    modifier whenArrayCountsNotEqual() {
         _;
     }
 
     /// @dev it should do nothing.
-    function test_RevertWhen_ArrayCountsZero() external whenNoDelegateCall toNonZeroAddress {
+    function test_RevertWhen_ArrayCountsZero() external whenNoDelegateCall whenToNonZeroAddress {
         uint256[] memory streamIds = new uint256[](0);
         uint128[] memory amounts = new uint128[](0);
         lockup.withdrawMultiple({ streamIds: streamIds, to: users.recipient, amounts: amounts });
     }
 
-    modifier arrayCountsNotZero() {
+    modifier whenArrayCountsNotZero() {
         _;
     }
 
@@ -84,9 +84,9 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_OnlyNullStreams()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
     {
         uint256 nullStreamId = 1729;
         uint256[] memory nonStreamIds = Solarray.uint256s(nullStreamId);
@@ -98,9 +98,9 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_SomeNullStreams()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
     {
         uint256 nullStreamId = 1729;
         uint256[] memory streamIds = Solarray.uint256s(nullStreamId, defaultStreamIds[0]);
@@ -115,7 +115,7 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualWithdrawnAmount, expectedWithdrawnAmount, "withdrawnAmount");
     }
 
-    modifier onlyNonNullStreams() {
+    modifier whenOnlyNonNullStreams() {
         _;
     }
 
@@ -123,10 +123,10 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedAllStreams_MaliciousThirdParty()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
     {
         // Make Eve the caller in this test.
         changePrank({ msgSender: users.eve });
@@ -142,10 +142,10 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedAllStreams_Sender()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
     {
         // Make the sender the caller in this test.
         changePrank({ msgSender: users.sender });
@@ -161,10 +161,10 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedAllStreams_FormerRecipient()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
     {
         // Transfer all streams to Alice.
         lockup.transferFrom({ from: users.recipient, to: users.alice, tokenId: defaultStreamIds[0] });
@@ -181,10 +181,10 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedSomeStreams_MaliciousThirdParty()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
     {
         // Create a stream with Eve as the recipient.
         uint256 eveStreamId = createDefaultStreamWithRecipient(users.eve);
@@ -207,10 +207,10 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_CallerUnauthorizedSomeStreams_FormerRecipient()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
     {
         // Transfer one of the streams to Eve.
         lockup.transferFrom({ from: users.recipient, to: users.alice, tokenId: defaultStreamIds[0] });
@@ -225,7 +225,7 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.withdrawMultiple({ streamIds: defaultStreamIds, to: users.recipient, amounts: defaultAmounts });
     }
 
-    modifier callerAuthorizedAllStreams() {
+    modifier whenCallerAuthorizedAllStreams() {
         _;
     }
 
@@ -233,11 +233,11 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_WithdrawMultiple_CallerApprovedOperator()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
     {
         // Approve the operator for all streams.
         lockup.setApprovalForAll(users.operator, true);
@@ -264,7 +264,7 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         assertEq(actualWithdrawnAmount1, expectedWithdrawnAmount, "withdrawnAmount1");
     }
 
-    modifier callerRecipient() {
+    modifier whenCallerRecipient() {
         _;
     }
 
@@ -272,12 +272,12 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_SomeAmountsZero()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
     {
         // Warp to 2,600 seconds after the start time (26% of the default stream duration).
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
@@ -290,7 +290,7 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.withdrawMultiple({ streamIds: defaultStreamIds, to: users.recipient, amounts: amounts });
     }
 
-    modifier allAmountsNotZero() {
+    modifier whenAllAmountsNotZero() {
         _;
     }
 
@@ -298,13 +298,13 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_RevertWhen_SomeAmountsGreaterThanWithdrawableAmount()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
-        allAmountsNotZero
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
+        whenAllAmountsNotZero
     {
         // Warp to 2,600 seconds after the start time (26% of the default stream duration).
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
@@ -323,7 +323,7 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         lockup.withdrawMultiple({ streamIds: defaultStreamIds, to: users.recipient, amounts: amounts });
     }
 
-    modifier allAmountsLessThanOrEqualToWithdrawableAmounts() {
+    modifier whenAllAmountsLessThanOrEqualToWithdrawableAmounts() {
         _;
     }
 
@@ -332,14 +332,14 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_WithdrawMultiple_AllStreamsEnded()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
-        allAmountsNotZero
-        allAmountsLessThanOrEqualToWithdrawableAmounts
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
+        whenAllAmountsNotZero
+        whenAllAmountsLessThanOrEqualToWithdrawableAmounts
     {
         // Warp into the future, past the end time.
         vm.warp({ timestamp: DEFAULT_END_TIME });
@@ -388,14 +388,14 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_WithdrawMultiple_AllStreamsOngoing()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
-        allAmountsNotZero
-        allAmountsLessThanOrEqualToWithdrawableAmounts
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
+        whenAllAmountsNotZero
+        whenAllAmountsLessThanOrEqualToWithdrawableAmounts
     {
         // Warp into the future, before the end time of the streams.
         vm.warp({ timestamp: DEFAULT_START_TIME + DEFAULT_TIME_WARP });
@@ -461,14 +461,14 @@ abstract contract WithdrawMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
     function test_WithdrawMultiple_SomeStreamsEndedSomeStreamsOngoing()
         external
         whenNoDelegateCall
-        toNonZeroAddress
-        arrayCountsNotEqual
-        arrayCountsNotZero
-        onlyNonNullStreams
-        callerAuthorizedAllStreams
-        callerRecipient
-        allAmountsNotZero
-        allAmountsLessThanOrEqualToWithdrawableAmounts
+        whenToNonZeroAddress
+        whenArrayCountsNotEqual
+        whenArrayCountsNotZero
+        whenOnlyNonNullStreams
+        whenCallerAuthorizedAllStreams
+        whenCallerRecipient
+        whenAllAmountsNotZero
+        whenAllAmountsLessThanOrEqualToWithdrawableAmounts
     {
         // Warp into the future.
         vm.warp({ timestamp: DEFAULT_END_TIME });


### PR DESCRIPTION
This PR adds the `when` prefix to all modifiers (except for the `useAdmin` modifier in the invariant tests).