### PR TITLE
perf: remove duplicate status check

### DIFF
--- a/src/abstracts/SablierV2Lockup.sol
+++ b/src/abstracts/SablierV2Lockup.sol
@@ -136,8 +136,8 @@ abstract contract SablierV2Lockup is
             streamId = streamIds[i];
 
             // Effects and Interactions: cancel the stream.
-            // Cancel this stream only if the `streamId` points to a stream that is active and cancelable.
-            if (getStatus(streamId) == Lockup.Status.ACTIVE && isCancelable(streamId)) {
+            // Cancel this stream only if the stream id points to a stream that is active and cancelable.
+            if (isCancelable(streamId)) {
                 _cancel(streamId);
             }
 


### PR DESCRIPTION
Addresses https://github.com/cantinasec/sablier/issues/9.

The `cancelMultiple` function checks the status of the stream twice, once in the explicit call to `getStatus`, and once in the call to the `isCancelable` function.

Side note: fuzz tests are taking a long time (over 6 hours, up from 1h 30m) due to a recently introduced bug in Foundry. We have notified the Foundry team about this.