### PR TITLE
docs: various improvements

### DIFF
--- a/src/SablierV2LockupDynamic.sol
+++ b/src/SablierV2LockupDynamic.sol
@@ -64,7 +64,7 @@ contract SablierV2LockupDynamic is
     /// @dev Counter for stream ids, used in the create functions.
     uint256 private _nextStreamId;
 
-    /// @dev Dynamic lockup streams mapped by unsigned integers ids.
+    /// @dev Lockup dynamic streams mapped by unsigned integers ids.
     mapping(uint256 id => LockupDynamic.Stream stream) private _streams;
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/src/SablierV2LockupLinear.sol
+++ b/src/SablierV2LockupLinear.sol
@@ -52,7 +52,7 @@ contract SablierV2LockupLinear is
     /// @dev Counter for stream ids, used in the create functions.
     uint256 private _nextStreamId;
 
-    /// @dev Sablier V2 linear lockup streams mapped by unsigned integers.
+    /// @dev Sablier V2 lockup linear streams mapped by unsigned integers.
     mapping(uint256 id => LockupLinear.Stream stream) private _streams;
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/src/interfaces/IAdminable.sol
+++ b/src/interfaces/IAdminable.sol
@@ -34,7 +34,7 @@ interface IAdminable {
     /// functionality that is only available to the admin.
     ///
     /// Requirements:
-    /// - The caller must be the contract admin.
+    /// - `msg.sender` must be the contract admin.
     ///
     /// @param newAdmin The address of the new admin.
     function transferAdmin(address newAdmin) external;

--- a/src/interfaces/ISablierV2Base.sol
+++ b/src/interfaces/ISablierV2Base.sol
@@ -54,7 +54,7 @@ interface ISablierV2Base is IAdminable {
     /// @dev Emits a {ClaimProtocolRevenues} event.
     ///
     /// Requirements:
-    /// - The caller must be the contract admin.
+    /// - `msg.sender` must be the contract admin.
     ///
     /// @param asset The contract address of the ERC-20 asset to claim the protocol revenues for.
     function claimProtocolRevenues(IERC20 asset) external;
@@ -68,7 +68,7 @@ interface ISablierV2Base is IAdminable {
     /// - Does not revert if the comptroller is the same.
     ///
     /// Requirements:
-    /// - The caller must be the contract admin.
+    /// - `msg.sender` must be the contract admin.
     ///
     /// @param newComptroller The address of the new comptroller contract.
     function setComptroller(ISablierV2Comptroller newComptroller) external;

--- a/src/interfaces/ISablierV2Comptroller.sol
+++ b/src/interfaces/ISablierV2Comptroller.sol
@@ -67,7 +67,7 @@ interface ISablierV2Comptroller is IAdminable {
     /// - Does not revert if the fee is the same.
     ///
     /// Requirements:
-    /// - The caller must be the contract admin.
+    /// - `msg.sender` must be the contract admin.
     ///
     /// @param newFlashFee The new flash fee to set, as an UD60x18 number where 100% = 1e18.
     function setFlashFee(UD60x18 newFlashFee) external;
@@ -83,7 +83,7 @@ interface ISablierV2Comptroller is IAdminable {
     /// - Does not revert if the fee is the same.
     ///
     /// Requirements:
-    /// - The caller must be the contract admin.
+    /// - `msg.sender` must be the contract admin.
     ///
     /// @param asset The contract address of the ERC-20 asset to make the query for.
     /// @param newProtocolFee The new protocol fee to set, as an UD60x18 number where 100% = 1e18.
@@ -94,7 +94,7 @@ interface ISablierV2Comptroller is IAdminable {
     /// @dev Emits a {ToggleFlashAsset} event.
     ///
     /// Requirements:
-    /// - The caller must be the admin.
+    /// - `msg.sender` must be the admin.
     ///
     /// @param asset The address of the ERC-20 asset to toggle.
     function toggleFlashAsset(IERC20 asset) external;

--- a/src/interfaces/ISablierV2Lockup.sol
+++ b/src/interfaces/ISablierV2Lockup.sol
@@ -163,7 +163,7 @@ interface ISablierV2Lockup is
     ///
     /// Requirements:
     /// - The call must not be a delegate call.
-    /// - The caller must be either the sender or the recipient of each stream.
+    /// - `msg.sender` must be either the sender or the recipient of each stream.
     ///
     /// @param streamIds The ids of the lockup streams to cancel.
     function cancelMultiple(uint256[] calldata streamIds) external;
@@ -193,7 +193,7 @@ interface ISablierV2Lockup is
     /// - Does not revert if the NFT descriptor is the same.
     ///
     /// Requirements:
-    /// - The caller must be the contract admin.
+    /// - `msg.sender` must be the contract admin.
     ///
     /// @param newNFTDescriptor The address of the new NFT descriptor contract.
     function setNFTDescriptor(ISablierV2NFTDescriptor newNFTDescriptor) external;
@@ -242,7 +242,7 @@ interface ISablierV2Lockup is
     /// Requirements:
     /// - The call must not be a delegate call.
     /// - The count of `streamIds` must match the count of `amounts`.
-    /// - The caller must be either the recipient or an approved operator of each stream.
+    /// - `msg.sender` must be either the recipient or an approved operator of each stream.
     /// - Every amount in `amounts` must not be zero and must not exceed the withdrawable amount.
     ///
     /// @param streamIds The ids of the lockup streams to withdraw.

--- a/src/interfaces/ISablierV2LockupDynamic.sol
+++ b/src/interfaces/ISablierV2LockupDynamic.sol
@@ -13,7 +13,7 @@ interface ISablierV2LockupDynamic is ISablierV2Lockup {
                                        EVENTS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when a dynamic lockup stream is created.
+    /// @notice Emitted when a lockup dynamic stream is created.
     /// @param streamId The id of the newly created lockup stream.
     /// @param funder The address which has funded the stream.
     /// @param sender The address from which to stream the assets, who will have the ability to cancel the stream.
@@ -43,21 +43,21 @@ interface ISablierV2LockupDynamic is ISablierV2Lockup {
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice The maximum number of segments permitted in a dynamic lockup stream.
+    /// @notice The maximum number of segments permitted in a lockup dynamic stream.
     /// @dev This is initialized at construction time and cannot be changed later.
     function MAX_SEGMENT_COUNT() external view returns (uint256);
 
-    /// @notice Queries the range of the dynamic lockup stream, a struct that encapsulates (i) the start time of the
+    /// @notice Queries the range of the lockup dynamic stream, a struct that encapsulates (i) the start time of the
     /// stream, and (ii) the end time of of the stream, both as Unix timestamps.
-    /// @param streamId The id of the dynamic lockup stream to make the query for.
+    /// @param streamId The id of the lockup dynamic stream to make the query for.
     function getRange(uint256 streamId) external view returns (LockupDynamic.Range memory range);
 
     /// @notice Queries the segments the protocol uses to compose the custom streaming curve.
-    /// @param streamId The id of the dynamic lockup stream to make the query for.
+    /// @param streamId The id of the lockup dynamic stream to make the query for.
     function getSegments(uint256 streamId) external view returns (LockupDynamic.Segment[] memory segments);
 
-    /// @notice Queries the dynamic lockup stream struct entity.
-    /// @param streamId The id of the dynamic lockup stream to make the query for.
+    /// @notice Queries the lockup dynamic stream entity.
+    /// @param streamId The id of the lockup dynamic stream to make the query for.
     function getStream(uint256 streamId) external view returns (LockupDynamic.Stream memory stream);
 
     /// @notice Calculates the amount that has been streamed to the recipient, in units of the asset's decimals.
@@ -74,14 +74,14 @@ interface ISablierV2LockupDynamic is ISablierV2Lockup {
     /// - $csa$ is the current segment amount.
     /// - $\Sigma(esa)$ is the sum of all elapsed segments' amounts.
     ///
-    /// @param streamId The id of the dynamic lockup stream to make the query for.
+    /// @param streamId The id of the lockup dynamic stream to make the query for.
     function streamedAmountOf(uint256 streamId) external view returns (uint128 streamedAmount);
 
     /*//////////////////////////////////////////////////////////////////////////
                                NON-CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a dynamic lockup stream by setting the start time to `block.timestamp`, and the end time
+    /// @notice Creates a lockup dynamic stream by setting the start time to `block.timestamp`, and the end time
     /// to the sum of `block.timestamp` and all specified time deltas. The segment milestones are derived from these
     /// deltas. The stream is funded by `msg.sender` and is wrapped in an ERC-721 NFT.
     ///
@@ -91,10 +91,10 @@ interface ISablierV2LockupDynamic is ISablierV2Lockup {
     /// - All from {createWithMilestones}.
     ///
     /// @param params Struct that encapsulates the function parameters.
-    /// @return streamId The id of the newly created dynamic lockup stream.
+    /// @return streamId The id of the newly created lockup dynamic stream.
     function createWithDeltas(LockupDynamic.CreateWithDeltas calldata params) external returns (uint256 streamId);
 
-    /// @notice Creates a dynamic lockup stream with the provided milestones, implying the end time from the last
+    /// @notice Creates a lockup dynamic stream with the provided milestones, implying the end time from the last
     /// segment's milestone. The stream is funded by `msg.sender` and is wrapped in an ERC-721 NFT.
     ///
     /// @dev Emits a {CreateLockupDynamicStream} and a {Transfer} event.
@@ -116,7 +116,7 @@ interface ISablierV2LockupDynamic is ISablierV2Lockup {
     /// - `msg.sender` must have allowed this contract to spend at least `params.totalAmount` assets.
     ///
     /// @param params Struct that encapsulates the function parameters.
-    /// @return streamId The id of the newly created dynamic lockup stream.
+    /// @return streamId The id of the newly created lockup dynamic stream.
     function createWithMilestones(LockupDynamic.CreateWithMilestones calldata params)
         external
         returns (uint256 streamId);

--- a/src/interfaces/ISablierV2LockupLinear.sol
+++ b/src/interfaces/ISablierV2LockupLinear.sol
@@ -13,8 +13,8 @@ interface ISablierV2LockupLinear is ISablierV2Lockup {
                                        EVENTS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when a linear lockup stream is created.
-    /// @param streamId The id of the newly created linear lockup stream.
+    /// @notice Emitted when a lockup linear stream is created.
+    /// @param streamId The id of the newly created lockup linear stream.
     /// @param funder The address which has funded the stream.
     /// @param sender The address from which to stream the assets, who will have the ability to cancel the stream.
     /// @param recipient The address toward which to stream the assets.
@@ -41,17 +41,17 @@ interface ISablierV2LockupLinear is ISablierV2Lockup {
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Queries the cliff time of the linear lockup stream.
-    /// @param streamId The id of the linear lockup stream to make the query for.
+    /// @notice Queries the cliff time of the lockup linear stream.
+    /// @param streamId The id of the lockup linear stream to make the query for.
     function getCliffTime(uint256 streamId) external view returns (uint40 cliffTime);
 
-    /// @notice Queries the range of the linear lockup stream, a struct that encapsulates (i) the start time of the
+    /// @notice Queries the range of the lockup linear stream, a struct that encapsulates (i) the start time of the
     /// stream, (ii) the cliff time of the stream, and (iii) the end time of the stream, all as Unix timestamps.
-    /// @param streamId The id of the linear lockup stream to make the query for.
+    /// @param streamId The id of the lockup linear stream to make the query for.
     function getRange(uint256 streamId) external view returns (LockupLinear.Range memory range);
 
-    /// @notice Queries the linear lockup stream struct entity.
-    /// @param streamId The id of the linear lockup stream to make the query for.
+    /// @notice Queries the lockup linear stream entity.
+    /// @param streamId The id of the lockup linear stream to make the query for.
     function getStream(uint256 streamId) external view returns (LockupLinear.Stream memory stream);
 
     /// @notice Calculates the amount that has been streamed to the recipient, in units of the asset's decimals.
@@ -67,14 +67,14 @@ interface ISablierV2LockupLinear is ISablierV2Lockup {
     /// - $d$ is the deposit amount.
     /// - $c$ is the cliff amount.
     ///
-    /// @param streamId The id of the linear lockup stream to make the query for.
+    /// @param streamId The id of the lockup linear stream to make the query for.
     function streamedAmountOf(uint256 streamId) external view returns (uint128 streamedAmount);
 
     /*//////////////////////////////////////////////////////////////////////////
                                NON-CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a linear lockup stream by setting the start time to `block.timestamp`, and the end time to
+    /// @notice Creates a lockup linear stream by setting the start time to `block.timestamp`, and the end time to
     /// the sum of `block.timestamp` and `params.durations.total. The stream is funded by `msg.sender` and is wrapped
     /// in an ERC-721 NFT.
     ///
@@ -84,12 +84,12 @@ interface ISablierV2LockupLinear is ISablierV2Lockup {
     /// - All from {createWithRange}.
     ///
     /// @param params Struct that encapsulates the function parameters.
-    /// @return streamId The id of the newly created linear lockup stream.
+    /// @return streamId The id of the newly created lockup linear stream.
     function createWithDurations(LockupLinear.CreateWithDurations calldata params)
         external
         returns (uint256 streamId);
 
-    /// @notice Creates a linear lockup stream with the provided start time and end time as the range. The stream is
+    /// @notice Creates a lockup linear stream with the provided start time and end time as the range. The stream is
     /// funded by `msg.sender` and is wrapped in an ERC-721 NFT.
     ///
     /// @dev Emits a {CreateLockupLinearStream} and a {Transfer} event.
@@ -107,6 +107,6 @@ interface ISablierV2LockupLinear is ISablierV2Lockup {
     /// - `msg.sender` must have allowed this contract to spend at least `params.totalAmount` assets.
     ///
     /// @param params Struct that encapsulates the function parameters.
-    /// @return streamId The id of the newly created linear lockup stream.
+    /// @return streamId The id of the newly created lockup linear stream.
     function createWithRange(LockupLinear.CreateWithRange calldata params) external returns (uint256 streamId);
 }

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -10,7 +10,9 @@ import { UD60x18 } from "@prb/math/UD60x18.sol";
 /// @param account The address of the broker the fee will be paid to.
 /// @param fee The percentage fee that the broker is paid from the total amount, as an UD60x18 number.
 struct Broker {
+    // slot 0
     address account;
+    // slot 1
     UD60x18 fee;
 }
 
@@ -22,8 +24,9 @@ library Lockup {
     /// @param withdrawn The amount of assets that have been withdrawn from the stream, in units of the asset's
     /// decimals.
     struct Amounts {
-        uint128 deposit; // ───┐
-        uint128 withdrawn; // ─┘
+        // slot 0
+        uint128 deposit;
+        uint128 withdrawn;
     }
 
     /// @notice Simple struct that encapsulates (i) the deposit amount, (ii) the protocol fee amount, and (iii) the
@@ -32,8 +35,8 @@ library Lockup {
     /// @param protocolFee The protocol fee amount, in units of the asset's decimals.
     /// @param brokerFee The broker fee amount, in units of the asset's decimals.
     struct CreateAmounts {
-        uint128 deposit; // ─────┐
-        uint128 protocolFee; // ─┘
+        uint128 deposit;
+        uint128 protocolFee;
         uint128 brokerFee;
     }
 
@@ -67,8 +70,8 @@ library LockupDynamic {
     /// stream and (ii) the percentage fee that the broker is paid from `totalAmount`, as an UD60x18 number.
     struct CreateWithDeltas {
         LockupDynamic.SegmentWithDelta[] segments;
-        address sender; // ──┐
-        bool cancelable; // ─┘
+        address sender;
+        bool cancelable;
         address recipient;
         uint128 totalAmount;
         IERC20 asset;
@@ -90,31 +93,32 @@ library LockupDynamic {
     /// stream and (ii) the percentage fee that the broker is paid from `totalAmount`, as an UD60x18 number.
     struct CreateWithMilestones {
         LockupDynamic.Segment[] segments;
-        address sender; // ──┐
-        uint40 startTime; // │
-        bool cancelable; // ─┘
+        address sender;
+        uint40 startTime;
+        bool cancelable;
         address recipient;
         uint128 totalAmount;
         IERC20 asset;
         Broker broker;
     }
 
-    /// @notice Range struct used as a field in the dynamic lockup stream.
+    /// @notice Range struct used as a field in the lockup dynamic stream.
     /// @param start The Unix timestamp for when the stream will start.
     /// @param end The Unix timestamp for when the stream will end.
     struct Range {
-        uint40 start; // ─┐
-        uint40 end; // ───┘
+        uint40 start;
+        uint40 end;
     }
 
-    /// @notice Segment struct used in the dynamic lockup stream.
+    /// @notice Segment struct used in the lockup dynamic stream.
     /// @param amount The amounts of assets to be streamed in this segment, in units of the asset's decimals.
     /// @param exponent The exponent of this segment, as an UD2x18 number.
     /// @param milestone The Unix timestamp for when this segment ends.
     struct Segment {
-        uint128 amount; // ───┐
-        UD2x18 exponent; //   │
-        uint40 milestone; // ─┘
+        // slot 0
+        uint128 amount;
+        UD2x18 exponent;
+        uint40 milestone;
     }
 
     /// @notice Segment struct used only at runtime in {SablierV2LockupDynamic-createWithDeltas}.
@@ -122,12 +126,12 @@ library LockupDynamic {
     /// @param exponent The exponent of this segment, as an UD2x18 number.
     /// @param delta The time difference between this segment and the previous one, in seconds.
     struct SegmentWithDelta {
-        uint128 amount; // ─┐
-        UD2x18 exponent; // │
-        uint40 delta; // ───┘
+        uint128 amount;
+        UD2x18 exponent;
+        uint40 delta;
     }
 
-    /// @notice dynamic Lockup stream struct.
+    /// @notice Lockup dynamic stream.
     /// @dev The fields are arranged like this to save gas via tight variable packing.
     /// @param amounts Simple struct with the deposit and the withdrawn amount.
     /// @param segments The segments the protocol uses to compose the custom streaming curve.
@@ -138,13 +142,17 @@ library LockupDynamic {
     /// @param status An enum that indicates the status of the stream.
     /// @param asset The contract address of the ERC-20 asset used for streaming.
     struct Stream {
+        // slot 0
         Lockup.Amounts amounts;
+        // slot 1
         Segment[] segments;
-        address sender; // ───────┐
-        uint40 startTime; //      │
-        uint40 endTime; //        │
-        bool isCancelable; //     │
-        Lockup.Status status; // ─┘
+        // slot 2
+        address sender;
+        uint40 startTime;
+        uint40 endTime;
+        bool isCancelable;
+        Lockup.Status status;
+        // slot 3
         IERC20 asset;
     }
 }
@@ -199,8 +207,8 @@ library LockupLinear {
     /// @param cliff The cliff duration in seconds.
     /// @param total The total duration in seconds.
     struct Durations {
-        uint40 cliff; // ─┐
-        uint40 total; // ─┘
+        uint40 cliff;
+        uint40 total;
     }
 
     /// @notice Range struct used as a field in the linear lockup linear.
@@ -208,12 +216,13 @@ library LockupLinear {
     /// @param cliff The Unix timestamp for when the cliff period will end.
     /// @param end The Unix timestamp for when the stream will end.
     struct Range {
-        uint40 start; // ─┐
-        uint40 cliff; //  │
-        uint40 end; // ───┘
+        // slot 0
+        uint40 start;
+        uint40 cliff;
+        uint40 end;
     }
 
-    /// @notice linear Lockup linear struct.
+    /// @notice linear Lockup linear.
     /// @dev The fields are arranged like this to save gas via tight variable packing.
     /// @param amounts Simple struct with the deposit and the withdrawn amount.
     /// @param sender The address of the sender of the stream.
@@ -224,13 +233,16 @@ library LockupLinear {
     /// @param endTime The Unix timestamp for when the stream will end.
     /// @param status An enum that indicates the status of the stream.
     struct Stream {
+        // slot 0
         Lockup.Amounts amounts;
-        address sender; // ────┐
-        uint40 startTime; //   │
-        uint40 cliffTime; //   │
-        bool isCancelable; // ─┘
-        IERC20 asset; // ─────────┐
-        uint40 endTime; //        │
-        Lockup.Status status; // ─┘
+        // slot 1
+        address sender;
+        uint40 startTime;
+        uint40 cliffTime;
+        bool isCancelable;
+        // slot 2
+        IERC20 asset;
+        uint40 endTime;
+        Lockup.Status status;
     }
 }


### PR DESCRIPTION
Addresses #393, #394, and also switches to the [`//slot 0`](https://twitter.com/brockjelmore/status/1627444547189084161) approach for commenting struct slots.