### PR TITLE
chore: mark "lib" as vendored code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+lib/** linguist-vendored
+wiki/** linguist-documentation

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
     ".gas-snapshot": "julia"
   },
   "editor.formatOnSave": true,
+  "npm.exclude": "**/lib/**",
   "solidity.formatter": "forge"
 }


### PR DESCRIPTION
Implements #409.

Changelog:

- [x] chore: mark "lib" as vendored code
- [x] chore: exclude "lib" from NPM Scripts in VSCode
- [x] chore: mark "wiki" as documentation code