### PR TITLE
refactor: transfer recipients assets first in "_cancel"

### DIFF
--- a/src/SablierV2LockupDynamic.sol
+++ b/src/SablierV2LockupDynamic.sol
@@ -418,11 +418,6 @@ contract SablierV2LockupDynamic is
         // Effects: mark the stream as canceled.
         _streams[streamId].status = Lockup.Status.CANCELED;
 
-        // Interactions: return the assets to the sender, if any.
-        if (senderAmount > 0) {
-            stream.asset.safeTransfer({ to: sender, value: senderAmount });
-        }
-
         if (recipientAmount > 0) {
             // Effects: add the recipient's amount to the withdrawn amount.
             unchecked {
@@ -431,6 +426,11 @@ contract SablierV2LockupDynamic is
 
             // Interactions: withdraw the tokens to the recipient.
             stream.asset.safeTransfer({ to: recipient, value: recipientAmount });
+        }
+
+        // Interactions: return the assets to the sender, if any.
+        if (senderAmount > 0) {
+            stream.asset.safeTransfer({ to: sender, value: senderAmount });
         }
 
         // Interactions: if the `msg.sender` is the sender and the recipient is a contract, try to invoke the cancel
@@ -467,7 +467,8 @@ contract SablierV2LockupDynamic is
         internal
         returns (uint256 streamId)
     {
-        // Safe Interactions: query the protocol fee. This is safe because it's a known Sablier contract.
+        // Safe Interactions: query the protocol fee. This is safe because it's a known Sablier contract that does
+        // not call other unknown contracts.
         UD60x18 protocolFee = comptroller.getProtocolFee(params.asset);
 
         // Checks: check the fees and calculate the fee amounts.

--- a/src/SablierV2LockupLinear.sol
+++ b/src/SablierV2LockupLinear.sol
@@ -256,10 +256,8 @@ contract SablierV2LockupLinear is
         range.start = uint40(block.timestamp);
 
         // Calculate the cliff time and the end time. It is safe to use unchecked arithmetic because
-        // {_createWithRange}
-        // {will nonetheless check that the end time is greater than or equal to the cliff time, and also that the
-        // cliff
-        // time is greater than or equal to the start time.
+        // {_createWithRange} will nonetheless check that the end time is greater than or equal to the cliff time,
+        // and also that the cliff time is greater than or equal to the start time.
         unchecked {
             range.cliff = range.start + params.durations.cliff;
             range.end = range.start + params.durations.total;
@@ -340,11 +338,6 @@ contract SablierV2LockupLinear is
         // Effects: mark the stream as canceled.
         _streams[streamId].status = Lockup.Status.CANCELED;
 
-        // Interactions: return the assets to the sender, if any.
-        if (senderAmount > 0) {
-            stream.asset.safeTransfer({ to: sender, value: senderAmount });
-        }
-
         if (recipientAmount > 0) {
             // Effects: add the recipient's amount to the withdrawn amount.
             unchecked {
@@ -353,6 +346,11 @@ contract SablierV2LockupLinear is
 
             // Interactions: withdraw the tokens to the recipient.
             stream.asset.safeTransfer({ to: recipient, value: recipientAmount });
+        }
+
+        // Interactions: return the assets to the sender, if any.
+        if (senderAmount > 0) {
+            stream.asset.safeTransfer({ to: sender, value: senderAmount });
         }
 
         // Interactions: if the `msg.sender` is the sender and the recipient is a contract, try to invoke the cancel
@@ -386,7 +384,8 @@ contract SablierV2LockupLinear is
 
     /// @dev See the documentation for the public functions that call this internal function.
     function _createWithRange(LockupLinear.CreateWithRange memory params) internal returns (uint256 streamId) {
-        // Safe Interactions: query the protocol fee. This is safe because it's a known Sablier contract.
+        // Safe Interactions: query the protocol fee. This is safe because it's a known Sablier contract that does
+        // not call other unknown contracts.
         UD60x18 protocolFee = comptroller.getProtocolFee(params.asset);
 
         // Checks: check that neither fee is greater than `MAX_FEE`, and then calculate the fee amounts and the

--- a/test/fuzz/lockup/shared/cancel-multiple/cancelMultiple.t.sol
+++ b/test/fuzz/lockup/shared/cancel-multiple/cancelMultiple.t.sol
@@ -9,7 +9,7 @@ import { Lockup } from "src/types/DataTypes.sol";
 import { Fuzz_Test } from "../../../Fuzz.t.sol";
 import { Lockup_Shared_Test } from "../../../../shared/lockup/Lockup.t.sol";
 
-abstract contract CancelMultiple_Unit_Test is Fuzz_Test, Lockup_Shared_Test {
+abstract contract CancelMultiple_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
     uint256[] internal defaultStreamIds;
 
     function setUp() public virtual override(Fuzz_Test, Lockup_Shared_Test) {

--- a/test/fuzz/lockup/shared/cancel/cancel.t.sol
+++ b/test/fuzz/lockup/shared/cancel/cancel.t.sol
@@ -95,16 +95,16 @@ abstract contract Cancel_Fuzz_Test is Fuzz_Test, Lockup_Shared_Test {
             lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
         }
 
-        // Expect the ERC-20 assets to be returned to the sender, if not zero.
-        uint128 senderAmount = lockup.returnableAmountOf(streamId);
-        if (senderAmount > 0) {
-            expectTransferCall({ to: users.sender, amount: senderAmount });
-        }
-
         // Expect the ERC-20 assets to be withdrawn to the recipient, if not zero.
         uint128 recipientAmount = lockup.withdrawableAmountOf(streamId);
         if (recipientAmount > 0) {
             expectTransferCall({ to: address(goodRecipient), amount: recipientAmount });
+        }
+
+        // Expect the ERC-20 assets to be returned to the sender, if not zero.
+        uint128 senderAmount = lockup.returnableAmountOf(streamId);
+        if (senderAmount > 0) {
+            expectTransferCall({ to: users.sender, amount: senderAmount });
         }
 
         // Expect a {CancelLockupStream} event to be emitted.

--- a/test/unit/lockup/shared/cancel-multiple/cancelMultiple.t.sol
+++ b/test/unit/lockup/shared/cancel-multiple/cancelMultiple.t.sol
@@ -278,7 +278,7 @@ abstract contract CancelMultiple_Unit_Test is Unit_Test, Lockup_Shared_Test {
         uint128 recipientAmount1 = lockup.withdrawableAmountOf(streamIds[1]);
         expectTransferCall({ to: users.recipient, amount: recipientAmount1 });
 
-        // Expect some ERC-20 assets to be returned to the sender only for the ongoing stream.
+        // Expect some ERC-20 assets to be returned to the sender (only for the ongoing stream).
         uint128 senderAmount0 = DEFAULT_DEPOSIT_AMOUNT - recipientAmount0;
         expectTransferCall({ to: users.sender, amount: senderAmount0 });
         uint128 senderAmount1 = DEFAULT_DEPOSIT_AMOUNT - recipientAmount1;

--- a/test/unit/lockup/shared/cancel/cancel.t.sol
+++ b/test/unit/lockup/shared/cancel/cancel.t.sol
@@ -288,13 +288,13 @@ abstract contract Cancel_Unit_Test is Unit_Test, Lockup_Shared_Test {
         // Create the stream.
         uint256 streamId = createDefaultStreamWithRecipient(address(goodRecipient));
 
-        // Expect the ERC-20 assets to be returned to the sender, if not zero.
-        uint128 senderAmount = lockup.returnableAmountOf(streamId);
-        expectTransferCall({ to: users.sender, amount: senderAmount });
-
         // Expect the ERC-20 assets to be withdrawn to the recipient, if not zero.
         uint128 recipientAmount = lockup.withdrawableAmountOf(streamId);
         expectTransferCall({ to: address(goodRecipient), amount: recipientAmount });
+
+        // Expect the ERC-20 assets to be returned to the sender, if not zero.
+        uint128 senderAmount = lockup.returnableAmountOf(streamId);
+        expectTransferCall({ to: users.sender, amount: senderAmount });
 
         // Expect a call to the recipient hook.
         vm.expectCall(
@@ -473,13 +473,13 @@ abstract contract Cancel_Unit_Test is Unit_Test, Lockup_Shared_Test {
         // Create the stream.
         uint256 streamId = createDefaultStreamWithSender(address(goodSender));
 
-        // Expect the ERC-20 assets to be returned to the sender.
-        uint128 senderAmount = lockup.returnableAmountOf(streamId);
-        expectTransferCall({ to: address(goodSender), amount: senderAmount });
-
         // Expect the ERC-20 assets to be withdrawn to the recipient.
         uint128 recipientAmount = lockup.withdrawableAmountOf(streamId);
         expectTransferCall({ to: users.recipient, amount: recipientAmount });
+
+        // Expect the ERC-20 assets to be returned to the sender.
+        uint128 senderAmount = lockup.returnableAmountOf(streamId);
+        expectTransferCall({ to: address(goodSender), amount: senderAmount });
 
         // Expect a call to the sender hook.
         vm.expectCall(


### PR DESCRIPTION
I managed to get Slither to work. Running it over the linear and the dynamic contracts has unsurfaced the following reentrancy issue in the `_cancel` function:

```text
INFO:Detectors:
Reentrancy in SablierV2LockupLinear._cancel(uint256) (src/SablierV2LockupLinear.sol#326-385):
	External calls:
	- stream.asset.safeTransfer(sender,senderAmount) (src/SablierV2LockupLinear.sol#345)
	State variables written after the call(s):
	- _streams[streamId].amounts.withdrawn += recipientAmount (src/SablierV2LockupLinear.sol#351)
	SablierV2LockupLinear._streams (src/SablierV2LockupLinear.sol#53) can be used in cross function reentrancies:
	- SablierV2LockupLinear._cancel(uint256) (src/SablierV2LockupLinear.sol#326-385)
	- SablierV2LockupLinear._createWithRange(LockupLinear.CreateWithRange) (src/SablierV2LockupLinear.sol#388-456)
	- SablierV2LockupLinear._isCallerStreamSender(uint256) (src/SablierV2LockupLinear.sol#312-314)
	- SablierV2LockupLinear._renounce(uint256) (src/SablierV2LockupLinear.sol#459-472)
	- SablierV2LockupLinear._withdraw(uint256,address,uint128) (src/SablierV2LockupLinear.sol#475-523)
	- SablierV2LockupLinear.getAsset(uint256) (src/SablierV2LockupLinear.sol#79-81)
	- SablierV2LockupLinear.getCliffTime(uint256) (src/SablierV2LockupLinear.sol#84-86)
	- SablierV2LockupLinear.getDepositAmount(uint256) (src/SablierV2LockupLinear.sol#89-91)
	- SablierV2LockupLinear.getEndTime(uint256) (src/SablierV2LockupLinear.sol#94-96)
	- SablierV2LockupLinear.getRange(uint256) (src/SablierV2LockupLinear.sol#99-105)
	- SablierV2LockupLinear.getSender(uint256) (src/SablierV2LockupLinear.sol#118-120)
	- SablierV2LockupLinear.getStartTime(uint256) (src/SablierV2LockupLinear.sol#123-125)
	- SablierV2LockupLinear.getStatus(uint256) (src/SablierV2LockupLinear.sol#128-136)
	- SablierV2LockupLinear.getStream(uint256) (src/SablierV2LockupLinear.sol#139-141)
	- SablierV2LockupLinear.getWithdrawnAmount(uint256) (src/SablierV2LockupLinear.sol#144-146)
	- SablierV2LockupLinear.isCancelable(uint256) (src/SablierV2LockupLinear.sol#149-160)
	- SablierV2LockupLinear.returnableAmountOf(uint256) (src/SablierV2LockupLinear.sol#163-174)
	- SablierV2LockupLinear.streamedAmountOf(uint256) (src/SablierV2LockupLinear.sol#177-224)
	- SablierV2LockupLinear.withdrawableAmountOf(uint256) (src/SablierV2LockupLinear.sol#232-241)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities-1
```

To fix this, we simply have to move two if statements around. This is what this PR does.