### PR TITLE
ci: run fork tests only monday, wednesday and friday

### DIFF
--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -1,0 +1,24 @@
+name: "CI Fork tests"
+
+on:
+    schedule:
+      - cron: "0 3 * * 1,3,5" # at 3:00 AM UTC on Monday, Wednesday and Friday
+
+jobs:
+  lint:
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-lint.yml@main"
+
+  build:
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-build.yml@main"
+
+  test-fork:
+      needs: ["lint", "build"]
+      secrets:
+        RPC_URL_MAINNET: ${{ secrets.RPC_URL_MAINNET }}
+      uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+      with:
+        foundry-fuzz-runs: 100
+        foundry-profile: "test-optimized"
+        fuzz-seed: true
+        match-path: "test/fork/**/*.sol"
+        name: "Fork tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,18 +52,6 @@ jobs:
       match-path: "test/invariant/**/*.sol"
       name: "Invariant tests"
 
-  test-fork:
-    needs: ["lint", "build"]
-    secrets:
-      RPC_URL_MAINNET: ${{ secrets.RPC_URL_MAINNET }}
-    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
-    with:
-      foundry-fuzz-runs: 100
-      foundry-profile: "test-optimized"
-      fuzz-seed: true
-      match-path: "test/fork/**/*.sol"
-      name: "Fork tests"
-
   coverage:
     needs: ["lint", "build"]
     uses: "sablier-labs/reusable-workflows/.github/workflows/forge-coverage.yml@main"


### PR DESCRIPTION
Closes https://github.com/sablier-labs/v2-core/issues/790

I have decided to run the tests once every two days.

Sunday is not included because on that day, they already run in the `ci-deep` workflow.

https://github.com/sablier-labs/v2-core/blob/9ebb59abfdbe3eb1f286ed4e04c849bad51e7113/.github/workflows/ci-deep.yml#L68-L77