### PR TITLE
fix: nft descriptor size

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,7 @@
     "SablierV2NFTDescriptor",
   ]
   optimizer = true
-  optimizer_runs = 5_000
+  optimizer_runs = 4000
   out = "out"
   script = "script"
   sender = "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38"


### PR DESCRIPTION
The current bytecode size of the `NFTDescriptor` contract is 24,762 (186 bytes more than the EIP-170 limit), and this is even with `--via-ir` and the `optimizer` enabled with 5k runs.

https://github.com/sablier-labs/v2-core/actions/runs/5125334769

This PR lowers the number of `optimizer_runs` to 4,000, which brings down the size of `NFTDescriptor` to ~24.17kB