### PR TITLE
chore: remove "cbor_metadata"

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,6 @@
 [profile.default]
   auto_detect_solc = false
   bytecode_hash = "none"
-  cbor_metadata = false
   emv_version = "paris"
   fs_permissions = [{ access = "read", path = "out-optimized" }]
   libs = ["lib"]


### PR DESCRIPTION
The CBOR metadata can be enabled as it won't affect deterministic compilation across operating systems.

Ref https://twitter.com/msolomon44/status/1659301831489757187