### PR TITLE
Fix Github workflow build cache

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -83,7 +83,9 @@ jobs:
       - name: "Cache the build so that it can be re-used by the other jobs"
         uses: "actions/cache/save@v3"
         with:
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
           key: "foundry-build-${{ github.sha }}"
 
       - name: "Add build summary"
@@ -110,7 +112,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the unit tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/unit\""
@@ -139,7 +143,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the integration tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/integration/**/*.sol\""
@@ -169,7 +175,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the invariant tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/invariant/**/*.sol\""
@@ -198,7 +206,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the fork tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/fork/**/*.sol\""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
       - name: "Cache the build so that it can be re-used by the other jobs"
         uses: "actions/cache/save@v3"
         with:
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
           key: "foundry-build-${{ github.sha }}"
 
       - name: "Store the contract artifacts in CI"
@@ -115,7 +117,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the unit tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/unit/**/*.sol\""
@@ -144,7 +148,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the integration tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/integration/**/*.sol\""
@@ -171,7 +177,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the utils tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/utils/**/*.sol\""
@@ -198,7 +206,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Run the invariant tests against the optimized build"
         run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/invariant/**/*.sol\""
@@ -227,7 +237,9 @@ jobs:
         with:
           fail-on-cache-miss: true
           key: "foundry-build-${{ github.sha }}"
-          path: "out-optimized"
+          path: |
+            out-optimized
+            cache
 
       - name: "Generate fuzz seed that changes weekly to avoid burning through RPC allowance"
         run: |


### PR DESCRIPTION
In current Github workflows, the `cache` folder generated by `forge` is not part of the cache, leading to contracts being recompiled in each test job.