### PR TITLE
refactor: apply Hake's recommendations

### DIFF
--- a/src/SablierV2LockupDynamic.sol
+++ b/src/SablierV2LockupDynamic.sol
@@ -547,7 +547,7 @@ contract SablierV2LockupDynamic is
             // Effects: bump the next stream id and record the protocol fee.
             // Using unchecked arithmetic because these calculations cannot realistically overflow, ever.
             _nextStreamId = streamId + 1;
-            protocolRevenues[params.asset] += createAmounts.protocolFee;
+            protocolRevenues[params.asset] = protocolRevenues[params.asset] + createAmounts.protocolFee;
         }
 
         // Effects: mint the NFT to the recipient.
@@ -608,7 +608,7 @@ contract SablierV2LockupDynamic is
     /// @dev See the documentation for the public functions that call this internal function.
     function _withdraw(uint256 streamId, address to, uint128 amount) internal override {
         // Effects: update the withdrawn amount.
-        _streams[streamId].amounts.withdrawn += amount;
+        _streams[streamId].amounts.withdrawn = _streams[streamId].amounts.withdrawn + amount;
 
         // Load the amounts in memory.
         Lockup.Amounts memory amounts = _streams[streamId].amounts;

--- a/src/SablierV2LockupLinear.sol
+++ b/src/SablierV2LockupLinear.sol
@@ -449,7 +449,7 @@ contract SablierV2LockupLinear is
         // Using unchecked arithmetic because these calculations cannot realistically overflow, ever.
         unchecked {
             _nextStreamId = streamId + 1;
-            protocolRevenues[params.asset] += createAmounts.protocolFee;
+            protocolRevenues[params.asset] = protocolRevenues[params.asset] + createAmounts.protocolFee;
         }
 
         // Effects: mint the NFT to the recipient.
@@ -509,7 +509,7 @@ contract SablierV2LockupLinear is
     /// @dev See the documentation for the public functions that call this internal function.
     function _withdraw(uint256 streamId, address to, uint128 amount) internal override {
         // Effects: update the withdrawn amount.
-        _streams[streamId].amounts.withdrawn += amount;
+        _streams[streamId].amounts.withdrawn = _streams[streamId].amounts.withdrawn + amount;
 
         // Load the amounts in memory.
         Lockup.Amounts memory amounts = _streams[streamId].amounts;

--- a/src/abstracts/SablierV2FlashLoan.sol
+++ b/src/abstracts/SablierV2FlashLoan.sol
@@ -149,7 +149,7 @@ abstract contract SablierV2FlashLoan is
         unchecked {
             // Effects: record the flash fee amount in the protocol revenues. The casting to uint128 is safe due
             // to the check at the start of the function.
-            protocolRevenues[IERC20(asset)] += uint128(fee);
+            protocolRevenues[IERC20(asset)] = protocolRevenues[IERC20(asset)] + uint128(fee);
 
             // Calculate the amount that the borrower must return.
             returnAmount = amount + fee;

--- a/src/libraries/Helpers.sol
+++ b/src/libraries/Helpers.sol
@@ -34,15 +34,14 @@ library Helpers {
         if (protocolFee.gt(maxFee)) {
             revert Errors.SablierV2Lockup_ProtocolFeeTooHigh(protocolFee, maxFee);
         }
-
-        // Calculate the protocol fee amount.
-        // The cast to uint128 is safe because the maximum fee is hard coded.
-        amounts.protocolFee = uint128(ud(totalAmount).mul(protocolFee).intoUint256());
-
         // Checks: the broker fee is not greater than `maxFee`.
         if (brokerFee.gt(maxFee)) {
             revert Errors.SablierV2Lockup_BrokerFeeTooHigh(brokerFee, maxFee);
         }
+
+        // Calculate the protocol fee amount.
+        // The cast to uint128 is safe because the maximum fee is hard coded.
+        amounts.protocolFee = uint128(ud(totalAmount).mul(protocolFee).intoUint256());
 
         // Calculate the broker fee amount.
         // The cast to uint128 is safe because the maximum fee is hard coded.
@@ -71,13 +70,13 @@ library Helpers {
             revert Errors.SablierV2Lockup_DepositAmountZero();
         }
 
-        // Check that the segment count is not zero.
+        // Checks: the segment count is not zero.
         uint256 segmentCount = segments.length;
         if (segmentCount == 0) {
             revert Errors.SablierV2LockupDynamic_SegmentCountZero();
         }
 
-        // Check that the segment count is not greater than the maximum allowed.
+        // Checks: the segment count is not greater than the maximum allowed.
         if (segmentCount > maxSegmentCount) {
             revert Errors.SablierV2LockupDynamic_SegmentCountTooHigh(segmentCount);
         }
@@ -179,11 +178,10 @@ library Helpers {
         // 2. Check that the milestones are ordered.
         uint256 count = segments.length;
         for (uint256 index = 0; index < count;) {
-            // Add the current segment amount to the sum. Note that this can overflow, causing the transaction to
-            // revert.
+            // Add the current segment amount to the sum.
             segmentAmountsSum += segments[index].amount;
 
-            // Check that the current milestone is strictly greater than the previous milestone.
+            // Checks: the current milestone is strictly greater than the previous milestone.
             currentMilestone = segments[index].milestone;
             if (currentMilestone <= previousMilestone) {
                 revert Errors.SablierV2LockupDynamic_SegmentMilestonesNotOrdered(
@@ -207,7 +205,7 @@ library Helpers {
             revert Errors.SablierV2Lockup_EndTimeInThePast(currentTime, currentMilestone);
         }
 
-        // Check that the deposit amount is equal to the segment amounts sum.
+        // Checks: the deposit amount is equal to the segment amounts sum.
         if (depositAmount != segmentAmountsSum) {
             revert Errors.SablierV2LockupDynamic_DepositAmountNotEqualToSegmentAmountsSum(
                 depositAmount, segmentAmountsSum


### PR DESCRIPTION
Addresses recommendations [G-02] and [G-03] from Hake's audit report.

- [x] Optimize the order of operations in `checkAndCalculateFees`
- [x] Optimize reads when writing state: `x = x + y` is more efficient than `x += y` (see this [GitHub gist](https://gist.github.com/IllIllI000/cbbfb267425b898e5be734d4008d4fe8#opcodes))

NOTE: this PR depends upon #423 being merged first.