### PR TITLE
refactor: remove unused imports

### DIFF
--- a/script/DeployDeterministicLockupDynamic.s.sol
+++ b/script/DeployDeterministicLockupDynamic.s.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.19 <=0.9.0;
 
-import { UD60x18 } from "@prb/math/UD60x18.sol";
-
 import { ISablierV2Comptroller } from "../src/interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2NFTDescriptor } from "../src/interfaces/ISablierV2NFTDescriptor.sol";
 import { SablierV2LockupDynamic } from "../src/SablierV2LockupDynamic.sol";

--- a/script/DeployDeterministicLockupLinear.s.sol
+++ b/script/DeployDeterministicLockupLinear.s.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.19 <=0.9.0;
 
-import { UD60x18 } from "@prb/math/UD60x18.sol";
-
 import { ISablierV2Comptroller } from "../src/interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2NFTDescriptor } from "../src/interfaces/ISablierV2NFTDescriptor.sol";
 import { SablierV2LockupLinear } from "../src/SablierV2LockupLinear.sol";

--- a/script/DeployLockupDynamic.s.sol
+++ b/script/DeployLockupDynamic.s.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.19 <=0.9.0;
 
-import { UD60x18 } from "@prb/math/UD60x18.sol";
-
 import { ISablierV2Comptroller } from "../src/interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2NFTDescriptor } from "../src/interfaces/ISablierV2NFTDescriptor.sol";
 import { SablierV2LockupDynamic } from "../src/SablierV2LockupDynamic.sol";

--- a/script/DeployLockupLinear.s.sol
+++ b/script/DeployLockupLinear.s.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.19 <=0.9.0;
 
-import { UD60x18 } from "@prb/math/UD60x18.sol";
-
 import { ISablierV2Comptroller } from "../src/interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2NFTDescriptor } from "../src/interfaces/ISablierV2NFTDescriptor.sol";
 import { SablierV2LockupLinear } from "../src/SablierV2LockupLinear.sol";

--- a/src/SablierV2LockupDynamic.sol
+++ b/src/SablierV2LockupDynamic.sol
@@ -331,7 +331,7 @@ contract SablierV2LockupDynamic is
     ///
     /// 1. Normalization to 18 decimals is not needed because there is no mix of amounts with different decimals.
     /// 2. The stream's start time must be in the past so that the calculations below do not overflow.
-    /// 3. The stream's end time must be in the future so that the the loop below does not panic with an "index out of
+    /// 3. The stream's end time must be in the future so that the loop below does not panic with an "index out of
     /// bounds" error.
     function _calculateStreamedAmountForMultipleSegments(uint256 streamId) internal view returns (uint128) {
         unchecked {

--- a/src/interfaces/hooks/ISablierV2LockupRecipient.sol
+++ b/src/interfaces/hooks/ISablierV2LockupRecipient.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.19;
 
-import { ISablierV2Lockup } from "../ISablierV2Lockup.sol";
-
 /// @title ISablierV2LockupRecipient
 /// @notice Interface for recipient contracts capable of reacting to cancellations, renouncements, and withdrawals.
 /// @dev Implementation of this interface is optional. If a recipient contract doesn't implement this

--- a/src/interfaces/hooks/ISablierV2LockupSender.sol
+++ b/src/interfaces/hooks/ISablierV2LockupSender.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.19;
 
-import { ISablierV2Lockup } from "../ISablierV2Lockup.sol";
-
 /// @title ISablierV2LockupSender
 /// @notice Interface for sender contracts capable of reacting to cancellations.
 /// @dev Implementation of this interface is optional. If a sender contract doesn't implement this interface,

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -16,7 +16,6 @@ import { SablierV2NFTDescriptor } from "../src/SablierV2NFTDescriptor.sol";
 
 import { ERC20MissingReturn } from "./mocks/erc20/ERC20MissingReturn.sol";
 import { GoodFlashLoanReceiver } from "./mocks/flash-loan/GoodFlashLoanReceiver.sol";
-import { NFTDescriptorMock } from "./mocks/NFTDescriptorMock.sol";
 import { Noop } from "./mocks/Noop.sol";
 import { GoodRecipient } from "./mocks/hooks/GoodRecipient.sol";
 import { GoodSender } from "./mocks/hooks/GoodSender.sol";

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -4,10 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { SablierV2Comptroller } from "src/SablierV2Comptroller.sol";
-import { SablierV2LockupDynamic } from "src/SablierV2LockupDynamic.sol";
-import { SablierV2LockupLinear } from "src/SablierV2LockupLinear.sol";
-
 import { Base_Test } from "../Base.t.sol";
 
 /// @notice Common logic needed by all fork tests.

--- a/test/fork/LockupDynamic.t.sol
+++ b/test/fork/LockupDynamic.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { UD60x18, ud } from "@prb/math/UD60x18.sol";
+import { UD60x18 } from "@prb/math/UD60x18.sol";
 import { Solarray } from "solarray/Solarray.sol";
 
 import { Broker, Lockup, LockupDynamic } from "src/types/DataTypes.sol";

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { Errors } from "src/libraries/Errors.sol";
 
 import { Base_Test } from "../Base.t.sol";
-import { Noop } from "../mocks/Noop.sol";
 import { FaultyFlashLoanReceiver } from "../mocks/flash-loan/FaultyFlashLoanReceiver.sol";
 import { ReentrantFlashLoanReceiver } from "../mocks/flash-loan/ReentrantFlashLoanReceiver.sol";
 import { ReentrantRecipient } from "../mocks/hooks/ReentrantRecipient.sol";

--- a/test/integration/basic/comptroller/set-protocol-fee/setProtocolFee.t.sol
+++ b/test/integration/basic/comptroller/set-protocol-fee/setProtocolFee.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";

--- a/test/integration/basic/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
+++ b/test/integration/basic/comptroller/toggle-flash-asset/toggleFlashAsset.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
-
 import { Errors } from "src/libraries/Errors.sol";
 
 import { Integration_Test } from "../../../Integration.t.sol";

--- a/test/integration/basic/flash-loan/flash-fee/flashFee.t.sol
+++ b/test/integration/basic/flash-loan/flash-fee/flashFee.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UD60x18, ud } from "@prb/math/UD60x18.sol";
+import { ud } from "@prb/math/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
 

--- a/test/integration/basic/flash-loan/flash-loan/flashLoan.t.sol
+++ b/test/integration/basic/flash-loan/flash-loan/flashLoan.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19;
 
-import { UD60x18, ud } from "@prb/math/UD60x18.sol";
+import { ud } from "@prb/math/UD60x18.sol";
 
 import { IERC3156FlashLender } from "src/interfaces/erc3156/IERC3156FlashLender.sol";
 import { Errors } from "src/libraries/Errors.sol";

--- a/test/integration/basic/flash-loan/max-flash-loan/maxFlashLoan.t.sol
+++ b/test/integration/basic/flash-loan/max-flash-loan/maxFlashLoan.t.sol
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UD60x18, ud, ZERO } from "@prb/math/UD60x18.sol";
-
-import { Errors } from "src/libraries/Errors.sol";
-
 import { FlashLoan_Integration_Shared_Test } from "../../../shared/flash-loan/FlashLoan.t.sol";
 
 contract MaxFlashLoan_Integration_Basic_Test is FlashLoan_Integration_Shared_Test {

--- a/test/integration/basic/lockup-dynamic/LockupDynamic.t.sol
+++ b/test/integration/basic/lockup-dynamic/LockupDynamic.t.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-import { ISablierV2Base } from "src/interfaces/ISablierV2Base.sol";
 import { ISablierV2Lockup } from "src/interfaces/ISablierV2Lockup.sol";
 
 import { LockupDynamic_Integration_Shared_Test } from "../../shared/lockup-dynamic/LockupDynamic.t.sol";

--- a/test/integration/basic/lockup-dynamic/constructor.t.sol
+++ b/test/integration/basic/lockup-dynamic/constructor.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UD60x18 } from "@prb/math/UD60x18.sol";
-
 import { SablierV2LockupDynamic } from "src/SablierV2LockupDynamic.sol";
 
 import { LockupDynamic_Integration_Basic_Test } from "./LockupDynamic.t.sol";

--- a/test/integration/basic/lockup-dynamic/create-with-milestones/createWithMilestones.t.sol
+++ b/test/integration/basic/lockup-dynamic/create-with-milestones/createWithMilestones.t.sol
@@ -2,8 +2,7 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { MAX_UD60x18, UD60x18, ud, ZERO } from "@prb/math/UD60x18.sol";
-import { UD2x18 } from "@prb/math/UD2x18.sol";
+import { UD60x18, ud, ZERO } from "@prb/math/UD60x18.sol";
 import { stdError } from "forge-std/StdError.sol";
 
 import { Errors } from "src/libraries/Errors.sol";

--- a/test/integration/basic/lockup-dynamic/streamed-amount-of/streamedAmountOf.t.sol
+++ b/test/integration/basic/lockup-dynamic/streamed-amount-of/streamedAmountOf.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Errors } from "src/libraries/Errors.sol";
 import { LockupDynamic } from "src/types/DataTypes.sol";
 
 import { LockupDynamic_Integration_Basic_Test } from "../LockupDynamic.t.sol";

--- a/test/integration/basic/lockup-dynamic/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/test/integration/basic/lockup-dynamic/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Errors } from "src/libraries/Errors.sol";
-
 import { LockupDynamic_Integration_Basic_Test } from "../LockupDynamic.t.sol";
 import { WithdrawableAmountOf_Integration_Basic_Test } from
     "../../lockup/withdrawable-amount-of/withdrawableAmountOf.t.sol";

--- a/test/integration/basic/lockup-linear/LockupLinear.t.sol
+++ b/test/integration/basic/lockup-linear/LockupLinear.t.sol
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import { ISablierV2Base } from "src/interfaces/ISablierV2Base.sol";
 import { ISablierV2Lockup } from "src/interfaces/ISablierV2Lockup.sol";
-import { SablierV2LockupLinear } from "src/SablierV2LockupLinear.sol";
 
 import { LockupLinear_Integration_Shared_Test } from "../../shared/lockup-linear/LockupLinear.t.sol";
 import { Integration_Test } from "../../Integration.t.sol";

--- a/test/integration/basic/lockup-linear/constructor.t.sol
+++ b/test/integration/basic/lockup-linear/constructor.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UD60x18 } from "@prb/math/UD60x18.sol";
-
 import { SablierV2LockupLinear } from "src/SablierV2LockupLinear.sol";
 
 import { LockupLinear_Integration_Basic_Test } from "./LockupLinear.t.sol";

--- a/test/integration/basic/lockup-linear/streamed-amount-of/streamedAmountOf.t.sol
+++ b/test/integration/basic/lockup-linear/streamed-amount-of/streamedAmountOf.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Errors } from "src/libraries/Errors.sol";
-
 import { LockupLinear_Integration_Basic_Test } from "../LockupLinear.t.sol";
 import { StreamedAmountOf_Integration_Basic_Test } from "../../lockup/streamed-amount-of/streamedAmountOf.t.sol";
 

--- a/test/integration/basic/lockup-linear/withdrawable-amount-of/withdrawableAmountOf.t.sol
+++ b/test/integration/basic/lockup-linear/withdrawable-amount-of/withdrawableAmountOf.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Errors } from "src/libraries/Errors.sol";
-
 import { LockupLinear_Integration_Basic_Test } from "../LockupLinear.t.sol";
 import { WithdrawableAmountOf_Integration_Basic_Test } from
     "../../lockup/withdrawable-amount-of/withdrawableAmountOf.t.sol";

--- a/test/integration/basic/lockup/get-recipient/getRecipient.t.sol
+++ b/test/integration/basic/lockup/get-recipient/getRecipient.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Errors } from "src/libraries/Errors.sol";
-
 import { Lockup_Integration_Shared_Test } from "../../../shared/lockup/Lockup.t.sol";
 import { Integration_Test } from "../../../Integration.t.sol";
 

--- a/test/integration/basic/lockup/withdraw-max-and-transfer/withdrawMaxAndTransfer.t.sol
+++ b/test/integration/basic/lockup/withdraw-max-and-transfer/withdrawMaxAndTransfer.t.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { ISablierV2Lockup } from "src/interfaces/ISablierV2Lockup.sol";
 import { Errors } from "src/libraries/Errors.sol";
-import { Lockup } from "src/types/DataTypes.sol";
 
 import { WithdrawMaxAndTransfer_Integration_Shared_Test } from "../../../shared/lockup/withdrawMaxAndTransfer.t.sol";
 import { Integration_Test } from "../../../Integration.t.sol";

--- a/test/integration/fuzz/flash-loan/flashLoan.t.sol
+++ b/test/integration/fuzz/flash-loan/flashLoan.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19;
 
-import { MAX_UD60x18, UD60x18, ud } from "@prb/math/UD60x18.sol";
+import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 
 import { IERC3156FlashBorrower } from "src/interfaces/erc3156/IERC3156FlashBorrower.sol";
 import { Errors } from "src/libraries/Errors.sol";

--- a/test/integration/fuzz/flash-loan/maxFlashLoan.t.sol
+++ b/test/integration/fuzz/flash-loan/maxFlashLoan.t.sol
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UD60x18, ud, ZERO } from "@prb/math/UD60x18.sol";
-
-import { Errors } from "src/libraries/Errors.sol";
-
 import { FlashLoan_Integration_Shared_Test } from "../../shared/flash-loan/FlashLoan.t.sol";
 
 contract MaxFlashLoan_Integration_Fuzz_Test is FlashLoan_Integration_Shared_Test {

--- a/test/integration/fuzz/lockup-dynamic/LockupDynamic.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/LockupDynamic.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import { ISablierV2Base } from "src/interfaces/ISablierV2Base.sol";
 import { ISablierV2Lockup } from "src/interfaces/ISablierV2Lockup.sol";
 
@@ -12,7 +10,6 @@ import { Cancel_Integration_Fuzz_Test } from "../lockup/cancel.t.sol";
 import { CancelMultiple_Integration_Fuzz_Test } from "../lockup/cancelMultiple.t.sol";
 import { GetWithdrawnAmount_Integration_Fuzz_Test } from "../lockup/getWithdrawnAmount.t.sol";
 import { RefundableAmountOf_Integration_Fuzz_Test } from "../lockup/refundableAmountOf.t.sol";
-import { Withdraw_Integration_Fuzz_Test } from "../lockup/withdraw.t.sol";
 import { WithdrawMax_Integration_Fuzz_Test } from "../lockup/withdrawMax.t.sol";
 import { WithdrawMaxAndTransfer_Integration_Fuzz_Test } from "../lockup/withdrawMaxAndTransfer.t.sol";
 import { WithdrawMultiple_Integration_Fuzz_Test } from "../lockup/withdrawMultiple.t.sol";

--- a/test/integration/fuzz/lockup-dynamic/createWithDeltas.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/createWithDeltas.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Errors } from "src/libraries/Errors.sol";
 import { Lockup, LockupDynamic } from "src/types/DataTypes.sol";
 
 import { CreateWithDeltas_Integration_Shared_Test } from "../../shared/lockup-dynamic/createWithDeltas.t.sol";

--- a/test/integration/fuzz/lockup-dynamic/createWithMilestones.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/createWithMilestones.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19 <0.9.0;
 import { MAX_UD60x18, UD60x18, ud, ZERO } from "@prb/math/UD60x18.sol";
 import { stdError } from "forge-std/StdError.sol";
 
-import { ISablierV2LockupDynamic } from "src/interfaces/ISablierV2LockupDynamic.sol";
 import { Errors } from "src/libraries/Errors.sol";
 import { Broker, Lockup, LockupDynamic } from "src/types/DataTypes.sol";
 

--- a/test/integration/fuzz/lockup-dynamic/withdraw.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/withdraw.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Broker, Lockup, LockupDynamic } from "src/types/DataTypes.sol";
+import { Lockup, LockupDynamic } from "src/types/DataTypes.sol";
 
 import { Withdraw_Integration_Fuzz_Test } from "../lockup/withdraw.t.sol";
 import { LockupDynamic_Integration_Fuzz_Test } from "./LockupDynamic.t.sol";

--- a/test/integration/fuzz/lockup-linear/LockupLinear.t.sol
+++ b/test/integration/fuzz/lockup-linear/LockupLinear.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import { ISablierV2Base } from "src/interfaces/ISablierV2Base.sol";
 import { ISablierV2Lockup } from "src/interfaces/ISablierV2Lockup.sol";
 

--- a/test/integration/fuzz/lockup-linear/withdrawableAmountOf.t.sol
+++ b/test/integration/fuzz/lockup-linear/withdrawableAmountOf.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
+import { ZERO } from "@prb/math/UD60x18.sol";
 
 import { Broker, LockupLinear } from "src/types/DataTypes.sol";
 

--- a/test/integration/fuzz/lockup/withdraw.t.sol
+++ b/test/integration/fuzz/lockup/withdraw.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ISablierV2LockupRecipient } from "src/interfaces/hooks/ISablierV2LockupRecipient.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { Withdraw_Integration_Shared_Test } from "../../shared/lockup/withdraw.t.sol";

--- a/test/integration/fuzz/lockup/withdrawMaxAndTransfer.t.sol
+++ b/test/integration/fuzz/lockup/withdrawMaxAndTransfer.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Lockup } from "src/types/DataTypes.sol";
-
 import { WithdrawMaxAndTransfer_Integration_Shared_Test } from "../../shared/lockup/withdrawMaxAndTransfer.t.sol";
 import { Integration_Test } from "../../Integration.t.sol";
 

--- a/test/integration/fuzz/lockup/withdrawMultiple.t.sol
+++ b/test/integration/fuzz/lockup/withdrawMultiple.t.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { Solarray } from "solarray/Solarray.sol";
 
-import { Errors } from "src/libraries/Errors.sol";
 import { Lockup } from "src/types/DataTypes.sol";
 
 import { WithdrawMultiple_Integration_Shared_Test } from "../../shared/lockup/withdrawMultiple.t.sol";

--- a/test/invariant/Invariant.t.sol
+++ b/test/invariant/Invariant.t.sol
@@ -3,8 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { StdInvariant } from "forge-std/StdInvariant.sol";
 
-import { SablierV2Comptroller } from "src/SablierV2Comptroller.sol";
-
 import { Base_Test } from "../Base.t.sol";
 import { ComptrollerHandler } from "./handlers/ComptrollerHandler.sol";
 import { TimestampStore } from "./stores/TimestampStore.sol";

--- a/test/invariant/LockupDynamic.t.sol
+++ b/test/invariant/LockupDynamic.t.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { SablierV2LockupDynamic } from "src/SablierV2LockupDynamic.sol";
 import { Lockup, LockupDynamic } from "src/types/DataTypes.sol";
 
 import { Lockup_Invariant_Test } from "./Lockup.t.sol";
 import { LockupDynamicCreateHandler } from "./handlers/LockupDynamicCreateHandler.sol";
 import { LockupDynamicHandler } from "./handlers/LockupDynamicHandler.sol";
 
-/// @dev Invariant tests for for {SablierV2LockupDynamic}.
+/// @dev Invariant tests for {SablierV2LockupDynamic}.
 contract LockupDynamic_Invariant_Test is Lockup_Invariant_Test {
     /*//////////////////////////////////////////////////////////////////////////
                                    TEST CONTRACTS

--- a/test/invariant/LockupLinear.t.sol
+++ b/test/invariant/LockupLinear.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { SablierV2LockupLinear } from "src/SablierV2LockupLinear.sol";
 import { Lockup, LockupLinear } from "src/types/DataTypes.sol";
 
 import { Lockup_Invariant_Test } from "./Lockup.t.sol";

--- a/test/invariant/handlers/LockupDynamicCreateHandler.sol
+++ b/test/invariant/handlers/LockupDynamicCreateHandler.sol
@@ -2,11 +2,10 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { UD60x18 } from "@prb/math/UD60x18.sol";
 
 import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2LockupDynamic } from "src/interfaces/ISablierV2LockupDynamic.sol";
-import { Lockup, LockupDynamic } from "src/types/DataTypes.sol";
+import { LockupDynamic } from "src/types/DataTypes.sol";
 
 import { LockupStore } from "../stores/LockupStore.sol";
 import { TimestampStore } from "../stores/TimestampStore.sol";

--- a/test/invariant/handlers/LockupLinearCreateHandler.sol
+++ b/test/invariant/handlers/LockupLinearCreateHandler.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.19 <0.9.0;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { ISablierV2LockupLinear } from "src/interfaces/ISablierV2LockupLinear.sol";
-import { Broker, LockupLinear } from "src/types/DataTypes.sol";
+import { LockupLinear } from "src/types/DataTypes.sol";
 
 import { TimestampStore } from "../stores/TimestampStore.sol";
 import { LockupStore } from "../stores/LockupStore.sol";

--- a/test/invariant/stores/TimestampStore.sol
+++ b/test/invariant/stores/TimestampStore.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { Lockup } from "src/types/DataTypes.sol";
-
 /// @dev Because Foundry does not commit the state changes between invariant runs, we need to
 /// save the current timestamp in a contract with persistent storage.
 contract TimestampStore {

--- a/test/mocks/NFTDescriptorMock.sol
+++ b/test/mocks/NFTDescriptorMock.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19;
 
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
-import { Errors } from "../../src/libraries/Errors.sol";
 import { NFTSVG } from "../../src/libraries/NFTSVG.sol";
 import { SVGElements } from "../../src/libraries/SVGElements.sol";
 import { Lockup } from "../../src/types/DataTypes.sol";

--- a/test/unit/basic/nft-descriptor/calculatePixelWidth.t.sol
+++ b/test/unit/basic/nft-descriptor/calculatePixelWidth.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { SVGElements } from "src/libraries/SVGElements.sol";
-
 import { NFTDescriptor_Unit_Basic_Test } from "./NFTDescriptor.t.sol";
 
 contract CalculatePixelWidth_Unit_Basic_Test is NFTDescriptor_Unit_Basic_Test {

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.19;
 import { PRBMathCastingUint128 as CastingUint128 } from "@prb/math/casting/Uint128.sol";
 import { PRBMathCastingUint40 as CastingUint40 } from "@prb/math/casting/Uint40.sol";
 import { SD59x18 } from "@prb/math/SD59x18.sol";
-import { UD2x18 } from "@prb/math/UD2x18.sol";
 import { UD60x18, ud } from "@prb/math/UD60x18.sol";
 
 import { LockupDynamic } from "../../src/types/DataTypes.sol";

--- a/test/utils/Fuzzers.sol
+++ b/test/utils/Fuzzers.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.19;
 
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { PRBMathCastingUint128 as CastingUint128 } from "@prb/math/casting/Uint128.sol";
 import { UD60x18, ud, uUNIT } from "@prb/math/UD60x18.sol";
 

--- a/test/utils/Precompiles.t.sol
+++ b/test/utils/Precompiles.t.sol
@@ -7,7 +7,6 @@ import { ISablierV2Comptroller } from "../../src/interfaces/ISablierV2Comptrolle
 import { ISablierV2LockupDynamic } from "../../src/interfaces/ISablierV2LockupDynamic.sol";
 import { ISablierV2LockupLinear } from "../../src/interfaces/ISablierV2LockupLinear.sol";
 import { ISablierV2NFTDescriptor } from "../../src/interfaces/ISablierV2NFTDescriptor.sol";
-import { SablierV2NFTDescriptor } from "../../src/SablierV2NFTDescriptor.sol";
 
 import { Base_Test } from "../Base.t.sol";
 import { Precompiles } from "./Precompiles.sol";

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19;
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { PRBMathUtils } from "@prb/math/test/Utils.sol";
-import { SD59x18 } from "@prb/math/SD59x18.sol";
 
 import { Vm } from "@prb/test/PRBTest.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";


### PR DESCRIPTION
I ran [`solhint-community`](https://github.com/sablier-labs/v2-core/issues/548) via the command-line to detect these unused imports, although I did not install it due to the reasons explained [here](https://github.com/sablier-labs/v2-core/issues/548#issuecomment-1611182578).