### PR TITLE
Updating .tree file in adminable_unit_test

### DIFF
--- a/test/unit/concrete/adminable/transfer-admin/transferAdmin.t.sol
+++ b/test/unit/concrete/adminable/transfer-admin/transferAdmin.t.sol
@@ -15,11 +15,11 @@ contract TransferAdmin_Unit_Concrete_Test is Adminable_Unit_Shared_Test {
         adminableMock.transferAdmin(users.eve);
     }
 
-    modifier whenCallerAdmin() {
+    modifier GivenCallerIsAdmin() {
         _;
     }
 
-    function test_TransferAdmin_SameAdmin() external whenCallerAdmin {
+    function test_TransferAdmin_SameAdmin() external GivenCallerIsAdmin {
         // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(adminableMock) });
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.admin });
@@ -33,7 +33,7 @@ contract TransferAdmin_Unit_Concrete_Test is Adminable_Unit_Shared_Test {
         assertEq(actualAdmin, expectedAdmin, "admin");
     }
 
-    function test_TransferAdmin_ZeroAddress() external whenCallerAdmin {
+    function test_TransferAdmin_ZeroAddress() external GivenCallerIsAdmin {
         // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(adminableMock) });
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: address(0) });
@@ -51,7 +51,7 @@ contract TransferAdmin_Unit_Concrete_Test is Adminable_Unit_Shared_Test {
         _;
     }
 
-    function test_TransferAdmin_NewAdmin() external whenCallerAdmin whenNotZeroAddress {
+    function test_TransferAdmin_NewAdmin() external GivenCallerIsAdmin whenNotZeroAddress {
         // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(adminableMock) });
         emit TransferAdmin({ oldAdmin: users.admin, newAdmin: users.alice });

--- a/test/unit/concrete/adminable/transfer-admin/transferAdmin.tree
+++ b/test/unit/concrete/adminable/transfer-admin/transferAdmin.tree
@@ -1,18 +1,14 @@
 transferAdmin.t.sol
-Scenario: Transfer ownership from one admin to another
-
-├──  Given the caller is not the admin
-│  ├── When trying to transfer ownership(from old admin to new one)
+├── Given the caller is not the admin
 │  └── Then it should revert
 └── Given the caller is the admin
-   ├── Given the admin(new) is the same as the current admin (actual)
-   │   └── When the admin transfers ownership to a new admin
-   │     ├── Then it should re-set the admin
-   │     └── And the {TransferAdmin} event should be emitted
-   └── Given the admin(new) is not the same as the current admin(actual)
-      ├── And the admin(new) is the zero address (who deploys the contract)
+   ├── When the new admin is the same as the current admin
+   │   ├── Then it should re-set the admin
+   │   └── And it should emit a {TransferAdmin} event
+   └── When the new admin is not the same as the current admin
+      ├── When the new admin is the zero address
       │  ├── Then it should set the admin to the zero address
-      │  └── And it should emit a {TransferAdmin}
-      └── And the admin is not the zero address
-         ├── Then it sets the new admin
-         └── And it should emit a {TransferAdmin} event and set the new admin
+      │  └── And it should emit a {TransferAdmin} event
+      └── When the new admin is not the zero address
+         ├── Then it should set the new admin
+         └── And it should emit a {TransferAdmin} event

--- a/test/unit/concrete/adminable/transfer-admin/transferAdmin.tree
+++ b/test/unit/concrete/adminable/transfer-admin/transferAdmin.tree
@@ -1,14 +1,18 @@
 transferAdmin.t.sol
-├── when the caller is not the admin
-│  └── it should revert
-└── when the caller is the admin
-   ├── when the admin is the same as the current admin
-   │  ├── it should re-set the admin
-   │  └── it should emit a {TransferAdmin} event
-   └── when the admin is not the same as the current admin
-      ├── when the admin is the zero address
-      │  ├── it should set the admin to the zero address
-      │  └── it should emit a {TransferAdmin}
-      └── when the admin is not the zero address
-         ├── it should set the new admin
-         └── it should emit a {TransferAdmin} event and set the new admin
+Scenario: Transfer ownership from one admin to another
+
+├──  Given the caller is not the admin
+│  ├── When trying to transfer ownership(from old admin to new one)
+│  └── Then it should revert
+└── Given the caller is the admin
+   ├── Given the admin(new) is the same as the current admin (actual)
+   │   └── When the admin transfers ownership to a new admin
+   │     ├── Then it should re-set the admin
+   │     └── And the {TransferAdmin} event should be emitted
+   └── Given the admin(new) is not the same as the current admin(actual)
+      ├── And the admin(new) is the zero address (who deploys the contract)
+      │  ├── Then it should set the admin to the zero address
+      │  └── And it should emit a {TransferAdmin}
+      └── And the admin is not the zero address
+         ├── Then it sets the new admin
+         └── And it should emit a {TransferAdmin} event and set the new admin


### PR DESCRIPTION
#621 

1. Updating the `.tree` file of `transferAdmin.t.sol` from folder `Adminable` under unit tests to make it more Understandable & Readable by using Cucumber's [Gherkin](https://cucumber.io/docs/gherkin/) syntax

2. Gave more clarity about the 2 Admins in the 8th line from the previous file.