### PR TITLE
refactor: stringify create2 salts

### DIFF
--- a/script/DeployDeterministicComptroller.s.sol
+++ b/script/DeployDeterministicComptroller.s.sol
@@ -11,7 +11,7 @@ contract DeployDeterministicComptroller is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         address initialAdmin
     )
         public
@@ -19,6 +19,6 @@ contract DeployDeterministicComptroller is BaseScript {
         broadcaster
         returns (SablierV2Comptroller comptroller)
     {
-        comptroller = new SablierV2Comptroller{ salt: bytes32(create2Salt) }(initialAdmin);
+        comptroller = new SablierV2Comptroller{ salt: bytes32(abi.encodePacked(create2Salt)) }(initialAdmin);
     }
 }

--- a/script/DeployDeterministicCore.s.sol
+++ b/script/DeployDeterministicCore.s.sol
@@ -20,7 +20,7 @@ contract DeployDeterministicCore is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy the contract via a deterministic CREATE2 factory.
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         address initialAdmin,
         uint256 maxSegmentCount
     )
@@ -34,15 +34,16 @@ contract DeployDeterministicCore is BaseScript {
             SablierV2NFTDescriptor nftDescriptor
         )
     {
-        comptroller = new SablierV2Comptroller{ salt: bytes32(create2Salt)}(initialAdmin);
-        nftDescriptor = new SablierV2NFTDescriptor{ salt: bytes32(create2Salt)}();
+        bytes32 salt = bytes32(abi.encodePacked(create2Salt));
+        comptroller = new SablierV2Comptroller{ salt: salt}(initialAdmin);
+        nftDescriptor = new SablierV2NFTDescriptor{ salt: salt}();
         // forgefmt: disable-next-line
-        lockupDynamic = new SablierV2LockupDynamic{ salt: bytes32(create2Salt)}(
+        lockupDynamic = new SablierV2LockupDynamic{ salt: salt}(
             initialAdmin,
             comptroller,
             nftDescriptor,
             maxSegmentCount
         );
-        lockupLinear = new SablierV2LockupLinear{ salt: bytes32(create2Salt)}(initialAdmin, comptroller, nftDescriptor);
+        lockupLinear = new SablierV2LockupLinear{ salt: salt}(initialAdmin, comptroller, nftDescriptor);
     }
 }

--- a/script/DeployDeterministicLockupDynamic.s.sol
+++ b/script/DeployDeterministicLockupDynamic.s.sol
@@ -13,7 +13,7 @@ contract DeployDeterministicLockupDynamic is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         address initialAdmin,
         ISablierV2Comptroller initialComptroller,
         ISablierV2NFTDescriptor initialNFTDescriptor,
@@ -24,7 +24,7 @@ contract DeployDeterministicLockupDynamic is BaseScript {
         broadcaster
         returns (SablierV2LockupDynamic lockupDynamic)
     {
-        lockupDynamic = new SablierV2LockupDynamic{ salt: bytes32(create2Salt) }(
+        lockupDynamic = new SablierV2LockupDynamic{ salt: bytes32(abi.encodePacked(create2Salt)) }(
             initialAdmin,
             initialComptroller,
             initialNFTDescriptor,

--- a/script/DeployDeterministicLockupLinear.s.sol
+++ b/script/DeployDeterministicLockupLinear.s.sol
@@ -13,7 +13,7 @@ contract DeployDeterministicLockupLinear is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         address initialAdmin,
         ISablierV2Comptroller initialComptroller,
         ISablierV2NFTDescriptor initialNFTDescriptor
@@ -23,7 +23,7 @@ contract DeployDeterministicLockupLinear is BaseScript {
         broadcaster
         returns (SablierV2LockupLinear lockupLinear)
     {
-        lockupLinear = new SablierV2LockupLinear{ salt: bytes32(create2Salt) }(
+        lockupLinear = new SablierV2LockupLinear{ salt: bytes32(abi.encodePacked(create2Salt)) }(
             initialAdmin,
             initialComptroller,
             initialNFTDescriptor

--- a/script/DeployDeterministicNFTDescriptor.s.sol
+++ b/script/DeployDeterministicNFTDescriptor.s.sol
@@ -10,7 +10,7 @@ import { BaseScript } from "./Base.s.sol";
 contract DeployDeterministicNFTDescriptor is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
-    function run(uint256 create2Salt) public virtual broadcaster returns (SablierV2NFTDescriptor nftDescriptor) {
-        nftDescriptor = new SablierV2NFTDescriptor{ salt: bytes32(create2Salt) }();
+    function run(string memory create2Salt) public virtual broadcaster returns (SablierV2NFTDescriptor nftDescriptor) {
+        nftDescriptor = new SablierV2NFTDescriptor{ salt: bytes32(abi.encodePacked(create2Salt)) }();
     }
 }


### PR DESCRIPTION
Using strings for the `create2Salt` parameter allows us to use the version as a CREATE2 salt, e.g.

- `1.0.0-rc.0`
- `Comptroller v1.0.0-rc.0`
- `SablierV2Comptroller v1.0.0-rc.0`