### PR TITLE
test: simplify comments re events and errors

### DIFF
--- a/test/fork/LockupDynamic.t.sol
+++ b/test/fork/LockupDynamic.t.sol
@@ -152,7 +152,7 @@ abstract contract LockupDynamic_Fork_Test is Fork_Test {
         vars.initialLockupDynamicBalance = vars.balances[0];
         vars.initialBrokerBalance = vars.balances[1];
 
-        // Expect a {CreateLockupDynamicStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vars.streamId = lockupDynamic.nextStreamId();
         vm.expectEmit({ emitter: address(lockupDynamic) });
         vars.range =
@@ -275,7 +275,7 @@ abstract contract LockupDynamic_Fork_Test is Fork_Test {
             vars.initialLockupDynamicBalance = vars.actualLockupDynamicBalance;
             vars.initialRecipientBalance = asset.balanceOf(params.recipient);
 
-            // Expect a {WithdrawFromLockupStream} event to be emitted.
+            // Expect the relevant event to be emitted.
             vm.expectEmit({ emitter: address(lockupDynamic) });
             emit WithdrawFromLockupStream({
                 streamId: vars.streamId,
@@ -336,7 +336,7 @@ abstract contract LockupDynamic_Fork_Test is Fork_Test {
             vars.initialSenderBalance = vars.balances[1];
             vars.initialRecipientBalance = vars.balances[2];
 
-            // Expect a {CancelLockupStream} event to be emitted.
+            // Expect the relevant event to be emitted.
             vm.expectEmit({ emitter: address(lockupDynamic) });
             vars.senderAmount = lockupDynamic.refundableAmountOf(vars.streamId);
             vars.recipientAmount = lockupDynamic.withdrawableAmountOf(vars.streamId);

--- a/test/fork/LockupLinear.t.sol
+++ b/test/fork/LockupLinear.t.sol
@@ -156,7 +156,7 @@ abstract contract LockupLinear_Fork_Test is Fork_Test {
         vars.createAmounts.brokerFee = ud(params.totalAmount).mul(params.broker.fee).intoUint128();
         vars.createAmounts.deposit = params.totalAmount - vars.createAmounts.protocolFee - vars.createAmounts.brokerFee;
 
-        // Expect a {CreateLockupLinearStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vars.streamId = lockupLinear.nextStreamId();
         vm.expectEmit({ emitter: address(lockupLinear) });
         emit CreateLockupLinearStream({
@@ -260,7 +260,7 @@ abstract contract LockupLinear_Fork_Test is Fork_Test {
             vars.initialLockupLinearBalance = vars.actualLockupLinearBalance;
             vars.initialRecipientBalance = asset.balanceOf(params.recipient);
 
-            // Expect a {WithdrawFromLockupStream} event to be emitted.
+            // Expect the relevant event to be emitted.
             vm.expectEmit({ emitter: address(lockupLinear) });
             emit WithdrawFromLockupStream({
                 streamId: vars.streamId,
@@ -319,7 +319,7 @@ abstract contract LockupLinear_Fork_Test is Fork_Test {
             vars.initialSenderBalance = vars.balances[1];
             vars.initialRecipientBalance = vars.balances[2];
 
-            // Expect a {CancelLockupStream} event to be emitted.
+            // Expect the relevant event to be emitted.
             vm.expectEmit({ emitter: address(lockupLinear) });
             vars.senderAmount = lockupLinear.refundableAmountOf(vars.streamId);
             vars.recipientAmount = lockupLinear.withdrawableAmountOf(vars.streamId);

--- a/test/integration/basic/comptroller/set-flash-fee/setFlashFee.t.sol
+++ b/test/integration/basic/comptroller/set-flash-fee/setFlashFee.t.sol
@@ -23,7 +23,7 @@ contract SetFlashFee_Integration_Basic_Test is Integration_Test {
     }
 
     function test_SetFlashFee_SameFee() external whenCallerAdmin {
-        // Expect a {SetFlashFee} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit SetFlashFee({ admin: users.admin, oldFlashFee: ZERO, newFlashFee: ZERO });
         comptroller.setFlashFee({ newFlashFee: ZERO });
@@ -44,7 +44,7 @@ contract SetFlashFee_Integration_Basic_Test is Integration_Test {
     function test_SetFlashFee() external {
         UD60x18 newFlashFee = defaults.FLASH_FEE();
 
-        // Expect a {SetFlashFee} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit SetFlashFee({ admin: users.admin, oldFlashFee: ZERO, newFlashFee: newFlashFee });
 

--- a/test/integration/basic/comptroller/set-protocol-fee/setProtocolFee.t.sol
+++ b/test/integration/basic/comptroller/set-protocol-fee/setProtocolFee.t.sol
@@ -24,7 +24,7 @@ contract SetProtocolFee_Integration_Basic_Test is Integration_Test {
     }
 
     function test_SetProtocolFee_SameFee() external whenCallerAdmin {
-        // Expect a {SetProtocolFee} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit SetProtocolFee({ admin: users.admin, asset: dai, oldProtocolFee: ZERO, newProtocolFee: ZERO });
 
@@ -44,7 +44,7 @@ contract SetProtocolFee_Integration_Basic_Test is Integration_Test {
     function test_SetProtocolFee() external whenCallerAdmin whenNewFee {
         UD60x18 newProtocolFee = defaults.FLASH_FEE();
 
-        // Expect a {SetProtocolFee} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit SetProtocolFee({ admin: users.admin, asset: dai, oldProtocolFee: ZERO, newProtocolFee: newProtocolFee });
 

--- a/test/integration/basic/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
+++ b/test/integration/basic/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
@@ -23,7 +23,7 @@ contract ToggleFlashAsset_Integration_Basic_Test is Integration_Test {
     }
 
     function test_ToggleFlashAsset_FlagNotEnabled() external whenCallerAdmin {
-        // Expect a {ToggleFlashAsset} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit ToggleFlashAsset({ admin: users.admin, asset: dai, newFlag: true });
 
@@ -41,7 +41,7 @@ contract ToggleFlashAsset_Integration_Basic_Test is Integration_Test {
     }
 
     function test_ToggleFlashAsset() external whenCallerAdmin whenFlagEnabled {
-        // Expect a {ToggleFlashAsset} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit ToggleFlashAsset({ admin: users.admin, asset: dai, newFlag: false });
 

--- a/test/integration/basic/flash-loan/flash-loan/flashLoan.t.sol
+++ b/test/integration/basic/flash-loan/flash-loan/flashLoan.t.sol
@@ -107,14 +107,14 @@ contract FlashLoanFunction_Integration_Basic_Test is FlashLoanFunction_Integrati
         // Mint the flash fee to the receiver so that they can repay the flash loan.
         deal({ token: address(dai), to: address(goodFlashLoanReceiver), give: fee });
 
-        // Expect `amount` of assets to be transferred from {SablierV2FlashLoan} to the receiver.
+        // Expect `amount` of assets to be transferred to the receiver.
         expectCallToTransfer({ to: address(goodFlashLoanReceiver), amount: LIQUIDITY_AMOUNT });
 
         // Expect `amount+fee` of assets to be transferred back from the receiver.
         uint256 returnAmount = LIQUIDITY_AMOUNT + fee;
         expectCallToTransferFrom({ from: address(goodFlashLoanReceiver), to: address(flashLoan), amount: returnAmount });
 
-        // Expect a {FlashLoan} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(flashLoan) });
         bytes memory data = bytes("Hello World");
         emit FlashLoan({

--- a/test/integration/basic/lockup-dynamic/constructor.t.sol
+++ b/test/integration/basic/lockup-dynamic/constructor.t.sol
@@ -9,7 +9,7 @@ import { LockupDynamic_Integration_Basic_Test } from "./LockupDynamic.t.sol";
 
 contract Constructor_LockupDynamic_Integration_Basic_Test is LockupDynamic_Integration_Basic_Test {
     function test_Constructor() external {
-        // Expect a {TransferAdmin} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit();
         emit TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
 

--- a/test/integration/basic/lockup-dynamic/create-with-deltas/createWithDeltas.t.sol
+++ b/test/integration/basic/lockup-dynamic/create-with-deltas/createWithDeltas.t.sol
@@ -90,11 +90,12 @@ contract CreateWithDeltas_LockupDynamic_Integration_Basic_Test is
 
             // Create new segments that overflow when the milestones are eventually calculated.
             LockupDynamic.SegmentWithDelta[] memory segments = new LockupDynamic.SegmentWithDelta[](2);
-            segments[0] = LockupDynamic.SegmentWithDelta({ amount: 0, exponent: ud2x18(1e18), delta: startTime + 1 });
+            segments[0] =
+                LockupDynamic.SegmentWithDelta({ amount: 0, exponent: ud2x18(1e18), delta: startTime + 1 seconds });
             segments[1] = defaults.segmentsWithDeltas()[0];
             segments[1].delta = MAX_UINT40;
 
-            // Expect a {SegmentMilestonesNotOrdered} error.
+            // Expect the relevant error to be thrown.
             uint256 index = 1;
             vm.expectRevert(
                 abi.encodeWithSelector(
@@ -144,7 +145,7 @@ contract CreateWithDeltas_LockupDynamic_Integration_Basic_Test is
         // Expect the broker fee to be paid to the broker.
         expectCallToTransferFrom({ from: funder, to: users.broker, amount: defaults.BROKER_FEE_AMOUNT() });
 
-        // Expect a {CreateLockupDynamicStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupDynamic) });
         emit CreateLockupDynamicStream({
             streamId: streamId,

--- a/test/integration/basic/lockup-dynamic/create-with-milestones/createWithMilestones.t.sol
+++ b/test/integration/basic/lockup-dynamic/create-with-milestones/createWithMilestones.t.sol
@@ -102,7 +102,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Basic_Test is
         LockupDynamic.Segment[] memory segments = defaults.segments();
         segments[0].milestone = defaults.START_TIME() - 1 seconds;
 
-        // Expect a {StartTimeNotLessThanFirstSegmentMilestone} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupDynamic_StartTimeNotLessThanFirstSegmentMilestone.selector,
@@ -128,7 +128,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Basic_Test is
         LockupDynamic.Segment[] memory segments = defaults.segments();
         segments[0].milestone = defaults.START_TIME();
 
-        // Expect a {StartTimeNotLessThanFirstSegmentMilestone} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupDynamic_StartTimeNotLessThanFirstSegmentMilestone.selector,
@@ -155,7 +155,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Basic_Test is
         LockupDynamic.Segment[] memory segments = defaults.segments();
         (segments[0].milestone, segments[1].milestone) = (segments[1].milestone, segments[0].milestone);
 
-        // Expect a {SegmentMilestonesNotOrdered} error.
+        // Expect the relevant error to be thrown.
         uint256 index = 1;
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -214,7 +214,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Basic_Test is
         params.broker = Broker({ account: address(0), fee: brokerFee });
         params.totalAmount = depositAmount;
 
-        // Expect a {DepositAmountNotEqualToSegmentAmountsSum} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupDynamic_DepositAmountNotEqualToSegmentAmountsSum.selector,
@@ -361,7 +361,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Basic_Test is
             amount: defaults.BROKER_FEE_AMOUNT()
         });
 
-        // Expect a {CreateLockupDynamicStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupDynamic) });
         emit CreateLockupDynamicStream({
             streamId: streamId,

--- a/test/integration/basic/lockup-linear/constructor.t.sol
+++ b/test/integration/basic/lockup-linear/constructor.t.sol
@@ -9,7 +9,7 @@ import { LockupLinear_Integration_Basic_Test } from "./LockupLinear.t.sol";
 
 contract Constructor_LockupLinear_Integration_Basic_Test is LockupLinear_Integration_Basic_Test {
     function test_Constructor() external {
-        // Expect a {TransferAdmin} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit();
         emit TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
 

--- a/test/integration/basic/lockup-linear/create-with-durations/createWithDurations.t.sol
+++ b/test/integration/basic/lockup-linear/create-with-durations/createWithDurations.t.sol
@@ -30,7 +30,7 @@ contract CreateWithDurations_LockupLinear_Integration_Basic_Test is
 
     function test_RevertWhen_CliffDurationCalculationOverflows() external whenNotDelegateCalled {
         uint40 startTime = getBlockTimestamp();
-        uint40 cliffDuration = MAX_UINT40 - startTime + 1;
+        uint40 cliffDuration = MAX_UINT40 - startTime + 1 seconds;
 
         // Calculate the end time. Needs to be "unchecked" to avoid an overflow.
         uint40 cliffTime;
@@ -38,7 +38,7 @@ contract CreateWithDurations_LockupLinear_Integration_Basic_Test is
             cliffTime = startTime + cliffDuration;
         }
 
-        // Expect a {StartTimeGreaterThanCliffTime} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupLinear_StartTimeGreaterThanCliffTime.selector, startTime, cliffTime
@@ -59,7 +59,7 @@ contract CreateWithDurations_LockupLinear_Integration_Basic_Test is
     {
         uint40 startTime = getBlockTimestamp();
         LockupLinear.Durations memory durations =
-            LockupLinear.Durations({ cliff: 0, total: MAX_UINT40 - startTime + 1 });
+            LockupLinear.Durations({ cliff: 0, total: MAX_UINT40 - startTime + 1 seconds });
 
         // Calculate the cliff time and the end time. Needs to be "unchecked" to avoid an overflow.
         uint40 cliffTime;
@@ -69,7 +69,7 @@ contract CreateWithDurations_LockupLinear_Integration_Basic_Test is
             endTime = startTime + durations.total;
         }
 
-        // Expect a {CliffTimeNotLessThanEndTime} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupLinear_CliffTimeNotLessThanEndTime.selector, cliffTime, endTime
@@ -110,7 +110,7 @@ contract CreateWithDurations_LockupLinear_Integration_Basic_Test is
         // Expect the broker fee to be paid to the broker.
         expectCallToTransferFrom({ from: funder, to: users.broker, amount: defaults.BROKER_FEE_AMOUNT() });
 
-        // Expect a {CreateLockupLinearStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupLinear) });
         emit CreateLockupLinearStream({
             streamId: streamId,

--- a/test/integration/basic/lockup-linear/create-with-range/createWithRange.t.sol
+++ b/test/integration/basic/lockup-linear/create-with-range/createWithRange.t.sol
@@ -197,7 +197,7 @@ contract CreateWithRange_LockupLinear_Integration_Basic_Test is
             amount: defaults.BROKER_FEE_AMOUNT()
         });
 
-        // Expect a {CreateLockupLinearStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupLinear) });
         emit CreateLockupLinearStream({
             streamId: streamId,

--- a/test/integration/basic/lockup/cancel-multiple/cancelMultiple.t.sol
+++ b/test/integration/basic/lockup/cancel-multiple/cancelMultiple.t.sol
@@ -220,7 +220,7 @@ abstract contract CancelMultiple_Integration_Basic_Test is Integration_Test, Can
         uint128 senderAmount1 = lockup.refundableAmountOf(testStreamIds[1]);
         expectCallToTransfer({ to: users.sender, amount: senderAmount1 });
 
-        // Expect multiple events to be emitted.
+        // Expect the relevant events to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit CancelLockupStream({
             streamId: testStreamIds[0],

--- a/test/integration/basic/lockup/cancel/cancel.t.sol
+++ b/test/integration/basic/lockup/cancel/cancel.t.sol
@@ -281,7 +281,7 @@ abstract contract Cancel_Integration_Basic_Test is Integration_Test, Cancel_Inte
             )
         );
 
-        // Expect a {CancelLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit CancelLockupStream(streamId, users.sender, address(goodRecipient), senderAmount, recipientAmount);
 
@@ -456,7 +456,7 @@ abstract contract Cancel_Integration_Basic_Test is Integration_Test, Cancel_Inte
             )
         );
 
-        // Expect a {CancelLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit CancelLockupStream(streamId, address(goodSender), users.recipient, senderAmount, recipientAmount);
 

--- a/test/integration/basic/lockup/claim-protocol-revenues/claimProtocolRevenues.t.sol
+++ b/test/integration/basic/lockup/claim-protocol-revenues/claimProtocolRevenues.t.sol
@@ -42,7 +42,7 @@ abstract contract ClaimProtocolRevenues_Integration_Basic_Test is Integration_Te
         uint128 protocolRevenues = defaults.PROTOCOL_FEE_AMOUNT();
         expectCallToTransfer({ to: users.admin, amount: protocolRevenues });
 
-        // Expect a {ClaimProtocolRevenues} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(base) });
         emit ClaimProtocolRevenues(users.admin, dai, protocolRevenues);
 

--- a/test/integration/basic/lockup/get-recipient/getRecipient.t.sol
+++ b/test/integration/basic/lockup/get-recipient/getRecipient.t.sol
@@ -36,7 +36,7 @@ abstract contract GetRecipient_Integration_Basic_Test is Integration_Test, Locku
         // Burn the NFT.
         lockup.burn(defaultStreamId);
 
-        // Expect an error when retrieving the recipient.
+        // Expect the relevant error when retrieving the recipient.
         vm.expectRevert("ERC721: invalid token ID");
         lockup.getRecipient(defaultStreamId);
     }

--- a/test/integration/basic/lockup/renounce/renounce.t.sol
+++ b/test/integration/basic/lockup/renounce/renounce.t.sol
@@ -125,7 +125,7 @@ abstract contract Renounce_Integration_Basic_Test is Integration_Test, Lockup_In
         // Create the stream with a no-op contract as the stream's recipient.
         uint256 streamId = createDefaultStreamWithRecipient(address(noop));
 
-        // Expect a call to hook.
+        // Expect a call to the hook.
         vm.expectCall(address(noop), abi.encodeCall(ISablierV2LockupRecipient.onStreamRenounced, (streamId)));
 
         // Renounce the stream.
@@ -152,7 +152,7 @@ abstract contract Renounce_Integration_Basic_Test is Integration_Test, Lockup_In
         // Create the stream with a reverting contract as the stream's recipient.
         uint256 streamId = createDefaultStreamWithRecipient(address(revertingRecipient));
 
-        // Expect a call to hook.
+        // Expect a call to the hook.
         vm.expectCall(
             address(revertingRecipient), abi.encodeCall(ISablierV2LockupRecipient.onStreamRenounced, (streamId))
         );
@@ -182,7 +182,7 @@ abstract contract Renounce_Integration_Basic_Test is Integration_Test, Lockup_In
         // Create the stream with a reentrant contract as the stream's recipient.
         uint256 streamId = createDefaultStreamWithRecipient(address(reentrantRecipient));
 
-        // Expect a call to hook.
+        // Expect a call to the hook.
         vm.expectCall(
             address(reentrantRecipient), abi.encodeCall(ISablierV2LockupRecipient.onStreamRenounced, (streamId))
         );
@@ -213,10 +213,10 @@ abstract contract Renounce_Integration_Basic_Test is Integration_Test, Lockup_In
         // Create the stream with a contract as the stream's recipient.
         uint256 streamId = createDefaultStreamWithRecipient(address(goodRecipient));
 
-        // Expect a call to hook.
+        // Expect a call to the hook.
         vm.expectCall(address(goodRecipient), abi.encodeCall(ISablierV2LockupRecipient.onStreamRenounced, (streamId)));
 
-        // Expect a {RenounceLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit RenounceLockupStream(streamId);
 

--- a/test/integration/basic/lockup/set-comptroller/setComptroller.t.sol
+++ b/test/integration/basic/lockup/set-comptroller/setComptroller.t.sol
@@ -27,7 +27,7 @@ abstract contract SetComptroller_Integration_Basic_Test is Integration_Test, Loc
     }
 
     function test_SetComptroller_SameComptroller() external whenCallerAdmin {
-        // Expect a {SetComptroller} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(base) });
         emit SetComptroller(users.admin, comptroller, comptroller);
 
@@ -44,7 +44,7 @@ abstract contract SetComptroller_Integration_Basic_Test is Integration_Test, Loc
         // Deploy the new comptroller.
         ISablierV2Comptroller newComptroller = new SablierV2Comptroller({ initialAdmin: users.admin });
 
-        // Expect a {SetComptroller} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(base) });
         emit SetComptroller(users.admin, comptroller, newComptroller);
 

--- a/test/integration/basic/lockup/set-nft-descriptor/setNFTDescriptor.t.sol
+++ b/test/integration/basic/lockup/set-nft-descriptor/setNFTDescriptor.t.sol
@@ -31,7 +31,7 @@ abstract contract SetNFTDescriptor_Integration_Basic_Test is Integration_Test, L
     }
 
     function test_SetNFTDescriptor_SameNFTDescriptor() external whenCallerAdmin {
-        // Expect a {SetNFTDescriptor} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit SetNFTDescriptor(users.admin, nftDescriptor, nftDescriptor);
 
@@ -47,7 +47,7 @@ abstract contract SetNFTDescriptor_Integration_Basic_Test is Integration_Test, L
         // Deploy the new NFT descriptor.
         ISablierV2NFTDescriptor newNFTDescriptor = new SablierV2NFTDescriptor();
 
-        // Expect a {SetNFTDescriptor} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit SetNFTDescriptor(users.admin, nftDescriptor, newNFTDescriptor);
 

--- a/test/integration/basic/lockup/withdraw-max/withdrawMax.t.sol
+++ b/test/integration/basic/lockup/withdraw-max/withdrawMax.t.sol
@@ -18,7 +18,7 @@ abstract contract WithdrawMax_Integration_Basic_Test is Integration_Test, Withdr
         // Expect the ERC-20 assets to be transferred to the Recipient.
         expectCallToTransfer({ to: users.recipient, amount: defaults.DEPOSIT_AMOUNT() });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({
             streamId: defaultStreamId,
@@ -59,7 +59,7 @@ abstract contract WithdrawMax_Integration_Basic_Test is Integration_Test, Withdr
         // Expect the assets to be transferred to the Recipient.
         expectCallToTransfer({ to: users.recipient, amount: withdrawAmount });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
 

--- a/test/integration/basic/lockup/withdraw-multiple/withdrawMultiple.t.sol
+++ b/test/integration/basic/lockup/withdraw-multiple/withdrawMultiple.t.sol
@@ -68,7 +68,7 @@ abstract contract WithdrawMultiple_Integration_Basic_Test is
         // Simulate the passage of time.
         vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
 
-        // Expect a {Null} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2Lockup_Null.selector, nullStreamId));
 
         // Withdraw from multiple streams.
@@ -91,7 +91,7 @@ abstract contract WithdrawMultiple_Integration_Basic_Test is
         // Deplete the first test stream.
         lockup.withdrawMax({ streamId: testStreamIds[0], to: users.recipient });
 
-        // Expect a {StreamDepleted} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2Lockup_StreamDepleted.selector, testStreamIds[0]));
 
         // Withdraw from multiple streams.
@@ -111,7 +111,7 @@ abstract contract WithdrawMultiple_Integration_Basic_Test is
         // Deplete the first test stream.
         lockup.withdrawMax({ streamId: testStreamIds[0], to: users.recipient });
 
-        // Expect a {StreamDepleted} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2Lockup_StreamDepleted.selector, testStreamIds[0]));
 
         // Withdraw from multiple streams.
@@ -295,7 +295,7 @@ abstract contract WithdrawMultiple_Integration_Basic_Test is
         expectCallToTransfer({ to: users.recipient, amount: testAmounts[1] });
         expectCallToTransfer({ to: users.recipient, amount: testAmounts[2] });
 
-        // Expect multiple events to be emitted.
+        // Expect the relevant events to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({ streamId: testStreamIds[0], to: users.recipient, amount: testAmounts[0] });
         vm.expectEmit({ emitter: address(lockup) });

--- a/test/integration/basic/lockup/withdraw/withdraw.t.sol
+++ b/test/integration/basic/lockup/withdraw/withdraw.t.sol
@@ -294,7 +294,7 @@ abstract contract Withdraw_Integration_Basic_Test is Integration_Test, Withdraw_
         // Expect the assets to be transferred to the Recipient.
         expectCallToTransfer({ to: users.recipient, amount: withdrawAmount });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
 
@@ -489,7 +489,7 @@ abstract contract Withdraw_Integration_Basic_Test is Integration_Test, Withdraw_
             )
         );
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
 

--- a/test/integration/fuzz/comptroller/setFlashFee.t.sol
+++ b/test/integration/fuzz/comptroller/setFlashFee.t.sol
@@ -13,7 +13,7 @@ contract SetFlashFee_Integration_Fuzz_Test is Integration_Test {
     function testFuzz_SetFlashFee(UD60x18 newFlashFee) external whenCallerAdmin {
         newFlashFee = _bound(newFlashFee, 0, MAX_FEE);
 
-        // Expect a {SetFlashFee} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit SetFlashFee({ admin: users.admin, oldFlashFee: ZERO, newFlashFee: newFlashFee });
 

--- a/test/integration/fuzz/comptroller/setProtocolFee.t.sol
+++ b/test/integration/fuzz/comptroller/setProtocolFee.t.sol
@@ -13,7 +13,7 @@ contract SetProtocolFee_Integration_Fuzz_Test is Integration_Test {
     function testFuzz_SetProtocolFee(UD60x18 newProtocolFee) external whenCallerAdmin {
         newProtocolFee = _bound(newProtocolFee, 1, MAX_FEE);
 
-        // Expect a {SetProtocolFee} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(comptroller) });
         emit SetProtocolFee({ admin: users.admin, asset: dai, oldProtocolFee: ZERO, newProtocolFee: newProtocolFee });
 

--- a/test/integration/fuzz/flash-loan/flashLoan.t.sol
+++ b/test/integration/fuzz/flash-loan/flashLoan.t.sol
@@ -85,7 +85,7 @@ contract FlashLoanFunction_Integration_Fuzz_Test is FlashLoanFunction_Integratio
         uint256 returnAmount = amount + fee;
         expectCallToTransferFrom({ from: address(goodFlashLoanReceiver), to: address(flashLoan), amount: returnAmount });
 
-        // Expect a {FlashLoan} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(flashLoan) });
         emit FlashLoan({
             initiator: users.admin,

--- a/test/integration/fuzz/lockup-dynamic/createWithDeltas.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/createWithDeltas.t.sol
@@ -82,7 +82,7 @@ contract CreateWithDeltas_LockupDynamic_Integration_Fuzz_Test is
             end: vars.segmentsWithMilestones[vars.segmentsWithMilestones.length - 1].milestone
         });
 
-        // Expect a {CreateLockupDynamicStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupDynamic) });
         emit CreateLockupDynamicStream({
             streamId: streamId,

--- a/test/integration/fuzz/lockup-dynamic/createWithMilestones.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/createWithMilestones.t.sol
@@ -74,7 +74,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Fuzz_Test is
         LockupDynamic.Segment[] memory segments = defaults.segments();
         segments[0].milestone = firstMilestone;
 
-        // Expect a {StartTimeNotLessThanFirstSegmentMilestone} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupDynamic_StartTimeNotLessThanFirstSegmentMilestone.selector,
@@ -116,7 +116,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Fuzz_Test is
         params.broker = Broker({ account: address(0), fee: brokerFee });
         params.totalAmount = depositAmount;
 
-        // Expect a {DepositAmountNotEqualToSegmentAmountsSum} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupDynamic_DepositAmountNotEqualToSegmentAmountsSum.selector,
@@ -266,7 +266,7 @@ contract CreateWithMilestones_LockupDynamic_Integration_Fuzz_Test is
             expectCallToTransferFrom({ from: funder, to: params.broker.account, amount: vars.createAmounts.brokerFee });
         }
 
-        // Expect a {CreateLockupDynamicStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupDynamic) });
         LockupDynamic.Range memory range =
             LockupDynamic.Range({ start: params.startTime, end: params.segments[params.segments.length - 1].milestone });

--- a/test/integration/fuzz/lockup-dynamic/withdraw.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/withdraw.t.sol
@@ -96,7 +96,7 @@ contract Withdraw_LockupDynamic_Integration_Fuzz_Test is
         // Expect the assets to be transferred to the fuzzed `to` address.
         expectCallToTransfer({ to: params.to, amount: vars.withdrawAmount });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupDynamic) });
         emit WithdrawFromLockupStream({ streamId: vars.streamId, to: params.to, amount: vars.withdrawAmount });
 

--- a/test/integration/fuzz/lockup-linear/createWithDurations.t.sol
+++ b/test/integration/fuzz/lockup-linear/createWithDurations.t.sol
@@ -25,7 +25,7 @@ contract CreateWithDurations_LockupLinear_Integration_Fuzz_Test is
         whenNotDelegateCalled
     {
         uint40 startTime = getBlockTimestamp();
-        cliffDuration = boundUint40(cliffDuration, MAX_UINT40 - startTime + 1, MAX_UINT40);
+        cliffDuration = boundUint40(cliffDuration, MAX_UINT40 - startTime + 1 seconds, MAX_UINT40);
 
         // Calculate the end time. Needs to be "unchecked" to avoid an overflow.
         uint40 cliffTime;
@@ -33,7 +33,7 @@ contract CreateWithDurations_LockupLinear_Integration_Fuzz_Test is
             cliffTime = startTime + cliffDuration;
         }
 
-        // Expect a {StartTimeGreaterThanCliffTime} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupLinear_StartTimeGreaterThanCliffTime.selector, startTime, cliffTime
@@ -54,7 +54,7 @@ contract CreateWithDurations_LockupLinear_Integration_Fuzz_Test is
     {
         uint40 startTime = getBlockTimestamp();
         durations.cliff = boundUint40(durations.cliff, 0, MAX_UINT40 - startTime);
-        durations.total = boundUint40(durations.total, MAX_UINT40 - startTime + 1, MAX_UINT40);
+        durations.total = boundUint40(durations.total, MAX_UINT40 - startTime + 1 seconds, MAX_UINT40);
 
         // Calculate the cliff time and the end time. Needs to be "unchecked" to avoid an overflow.
         uint40 cliffTime;
@@ -64,7 +64,7 @@ contract CreateWithDurations_LockupLinear_Integration_Fuzz_Test is
             endTime = startTime + durations.total;
         }
 
-        // Expect a {CliffTimeNotLessThanEndTime} error.
+        // Expect the relevant error to be thrown.
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2LockupLinear_CliffTimeNotLessThanEndTime.selector, cliffTime, endTime
@@ -107,7 +107,7 @@ contract CreateWithDurations_LockupLinear_Integration_Fuzz_Test is
             end: getBlockTimestamp() + durations.total
         });
 
-        // Expect a {CreateLockupLinearStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupLinear) });
         emit CreateLockupLinearStream({
             streamId: streamId,

--- a/test/integration/fuzz/lockup-linear/createWithRange.t.sol
+++ b/test/integration/fuzz/lockup-linear/createWithRange.t.sol
@@ -182,7 +182,7 @@ contract CreateWithRange_LockupLinear_Integration_Fuzz_Test is
             expectCallToTransferFrom({ from: funder, to: params.broker.account, amount: vars.createAmounts.brokerFee });
         }
 
-        // Expect a {CreateLockupLinearStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockupLinear) });
         emit CreateLockupLinearStream({
             streamId: streamId,

--- a/test/integration/fuzz/lockup/cancel.t.sol
+++ b/test/integration/fuzz/lockup/cancel.t.sol
@@ -79,7 +79,7 @@ abstract contract Cancel_Integration_Fuzz_Test is Integration_Test, Cancel_Integ
         uint128 senderAmount = lockup.refundableAmountOf(streamId);
         expectCallToTransfer({ to: users.sender, amount: senderAmount });
 
-        // Expect a {CancelLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         uint128 recipientAmount = lockup.withdrawableAmountOf(streamId);
         vm.expectEmit({ emitter: address(lockup) });
         emit CancelLockupStream(streamId, users.sender, address(goodRecipient), senderAmount, recipientAmount);
@@ -144,7 +144,7 @@ abstract contract Cancel_Integration_Fuzz_Test is Integration_Test, Cancel_Integ
         uint128 senderAmount = lockup.refundableAmountOf(streamId);
         expectCallToTransfer({ to: address(goodSender), amount: senderAmount });
 
-        // Expect a {CancelLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         uint128 recipientAmount = lockup.withdrawableAmountOf(streamId);
         vm.expectEmit({ emitter: address(lockup) });
         emit CancelLockupStream(streamId, address(goodSender), users.recipient, senderAmount, recipientAmount);

--- a/test/integration/fuzz/lockup/cancelMultiple.t.sol
+++ b/test/integration/fuzz/lockup/cancelMultiple.t.sol
@@ -42,7 +42,7 @@ abstract contract CancelMultiple_Integration_Fuzz_Test is Integration_Test, Canc
         uint128 senderAmount1 = lockup.refundableAmountOf(streamIds[1]);
         expectCallToTransfer({ to: users.sender, amount: senderAmount1 });
 
-        // Expect multiple events to be emitted.
+        // Expect the relevant events to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit CancelLockupStream({
             streamId: streamIds[0],

--- a/test/integration/fuzz/lockup/withdraw.t.sol
+++ b/test/integration/fuzz/lockup/withdraw.t.sol
@@ -85,7 +85,7 @@ abstract contract Withdraw_Integration_Fuzz_Test is Integration_Test, Withdraw_I
         // Expect the assets to be transferred to the fuzzed `to` address.
         expectCallToTransfer({ to: to, amount: withdrawAmount });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream(defaultStreamId, to, withdrawAmount);
 
@@ -147,7 +147,7 @@ abstract contract Withdraw_Integration_Fuzz_Test is Integration_Test, Withdraw_I
         // Expect the assets to be transferred to the fuzzed `to` address.
         expectCallToTransfer({ to: to, amount: withdrawAmount });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream(defaultStreamId, to, withdrawAmount);
 

--- a/test/integration/fuzz/lockup/withdrawMax.t.sol
+++ b/test/integration/fuzz/lockup/withdrawMax.t.sol
@@ -20,7 +20,7 @@ abstract contract WithdrawMax_Integration_Fuzz_Test is Integration_Test, Withdra
         // Expect the ERC-20 assets to be transferred to the Recipient.
         expectCallToTransfer({ to: users.recipient, amount: defaults.DEPOSIT_AMOUNT() });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({
             streamId: defaultStreamId,
@@ -63,7 +63,7 @@ abstract contract WithdrawMax_Integration_Fuzz_Test is Integration_Test, Withdra
         // Expect the assets to be transferred to the Recipient.
         expectCallToTransfer({ to: users.recipient, amount: withdrawAmount });
 
-        // Expect a {WithdrawFromLockupStream} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({ streamId: defaultStreamId, to: users.recipient, amount: withdrawAmount });
 

--- a/test/integration/fuzz/lockup/withdrawMultiple.t.sol
+++ b/test/integration/fuzz/lockup/withdrawMultiple.t.sol
@@ -63,7 +63,7 @@ abstract contract WithdrawMultiple_Integration_Fuzz_Test is
         expectCallToTransfer({ to: to, amount: ongoingWithdrawAmount });
         expectCallToTransfer({ to: to, amount: settledWithdrawAmount });
 
-        // Expect multiple events to be emitted.
+        // Expect the relevant events to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit WithdrawFromLockupStream({ streamId: ongoingStreamId, to: to, amount: ongoingWithdrawAmount });
         vm.expectEmit({ emitter: address(lockup) });

--- a/test/unit/basic/adminable/transfer-admin/transferAdmin.t.sol
+++ b/test/unit/basic/adminable/transfer-admin/transferAdmin.t.sol
@@ -20,7 +20,7 @@ contract TransferAdmin_Unit_Basic_Test is Adminable_Unit_Shared_Test {
     }
 
     function test_TransferAdmin_SameAdmin() external whenCallerAdmin {
-        // Expect a {TransferAdmin} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(adminableMock) });
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.admin });
 
@@ -34,7 +34,7 @@ contract TransferAdmin_Unit_Basic_Test is Adminable_Unit_Shared_Test {
     }
 
     function test_TransferAdmin_ZeroAddress() external whenCallerAdmin {
-        // Expect a {TransferAdmin} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(adminableMock) });
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: address(0) });
 
@@ -52,7 +52,7 @@ contract TransferAdmin_Unit_Basic_Test is Adminable_Unit_Shared_Test {
     }
 
     function test_TransferAdmin_NewAdmin() external whenCallerAdmin whenNotZeroAddress {
-        // Expect a {TransferAdmin} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(adminableMock) });
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.alice });
 

--- a/test/unit/basic/comptroller/constructor.t.sol
+++ b/test/unit/basic/comptroller/constructor.t.sol
@@ -7,7 +7,7 @@ import { Base_Test } from "../../../Base.t.sol";
 
 contract Constructor_Comptroller_Unit_Basic_Test is Base_Test {
     function test_Constructor() external {
-        // Expect a {TransferAdmin} to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit();
         emit TransferAdmin({ oldAdmin: address(0), newAdmin: users.admin });
 

--- a/test/unit/fuzz/transferAdmin.t.sol
+++ b/test/unit/fuzz/transferAdmin.t.sol
@@ -25,7 +25,7 @@ contract TransferAdmin_Unit_Fuzz_Test is Adminable_Unit_Shared_Test {
     function testFuzz_TransferAdmin(address newAdmin) external whenCallerAdmin {
         vm.assume(newAdmin != address(0));
 
-        // Expect a {TransferAdmin} event to be emitted.
+        // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(adminableMock) });
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: newAdmin });
 

--- a/test/utils/Fuzzers.sol
+++ b/test/utils/Fuzzers.sol
@@ -144,7 +144,7 @@ abstract contract Fuzzers is Constants, Utils {
 
         // The first milestones is precomputed to avoid an underflow in the first loop iteration. We have to
         // add 1 because the first milestone must be greater than the start time.
-        segments[0].milestone = startTime + 1;
+        segments[0].milestone = startTime + 1 seconds;
 
         // Fuzz the milestones while preserving their order in the array. For each milestone, set its initial guess
         // as the sum of the starting milestone and the step size multiplied by the current index. This ensures that


### PR DESCRIPTION
This PR lowers the maintenance overhead by removing the event/ error name in the comment, which doesn't provide any value because the event/ error is literally written two lines below.