### PR TITLE
Updating .tree file in adminable_unit_test

### DIFF
--- a/test/unit/concrete/adminable/transfer-admin/transferAdmin.tree
+++ b/test/unit/concrete/adminable/transfer-admin/transferAdmin.tree
@@ -1,14 +1,18 @@
 transferAdmin.t.sol
-├── when the caller is not the admin
-│  └── it should revert
-└── when the caller is the admin
-   ├── when the admin is the same as the current admin
-   │  ├── it should re-set the admin
-   │  └── it should emit a {TransferAdmin} event
-   └── when the admin is not the same as the current admin
-      ├── when the admin is the zero address
-      │  ├── it should set the admin to the zero address
-      │  └── it should emit a {TransferAdmin}
-      └── when the admin is not the zero address
-         ├── it should set the new admin
-         └── it should emit a {TransferAdmin} event and set the new admin
+Scenario: Transfer ownership from one admin to another
+
+├──  Given the caller is not the admin
+│  ├── When trying to transfer ownership(from old admin to new one)
+│  └── Then it should revert
+└── Given the caller is the admin
+   ├── Given the admin(new) is the same as the current admin (actual)
+   │   └── When the admin transfers ownership to a new admin
+   │     ├── Then it should re-set the admin
+   │     └── And the {TransferAdmin} event should be emitted
+   └── Given the admin(new) is not the same as the current admin(actual)
+      ├── And the admin(new) is the zero address (who deploys the contract)
+      │  ├── Then it should set the admin to the zero address
+      │  └── And it should emit a {TransferAdmin}
+      └── And the admin is not the zero address
+         ├── Then it sets the new admin
+         └── And it should emit a {TransferAdmin} event and set the new admin


### PR DESCRIPTION
#621 

1. Making the `.tree` file of `transferAdmin.t.sol` in concrete unit test more Understandable & Readable with the help of Cucumber's [Gherkin](https://cucumber.io/docs/gherkin/) syntax.

2. Also differentiate the two `admin` in line 8 from the previous file.
