### PR TITLE
refactor: provide default mnemonic in base script

### DIFF
--- a/script/shared/Base.s.sol
+++ b/script/shared/Base.s.sol
@@ -4,13 +4,21 @@ pragma solidity >=0.8.19 <=0.9.0;
 import { Script } from "forge-std/Script.sol";
 
 abstract contract BaseScript is Script {
+    /// @dev Included to enable compilation of the script without a $MNEMONIC environment variable.
+    string internal constant TEST_MNEMONIC = "test test test test test test test test test test test junk";
+
+    /// @dev Needed for the deterministic deployments.
     bytes32 internal constant ZERO_SALT = bytes32(0);
+
+    /// @dev The address of the contract deployer.
     address internal deployer;
+
+    /// @dev Used to derive the deployer's address.
     string internal mnemonic;
 
     constructor() {
-        mnemonic = vm.envString("MNEMONIC");
-        (deployer,) = deriveRememberKey(mnemonic, 0);
+        mnemonic = vm.envOr("MNEMONIC", TEST_MNEMONIC);
+        (deployer,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
     }
 
     modifier broadcaster() {


### PR DESCRIPTION
As per @andreivladbrg's remark, since https://github.com/sablierhq/v2-core/pull/448 was merged, the base script cannot be used anymore if a `MNEMONIC` is not set as an environment variable.

This PR resolves this limitation by using the `envOr` cheat instead of `envString`, and by providing a default test mnemonic.