### PR TITLE
chore: add missing modifier in test_SetFlashFee

### DIFF
--- a/test/integration/concrete/comptroller/set-flash-fee/setFlashFee.t.sol
+++ b/test/integration/concrete/comptroller/set-flash-fee/setFlashFee.t.sol
@@ -41,7 +41,7 @@ contract SetFlashFee_Integration_Concrete_Test is Integration_Test {
         _;
     }
 
-    function test_SetFlashFee() external {
+    function test_SetFlashFee() external whenCallerAdmin whenNewFee {
         UD60x18 newFlashFee = defaults.FLASH_FEE();
 
         // Expect the relevant event to be emitted.


### PR DESCRIPTION
Base on the pattern, the `test_SetFlashFee` test seems to be missing the defined modifier to describe that this is in the "is admin x whenNewFee" branch