### PR TITLE
chore: disable codecov/status check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,9 @@
 codecov:
   require_ci_to_pass: false
 comment: false
+coverage:
+  status:
+    patch: off
 ignore:
   - "script"
   - "test"


### PR DESCRIPTION
The Codecov [status check](https://docs.codecov.com/docs/commit-status#patch-status) is so often providing misleading results that it seems like it would be better to remove it.

- It shows dubious incomplete hits, e.g. [87.50% of diff hit](https://github.com/sablierhq/v2-core/pull/396/checks?check_run_id=12489349765) even if the tests have covered all added branches in [PR 396](https://github.com/sablierhq/v2-core/pull/396)
- It reports untested code in `test`

This may be partly due to Foundry, as per the explanation in https://github.com/sablierhq/v2-core/issues/332.