### PR TITLE
build: remove goerli support

### DIFF
--- a/.github/workflows/deploy-comptroller.yml
+++ b/.github/workflows/deploy-comptroller.yml
@@ -20,7 +20,7 @@ on:
         description: "Initial contract admin."
         required: false
       chain:
-        default: "goerli"
+        default: "sepolia"
         description: "Chain name as defined in the Foundry config."
         required: false
 

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -20,7 +20,7 @@ on:
         description: "Initial protocol admin."
         required: false
       chain:
-        default: "goerli"
+        default: "sepolia"
         description: "Chain name as defined in the Foundry config."
         required: false
       max-segment-count:

--- a/.github/workflows/deploy-lockup-dynamic.yml
+++ b/.github/workflows/deploy-lockup-dynamic.yml
@@ -20,7 +20,7 @@ on:
         description: "Initial contract admin."
         required: false
       chain:
-        default: "goerli"
+        default: "sepolia"
         description: "Chain name as defined in the Foundry config."
         required: false
       comptroller:

--- a/.github/workflows/deploy-lockup-linear.yml
+++ b/.github/workflows/deploy-lockup-linear.yml
@@ -20,7 +20,7 @@ on:
         description: "Initial contract admin."
         required: false
       chain:
-        default: "goerli"
+        default: "sepolia"
         description: "Chain name as defined in the Foundry config."
         required: false
       comptroller:

--- a/.github/workflows/deploy-nft-descriptor.yml
+++ b/.github/workflows/deploy-nft-descriptor.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       chain:
-        default: "goerli"
+        default: "sepolia"
         description: "Chain name as defined in the Foundry config."
         required: false
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ The Program does NOT cover the following:
 - Code located in the [test](./test) or [script](./script) directories.
 - External code in the [lib](./lib) directory, except for code that is explicitly used by a deployed contract located in
   the [src](./src) directory.
-- Contract deployments on test networks, such as Goerli.
+- Contract deployments on test networks, such as Sepolia.
 - Bugs in third-party contracts or platforms interacting with Sablier V2 Core.
 - Previously reported or discovered vulnerabilities in contracts built by third parties on Sablier V2 Core.
 - Bugs that have already been reported.

--- a/foundry.toml
+++ b/foundry.toml
@@ -84,7 +84,6 @@
   avalanche = { key = "${API_KEY_SNOWTRACE" }
   bnb_smart_chain = { key = "${API_KEY_BSCSCAN}" }
   gnosis_chain = { key = "${API_KEY_GNOSISSCAN}" }
-  goerli = { key = "${API_KEY_ETHERSCAN}" }
   mainnet = { key = "${API_KEY_ETHERSCAN}" }
   optimism = { key = "${API_KEY_OPTIMISTIC_ETHERSCAN}" }
   polygon = { key = "${API_KEY_POLYGONSCAN}" }
@@ -105,7 +104,6 @@
   avalanche = "https://avalanche-mainnet.infura.io/v3/${API_KEY_INFURA}"
   bnb_smart_chain = "https://bsc-dataseed.binance.org"
   gnosis_chain = "https://rpc.gnosischain.com"
-  goerli = "https://goerli.infura.io/v3/${API_KEY_INFURA}"
   localhost = "http://localhost:8545"
   mainnet = "${RPC_URL_MAINNET}"
   optimism = "https://optimism-mainnet.infura.io/v3/${API_KEY_INFURA}"


### PR DESCRIPTION
Remove goerli support in `foundry.toml` file and use sepolia as default chain in deployment workflows.