### PR TITLE
refactor: rename deployer to broadcaster

### DIFF
--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -10,19 +10,31 @@ abstract contract BaseScript is Script {
     /// @dev Needed for the deterministic deployments.
     bytes32 internal constant ZERO_SALT = bytes32(0);
 
-    /// @dev The address of the contract deployer.
-    address internal deployer;
+    /// @dev The address of the transaction broadcaster.
+    address internal broadcaster;
 
-    /// @dev Used to derive the deployer's address.
+    /// @dev Used to derive the broadcaster's address if $ETH_FROM is not defined.
     string internal mnemonic;
 
+    /// @dev Initializes the transaction broadcaster like this:
+    ///
+    /// - If $ETH_FROM is defined, use it.
+    /// - Otherwise, derive the broadcaster address from $MNEMONIC.
+    /// - If $MNEMONIC is not defined, default to a test mnemonic.
+    ///
+    /// The use case for $ETH_FROM is to specify the broadcaster key and its address via the command line.
     constructor() {
-        mnemonic = vm.envOr("MNEMONIC", TEST_MNEMONIC);
-        (deployer,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
+        address from = vm.envOr({ name: "ETH_FROM", defaultValue: address(0) });
+        if (from != address(0)) {
+            broadcaster = from;
+        } else {
+            mnemonic = vm.envOr({ name: "MNEMONIC", defaultValue: TEST_MNEMONIC });
+            (broadcaster,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
+        }
     }
 
-    modifier broadcaster() {
-        vm.startBroadcast(deployer);
+    modifier broadcast() {
+        vm.startBroadcast(broadcaster);
         _;
         vm.stopBroadcast();
     }

--- a/script/DeployComptroller.s.sol
+++ b/script/DeployComptroller.s.sol
@@ -6,7 +6,7 @@ import { SablierV2Comptroller } from "../src/SablierV2Comptroller.sol";
 import { BaseScript } from "./Base.s.sol";
 
 contract DeployComptroller is BaseScript {
-    function run(address initialAdmin) public virtual broadcaster returns (SablierV2Comptroller comptroller) {
+    function run(address initialAdmin) public virtual broadcast returns (SablierV2Comptroller comptroller) {
         comptroller = new SablierV2Comptroller(initialAdmin);
     }
 }

--- a/script/DeployCore.s.sol
+++ b/script/DeployCore.s.sol
@@ -20,7 +20,7 @@ contract DeployCore is BaseScript {
     )
         public
         virtual
-        broadcaster
+        broadcast
         returns (
             SablierV2Comptroller comptroller,
             SablierV2LockupDynamic lockupDynamic,

--- a/script/DeployDeterministicComptroller.s.sol
+++ b/script/DeployDeterministicComptroller.s.sol
@@ -16,7 +16,7 @@ contract DeployDeterministicComptroller is BaseScript {
     )
         public
         virtual
-        broadcaster
+        broadcast
         returns (SablierV2Comptroller comptroller)
     {
         comptroller = new SablierV2Comptroller{ salt: bytes32(abi.encodePacked(create2Salt)) }(initialAdmin);

--- a/script/DeployDeterministicCore.s.sol
+++ b/script/DeployDeterministicCore.s.sol
@@ -26,7 +26,7 @@ contract DeployDeterministicCore is BaseScript {
     )
         public
         virtual
-        broadcaster
+        broadcast
         returns (
             SablierV2Comptroller comptroller,
             SablierV2LockupDynamic lockupDynamic,

--- a/script/DeployDeterministicLockupDynamic.s.sol
+++ b/script/DeployDeterministicLockupDynamic.s.sol
@@ -21,7 +21,7 @@ contract DeployDeterministicLockupDynamic is BaseScript {
     )
         public
         virtual
-        broadcaster
+        broadcast
         returns (SablierV2LockupDynamic lockupDynamic)
     {
         lockupDynamic = new SablierV2LockupDynamic{ salt: bytes32(abi.encodePacked(create2Salt)) }(

--- a/script/DeployDeterministicLockupLinear.s.sol
+++ b/script/DeployDeterministicLockupLinear.s.sol
@@ -20,7 +20,7 @@ contract DeployDeterministicLockupLinear is BaseScript {
     )
         public
         virtual
-        broadcaster
+        broadcast
         returns (SablierV2LockupLinear lockupLinear)
     {
         lockupLinear = new SablierV2LockupLinear{ salt: bytes32(abi.encodePacked(create2Salt)) }(

--- a/script/DeployDeterministicNFTDescriptor.s.sol
+++ b/script/DeployDeterministicNFTDescriptor.s.sol
@@ -10,7 +10,7 @@ import { BaseScript } from "./Base.s.sol";
 contract DeployDeterministicNFTDescriptor is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
-    function run(string memory create2Salt) public virtual broadcaster returns (SablierV2NFTDescriptor nftDescriptor) {
+    function run(string memory create2Salt) public virtual broadcast returns (SablierV2NFTDescriptor nftDescriptor) {
         nftDescriptor = new SablierV2NFTDescriptor{ salt: bytes32(abi.encodePacked(create2Salt)) }();
     }
 }

--- a/script/DeployLockupDynamic.s.sol
+++ b/script/DeployLockupDynamic.s.sol
@@ -16,7 +16,7 @@ contract DeployLockupDynamic is BaseScript {
     )
         public
         virtual
-        broadcaster
+        broadcast
         returns (SablierV2LockupDynamic lockupDynamic)
     {
         lockupDynamic = new SablierV2LockupDynamic(

--- a/script/DeployLockupLinear.s.sol
+++ b/script/DeployLockupLinear.s.sol
@@ -15,7 +15,7 @@ contract DeployLockupLinear is BaseScript {
     )
         public
         virtual
-        broadcaster
+        broadcast
         returns (SablierV2LockupLinear lockupLinear)
     {
         lockupLinear = new SablierV2LockupLinear(initialAdmin, initialComptroller, initialNFTDescriptor);

--- a/script/DeployNFTDescriptor.s.sol
+++ b/script/DeployNFTDescriptor.s.sol
@@ -6,7 +6,7 @@ import { SablierV2NFTDescriptor } from "../src/SablierV2NFTDescriptor.sol";
 import { BaseScript } from "./Base.s.sol";
 
 contract DeployNFTDescriptor is BaseScript {
-    function run() public virtual broadcaster returns (SablierV2NFTDescriptor nftDescriptor) {
+    function run() public virtual broadcast returns (SablierV2NFTDescriptor nftDescriptor) {
         nftDescriptor = new SablierV2NFTDescriptor();
     }
 }

--- a/script/Init.s.sol
+++ b/script/Init.s.sol
@@ -26,9 +26,9 @@ contract Init is BaseScript {
         IERC20 asset
     )
         public
-        broadcaster
+        broadcast
     {
-        address sender = deployer;
+        address sender = broadcaster;
         address recipient = vm.addr(vm.deriveKey({ mnemonic: mnemonic, index: 1 }));
 
         /*//////////////////////////////////////////////////////////////////////////

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -56,7 +56,7 @@ abstract contract Utils is StdUtils, PRBMathUtils {
 
     /// @dev Checks if the Foundry profile is "test-optimized".
     function isTestOptimizedProfile() internal returns (bool) {
-        string memory profile = vm.envOr("FOUNDRY_PROFILE", string(""));
+        string memory profile = vm.envOr({ name: "FOUNDRY_PROFILE", defaultValue: string("") });
         return Strings.equal(profile, "test-optimized");
     }
 }


### PR DESCRIPTION
This PR does two things:

- Rename `deployer` to `broadcaster` in `BaseScript` (not all scripts deploy contracts)
- Allows the user to pass the broadcaster key and address via the command line (e.g. by passing `--ledger` and setting the `ETH_FROM` environment variable)

I needed to make this refactor to be able to deploy using Ledger.