### PR TITLE
fix: avoid duplicate calls on withdraw hook when sender is also the recipient

### DIFF
--- a/src/abstracts/SablierV2Lockup.sol
+++ b/src/abstracts/SablierV2Lockup.sol
@@ -388,10 +388,10 @@ abstract contract SablierV2Lockup is
             }) { } catch { }
         }
 
-        // Interactions: if `msg.sender` is not the sender and the sender is a contract, try to invoke the
-        // withdraw hook on it without reverting if the hook is not implemented, and also without bubbling up
-        // any potential revert.
-        if (msg.sender != sender && sender.code.length > 0) {
+        // Interactions: if `msg.sender` is not the sender, sender is not same as the recipient and the sender is a
+        // contract, try to invoke the withdraw hook on it without reverting if the hook is not implemented, and also
+        // without bubbling up any potential revert.
+        if (msg.sender != sender && sender != recipient && sender.code.length > 0) {
             try ISablierV2Sender(sender).onLockupStreamWithdrawn({
                 streamId: streamId,
                 caller: msg.sender,

--- a/src/abstracts/SablierV2Lockup.sol
+++ b/src/abstracts/SablierV2Lockup.sol
@@ -388,10 +388,10 @@ abstract contract SablierV2Lockup is
             }) { } catch { }
         }
 
-        // Interactions: if `msg.sender` is not the sender, sender is not same as the recipient and the sender is a
-        // contract, try to invoke the withdraw hook on it without reverting if the hook is not implemented, and also
+        // Interactions: if `msg.sender` is not the sender, the sender is a contract and sender is different from the
+        // recipient, try to invoke the withdraw hook on it without reverting if the hook is not implemented, and also
         // without bubbling up any potential revert.
-        if (msg.sender != sender && sender != recipient && sender.code.length > 0) {
+        if (msg.sender != sender && sender.code.length > 0 && sender != recipient) {
             try ISablierV2Sender(sender).onLockupStreamWithdrawn({
                 streamId: streamId,
                 caller: msg.sender,

--- a/test/integration/concrete/lockup-dynamic/LockupDynamic.t.sol
+++ b/test/integration/concrete/lockup-dynamic/LockupDynamic.t.sol
@@ -31,8 +31,9 @@ import { SetComptroller_Integration_Concrete_Test } from "../lockup/set-comptrol
 import { SetNFTDescriptor_Integration_Concrete_Test } from "../lockup/set-nft-descriptor/setNFTDescriptor.t.sol";
 import { StatusOf_Integration_Concrete_Test } from "../lockup/status-of/statusOf.t.sol";
 import { TransferFrom_Integration_Concrete_Test } from "../lockup/transfer-from/transferFrom.t.sol";
-import { Withdraw_Integration_Concrete_Test } from "../lockup/withdraw/withdraw.t.sol";
 import { WasCanceled_Integration_Concrete_Test } from "../lockup/was-canceled/wasCanceled.t.sol";
+import { Withdraw_Integration_Concrete_Test } from "../lockup/withdraw/withdraw.t.sol";
+import { WithdrawHooks_Integration_Concrete_Test } from "../lockup/withdraw-hooks/withdrawHooks.t.sol";
 import { WithdrawMax_Integration_Concrete_Test } from "../lockup/withdraw-max/withdrawMax.t.sol";
 import { WithdrawMaxAndTransfer_Integration_Concrete_Test } from
     "../lockup/withdraw-max-and-transfer/withdrawMaxAndTransfer.t.sol";
@@ -431,6 +432,20 @@ contract Withdraw_LockupDynamic_Integration_Concrete_Test is
     {
         LockupDynamic_Integration_Concrete_Test.setUp();
         Withdraw_Integration_Concrete_Test.setUp();
+    }
+}
+
+contract WithdrawHooks_LockupDynamic_Integration_Concrete_Test is
+    LockupDynamic_Integration_Concrete_Test,
+    WithdrawHooks_Integration_Concrete_Test
+{
+    function setUp()
+        public
+        virtual
+        override(LockupDynamic_Integration_Concrete_Test, WithdrawHooks_Integration_Concrete_Test)
+    {
+        LockupDynamic_Integration_Concrete_Test.setUp();
+        WithdrawHooks_Integration_Concrete_Test.setUp();
     }
 }
 

--- a/test/integration/concrete/lockup-linear/LockupLinear.t.sol
+++ b/test/integration/concrete/lockup-linear/LockupLinear.t.sol
@@ -34,6 +34,7 @@ import { StatusOf_Integration_Concrete_Test } from "../lockup/status-of/statusOf
 import { TransferFrom_Integration_Concrete_Test } from "../lockup/transfer-from/transferFrom.t.sol";
 import { WasCanceled_Integration_Concrete_Test } from "../lockup/was-canceled/wasCanceled.t.sol";
 import { Withdraw_Integration_Concrete_Test } from "../lockup/withdraw/withdraw.t.sol";
+import { WithdrawHooks_Integration_Concrete_Test } from "../lockup/withdraw-hooks/withdrawHooks.t.sol";
 import { WithdrawMax_Integration_Concrete_Test } from "../lockup/withdraw-max/withdrawMax.t.sol";
 import { WithdrawMaxAndTransfer_Integration_Concrete_Test } from
     "../lockup/withdraw-max-and-transfer/withdrawMaxAndTransfer.t.sol";
@@ -432,6 +433,20 @@ contract Withdraw_LockupLinear_Integration_Concrete_Test is
     {
         LockupLinear_Integration_Concrete_Test.setUp();
         Withdraw_Integration_Concrete_Test.setUp();
+    }
+}
+
+contract WithdrawHooks_LockupLinear_Integration_Concrete_Test is
+    LockupLinear_Integration_Concrete_Test,
+    WithdrawHooks_Integration_Concrete_Test
+{
+    function setUp()
+        public
+        virtual
+        override(LockupLinear_Integration_Concrete_Test, WithdrawHooks_Integration_Concrete_Test)
+    {
+        LockupLinear_Integration_Concrete_Test.setUp();
+        WithdrawHooks_Integration_Concrete_Test.setUp();
     }
 }
 

--- a/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
+++ b/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
+import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";
+
+import { Integration_Test } from "../../../Integration.t.sol";
+import { Withdraw_Integration_Shared_Test } from "../../../shared/lockup/withdraw.t.sol";
+
+abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, Withdraw_Integration_Shared_Test {
+    function setUp() public virtual override(Integration_Test, Withdraw_Integration_Shared_Test) {
+        Withdraw_Integration_Shared_Test.setUp();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_WithdrawHooks_CallerUnknown() external {
+        address unknownCaller = address(0xCAFE);
+
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+
+        // Make unknownCaller the caller in this test.
+        changePrank({ msgSender: unknownCaller });
+
+        // Simulate the passage of time.
+        vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, unknownCaller, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Expect a call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, unknownCaller, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_CallerApprovedOperator() external {
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+
+        // Approve the operator to handle the stream.
+        changePrank({ msgSender: address(goodRecipient) });
+        lockup.approve({ to: users.operator, tokenId: streamId });
+
+        // Make the operator the caller in this test.
+        changePrank({ msgSender: users.operator });
+
+        // Simulate the passage of time.
+        vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, users.operator, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Expect a call to the sender hook.
+        // solhint-disable max-line-length
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, users.operator, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_CallerSender() external {
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+
+        // Make the sender the caller in this test.
+        changePrank({ msgSender: address(goodSender) });
+
+        // Simulate the passage of time.
+        vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect 1 call to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, address(goodSender), address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Expect 0 calls to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn,
+                (streamId, address(goodSender), address(goodRecipient), withdrawAmount)
+                ),
+            count: 0
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_CallerRecipient() external {
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+
+        // Make the recipient the caller in this test.
+        changePrank({ msgSender: address(goodRecipient) });
+
+        // Simulate the passage of time.
+        vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect 0 calls to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, address(goodRecipient), address(goodRecipient), withdrawAmount)
+                ),
+            count: 0
+        });
+
+        // Expect 1 call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn,
+                (streamId, address(goodRecipient), address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    modifier givenSenderIsRecipient() {
+        _;
+    }
+
+    function test_SenderHook_CallerUnknown() external givenSenderIsRecipient {
+        address unknownCaller = address(0xCAFE);
+
+        // Create the stream with recipient which is same as the sender contract.
+        uint256 streamId = createDefaultStreamToSelf(address(goodSender));
+
+        // Make unknownCaller the caller in this test.
+        changePrank({ msgSender: unknownCaller });
+
+        // Simulate the passage of time.
+        vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, unknownCaller, address(goodSender), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
+    }
+
+    function test_SenderHook_CallerApprovedOperator() external givenSenderIsRecipient {
+        // Create the stream with recipient which is same as the sender contract.
+        uint256 streamId = createDefaultStreamToSelf(address(goodSender));
+
+        // Approve the operator to handle the stream.
+        changePrank({ msgSender: address(goodSender) });
+        lockup.approve({ to: users.operator, tokenId: streamId });
+
+        // Make the operator the caller in this test.
+        changePrank({ msgSender: users.operator });
+
+        // Simulate the passage of time.
+        vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, users.operator, address(goodSender), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
+    }
+
+    function test_SenderHook_CallerSender() external givenSenderIsRecipient {
+        // Create the stream with the sender as the recipient.
+        uint256 streamId = createDefaultStreamToSelf(address(goodSender));
+
+        // Approve the operator to handle the stream.
+        changePrank({ msgSender: address(goodSender) });
+
+        // Simulate the passage of time.
+        vm.warp({ timestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect 0 calls to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn,
+                (streamId, address(goodSender), address(goodSender), withdrawAmount)
+                ),
+            count: 0
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
+    }
+}

--- a/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
+++ b/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
@@ -13,7 +13,7 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         Withdraw_Integration_Shared_Test.setUp();
     }
 
-    modifier givenSenderAndRecipientDifferent() {
+    modifier givenDifferentSenderAndRecipient() {
         _;
     }
 
@@ -21,7 +21,7 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         external
         givenSenderContract
         givenRecipientContract
-        givenSenderAndRecipientDifferent
+        givenDifferentSenderAndRecipient
     {
         address unknownCaller = address(0xCAFE);
 
@@ -64,7 +64,7 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         external
         givenSenderContract
         givenRecipientContract
-        givenSenderAndRecipientDifferent
+        givenDifferentSenderAndRecipient
     {
         // Create the stream with sender and recipient as contracts.
         uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
@@ -109,7 +109,7 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         external
         givenSenderContract
         givenRecipientContract
-        givenSenderAndRecipientDifferent
+        givenDifferentSenderAndRecipient
     {
         // Create the stream with sender and recipient as contracts.
         uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
@@ -151,7 +151,7 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         external
         givenSenderContract
         givenRecipientContract
-        givenSenderAndRecipientDifferent
+        givenDifferentSenderAndRecipient
     {
         // Create the stream with sender and recipient as contracts.
         uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
@@ -189,11 +189,11 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
     }
 
-    modifier givenSenderIsRecipient() {
+    modifier givenSameSenderAndRecipient() {
         _;
     }
 
-    function test_WithdrawHooks_SenderHook_CallerUnknown() external givenSenderContract givenSenderIsRecipient {
+    function test_WithdrawHooks_SenderHook_CallerUnknown() external givenSenderContract givenSameSenderAndRecipient {
         address unknownCaller = address(0xCAFE);
 
         // Create the stream with recipient which is same as the sender contract.
@@ -224,7 +224,7 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
     function test_WithdrawHooks_SenderHook_CallerApprovedOperator()
         external
         givenSenderContract
-        givenSenderIsRecipient
+        givenSameSenderAndRecipient
     {
         // Create the stream with recipient which is same as the sender contract.
         uint256 streamId = createDefaultStreamToSender(address(goodSender));
@@ -255,7 +255,7 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
     }
 
-    function test_WithdrawHooks_SenderHook_CallerSender() external givenSenderContract givenSenderIsRecipient {
+    function test_WithdrawHooks_SenderHook_CallerSender() external givenSenderContract givenSameSenderAndRecipient {
         // Create the stream with the sender as the recipient.
         uint256 streamId = createDefaultStreamToSender(address(goodSender));
 

--- a/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
+++ b/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
+// solhint-disable max-line-length
 pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
@@ -12,17 +13,22 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         Withdraw_Integration_Shared_Test.setUp();
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                       TESTS
-    //////////////////////////////////////////////////////////////////////////*/
+    modifier givenSenderAndRecipientDifferent() {
+        _;
+    }
 
-    function test_WithdrawHooks_CallerUnknown() external {
+    function test_WithdrawHooks_CallerUnknown()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenSenderAndRecipientDifferent
+    {
         address unknownCaller = address(0xCAFE);
 
         // Create the stream with sender and recipient as contracts.
-        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
 
-        // Make unknownCaller the caller in this test.
+        // Make `unknownCaller` the caller in this test.
         changePrank({ msgSender: unknownCaller });
 
         // Simulate the passage of time.
@@ -54,9 +60,14 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
     }
 
-    function test_WithdrawHooks_CallerApprovedOperator() external {
+    function test_WithdrawHooks_CallerApprovedOperator()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenSenderAndRecipientDifferent
+    {
         // Create the stream with sender and recipient as contracts.
-        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
 
         // Approve the operator to handle the stream.
         changePrank({ msgSender: address(goodRecipient) });
@@ -82,7 +93,6 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         });
 
         // Expect a call to the sender hook.
-        // solhint-disable max-line-length
         vm.expectCall({
             callee: address(goodSender),
             data: abi.encodeCall(
@@ -95,9 +105,14 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
     }
 
-    function test_WithdrawHooks_CallerSender() external {
+    function test_WithdrawHooks_CallerSender()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenSenderAndRecipientDifferent
+    {
         // Create the stream with sender and recipient as contracts.
-        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
 
         // Make the sender the caller in this test.
         changePrank({ msgSender: address(goodSender) });
@@ -132,9 +147,14 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
     }
 
-    function test_WithdrawHooks_CallerRecipient() external {
+    function test_WithdrawHooks_CallerRecipient()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenSenderAndRecipientDifferent
+    {
         // Create the stream with sender and recipient as contracts.
-        uint256 streamId = createDefaultStream(address(goodRecipient), address(goodSender));
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
 
         // Make the recipient the caller in this test.
         changePrank({ msgSender: address(goodRecipient) });
@@ -173,11 +193,11 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         _;
     }
 
-    function test_SenderHook_CallerUnknown() external givenSenderIsRecipient {
+    function test_WithdrawHooks_SenderHook_CallerUnknown() external givenSenderContract givenSenderIsRecipient {
         address unknownCaller = address(0xCAFE);
 
         // Create the stream with recipient which is same as the sender contract.
-        uint256 streamId = createDefaultStreamToSelf(address(goodSender));
+        uint256 streamId = createDefaultStreamToSender(address(goodSender));
 
         // Make unknownCaller the caller in this test.
         changePrank({ msgSender: unknownCaller });
@@ -201,9 +221,13 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
     }
 
-    function test_SenderHook_CallerApprovedOperator() external givenSenderIsRecipient {
+    function test_WithdrawHooks_SenderHook_CallerApprovedOperator()
+        external
+        givenSenderContract
+        givenSenderIsRecipient
+    {
         // Create the stream with recipient which is same as the sender contract.
-        uint256 streamId = createDefaultStreamToSelf(address(goodSender));
+        uint256 streamId = createDefaultStreamToSender(address(goodSender));
 
         // Approve the operator to handle the stream.
         changePrank({ msgSender: address(goodSender) });
@@ -231,9 +255,9 @@ abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, W
         lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
     }
 
-    function test_SenderHook_CallerSender() external givenSenderIsRecipient {
+    function test_WithdrawHooks_SenderHook_CallerSender() external givenSenderContract givenSenderIsRecipient {
         // Create the stream with the sender as the recipient.
-        uint256 streamId = createDefaultStreamToSelf(address(goodSender));
+        uint256 streamId = createDefaultStreamToSender(address(goodSender));
 
         // Approve the operator to handle the stream.
         changePrank({ msgSender: address(goodSender) });

--- a/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.tree
+++ b/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.tree
@@ -1,5 +1,5 @@
 withdrawHooks.t.sol
-├── given recipient is different than the sender
+├── given the recipient is different than the sender
 │   ├── when the caller is unknown
 │   │   ├── it should make one hook call to the sender
 │   │   └── it should make one hook call to the recipient
@@ -7,15 +7,15 @@ withdrawHooks.t.sol
 │   │   ├── it should make one hook call to the sender
 │   │   └── it should make one hook call to the recipient
 │   ├── when the caller is the sender
-│   │   ├── it should make zero hook calls to the sender
+│   │   ├── it should not make any hook call to the sender
 │   │   └── it should make one hook call to the recipient
 │   └── when the caller is the recipient
 │       ├── it should make one hook call to the sender
-│       └── it should make zero hook calls to the recipient
+│       └── it should not make any hook call to the recipient
 └── given the recipient is same as the sender
     ├── when the caller is unknown
     │   └── it should make one hook call to the sender
     ├── when the caller is an approved third party
     │   └── it should make one hook call to the sender
     └── when the caller is the sender
-        └── it should make zero hook calls to the sender
+        └── it should not make any hook call to the sender

--- a/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.tree
+++ b/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.tree
@@ -1,0 +1,21 @@
+withdrawHooks.t.sol
+├── given recipient is different than the sender
+│   ├── when the caller is unknown
+│   │   ├── it should make one hook call to the sender
+│   │   └── it should make one hook call to the recipient
+│   ├── when the caller is an approved third party
+│   │   ├── it should make one hook call to the sender
+│   │   └── it should make one hook call to the recipient
+│   ├── when the caller is the sender
+│   │   ├── it should make zero hook calls to the sender
+│   │   └── it should make one hook call to the recipient
+│   └── when the caller is the recipient
+│       ├── it should make one hook call to the sender
+│       └── it should make zero hook calls to the recipient
+└── given the recipient is same as the sender
+    ├── when the caller is unknown
+    │   └── it should make one hook call to the sender
+    ├── when the caller is an approved third party
+    │   └── it should make one hook call to the sender
+    └── when the caller is the sender
+        └── it should make zero hook calls to the sender

--- a/test/integration/concrete/lockup/withdraw/withdraw.t.sol
+++ b/test/integration/concrete/lockup/withdraw/withdraw.t.sol
@@ -16,10 +16,6 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test, Withdr
         Withdraw_Integration_Shared_Test.setUp();
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                       TESTS
-    //////////////////////////////////////////////////////////////////////////*/
-
     function test_RevertWhen_DelegateCalled() external {
         uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
         bytes memory callData =
@@ -197,10 +193,6 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test, Withdr
         test_Withdraw_CallerRecipient(defaultStreamId, users.sender);
     }
 
-    modifier givenSenderContract() {
-        _;
-    }
-
     function test_Withdraw_SenderDoesNotImplementHook()
         external
         whenNotDelegateCalled
@@ -316,7 +308,7 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test, Withdr
         test_Withdraw_CallerRecipient(streamId, address(goodSender));
     }
 
-    function test_Withdraw_CallerUnknownAddress()
+    function test_Withdraw_CallerUnknown()
         external
         whenNotDelegateCalled
         givenNotNull
@@ -457,10 +449,6 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test, Withdr
         whenStreamHasNotBeenCanceled
     {
         test_Withdraw_CallerSender(defaultStreamId, users.recipient);
-    }
-
-    modifier givenRecipientContract() {
-        _;
     }
 
     function test_Withdraw_RecipientDoesNotImplementHook()

--- a/test/integration/shared/lockup-dynamic/LockupDynamic.t.sol
+++ b/test/integration/shared/lockup-dynamic/LockupDynamic.t.sol
@@ -52,6 +52,14 @@ abstract contract LockupDynamic_Integration_Shared_Test is Lockup_Integration_Sh
         streamId = lockupDynamic.createWithTimestamps(_params.createWithTimestamps);
     }
 
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStream(address recipient, address sender) internal override returns (uint256 streamId) {
+        LockupDynamic.CreateWithTimestamps memory params = _params.createWithTimestamps;
+        params.sender = sender;
+        params.recipient = recipient;
+        streamId = lockupDynamic.createWithTimestamps(params);
+    }
+
     /// @dev Creates the default stream with the provided asset.
     function createDefaultStreamWithAsset(IERC20 asset) internal override returns (uint256 streamId) {
         LockupDynamic.CreateWithTimestamps memory params = _params.createWithTimestamps;

--- a/test/integration/shared/lockup-dynamic/LockupDynamic.t.sol
+++ b/test/integration/shared/lockup-dynamic/LockupDynamic.t.sol
@@ -52,14 +52,6 @@ abstract contract LockupDynamic_Integration_Shared_Test is Lockup_Integration_Sh
         streamId = lockupDynamic.createWithTimestamps(_params.createWithTimestamps);
     }
 
-    /// @dev Creates the default stream with the provided sender and recipient.
-    function createDefaultStream(address recipient, address sender) internal override returns (uint256 streamId) {
-        LockupDynamic.CreateWithTimestamps memory params = _params.createWithTimestamps;
-        params.sender = sender;
-        params.recipient = recipient;
-        streamId = lockupDynamic.createWithTimestamps(params);
-    }
-
     /// @dev Creates the default stream with the provided asset.
     function createDefaultStreamWithAsset(IERC20 asset) internal override returns (uint256 streamId) {
         LockupDynamic.CreateWithTimestamps memory params = _params.createWithTimestamps;
@@ -153,6 +145,21 @@ abstract contract LockupDynamic_Integration_Shared_Test is Lockup_Integration_Sh
     function createDefaultStreamWithTotalAmount(uint128 totalAmount) internal override returns (uint256 streamId) {
         LockupDynamic.CreateWithTimestamps memory params = _params.createWithTimestamps;
         params.totalAmount = totalAmount;
+        streamId = lockupDynamic.createWithTimestamps(params);
+    }
+
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStreamWithUsers(
+        address recipient,
+        address sender
+    )
+        internal
+        override
+        returns (uint256 streamId)
+    {
+        LockupDynamic.CreateWithTimestamps memory params = _params.createWithTimestamps;
+        params.sender = sender;
+        params.recipient = recipient;
         streamId = lockupDynamic.createWithTimestamps(params);
     }
 }

--- a/test/integration/shared/lockup-linear/LockupLinear.t.sol
+++ b/test/integration/shared/lockup-linear/LockupLinear.t.sol
@@ -29,6 +29,14 @@ abstract contract LockupLinear_Integration_Shared_Test is Lockup_Integration_Sha
         streamId = lockupLinear.createWithTimestamps(_params.createWithTimestamps);
     }
 
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStream(address recipient, address sender) internal override returns (uint256 streamId) {
+        LockupLinear.CreateWithTimestamps memory params = _params.createWithTimestamps;
+        params.sender = sender;
+        params.recipient = recipient;
+        streamId = lockupLinear.createWithTimestamps(params);
+    }
+
     /// @dev Creates the default stream with the provided address.
     function createDefaultStreamWithAsset(IERC20 asset) internal override returns (uint256 streamId) {
         LockupLinear.CreateWithTimestamps memory params = _params.createWithTimestamps;

--- a/test/integration/shared/lockup-linear/LockupLinear.t.sol
+++ b/test/integration/shared/lockup-linear/LockupLinear.t.sol
@@ -29,14 +29,6 @@ abstract contract LockupLinear_Integration_Shared_Test is Lockup_Integration_Sha
         streamId = lockupLinear.createWithTimestamps(_params.createWithTimestamps);
     }
 
-    /// @dev Creates the default stream with the provided sender and recipient.
-    function createDefaultStream(address recipient, address sender) internal override returns (uint256 streamId) {
-        LockupLinear.CreateWithTimestamps memory params = _params.createWithTimestamps;
-        params.sender = sender;
-        params.recipient = recipient;
-        streamId = lockupLinear.createWithTimestamps(params);
-    }
-
     /// @dev Creates the default stream with the provided address.
     function createDefaultStreamWithAsset(IERC20 asset) internal override returns (uint256 streamId) {
         LockupLinear.CreateWithTimestamps memory params = _params.createWithTimestamps;
@@ -119,6 +111,21 @@ abstract contract LockupLinear_Integration_Shared_Test is Lockup_Integration_Sha
     function createDefaultStreamWithTotalAmount(uint128 totalAmount) internal override returns (uint256 streamId) {
         LockupLinear.CreateWithTimestamps memory params = _params.createWithTimestamps;
         params.totalAmount = totalAmount;
+        streamId = lockupLinear.createWithTimestamps(params);
+    }
+
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStreamWithUsers(
+        address recipient,
+        address sender
+    )
+        internal
+        override
+        returns (uint256 streamId)
+    {
+        LockupLinear.CreateWithTimestamps memory params = _params.createWithTimestamps;
+        params.sender = sender;
+        params.recipient = recipient;
         streamId = lockupLinear.createWithTimestamps(params);
     }
 }

--- a/test/integration/shared/lockup/Lockup.t.sol
+++ b/test/integration/shared/lockup/Lockup.t.sol
@@ -44,9 +44,6 @@ abstract contract Lockup_Integration_Shared_Test is Base_Test {
     /// @dev Creates the default stream.
     function createDefaultStream() internal virtual returns (uint256 streamId);
 
-    /// @dev Creates the default stream with the provided sender and recipient.
-    function createDefaultStream(address recipient, address sender) internal virtual returns (uint256 streamId);
-
     /// @dev Creates the default stream but make it not cancelable.
     function createDefaultStreamNotCancelable() internal virtual returns (uint256 streamId);
 
@@ -54,8 +51,8 @@ abstract contract Lockup_Integration_Shared_Test is Base_Test {
     function createDefaultStreamNotTransferable() internal virtual returns (uint256 streamId);
 
     /// @dev Creates the default stream with recipient as the sender.
-    function createDefaultStreamToSelf(address sender) internal virtual returns (uint256 streamId) {
-        return createDefaultStream(sender, sender);
+    function createDefaultStreamToSender(address sender) internal virtual returns (uint256 streamId) {
+        return createDefaultStreamWithUsers(sender, sender);
     }
 
     /// @dev Creates the default stream with the provided address.
@@ -78,4 +75,13 @@ abstract contract Lockup_Integration_Shared_Test is Base_Test {
 
     /// @dev Creates the default stream with the provided total amount.
     function createDefaultStreamWithTotalAmount(uint128 totalAmount) internal virtual returns (uint256 streamId);
+
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStreamWithUsers(
+        address recipient,
+        address sender
+    )
+        internal
+        virtual
+        returns (uint256 streamId);
 }

--- a/test/integration/shared/lockup/Lockup.t.sol
+++ b/test/integration/shared/lockup/Lockup.t.sol
@@ -44,11 +44,19 @@ abstract contract Lockup_Integration_Shared_Test is Base_Test {
     /// @dev Creates the default stream.
     function createDefaultStream() internal virtual returns (uint256 streamId);
 
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStream(address recipient, address sender) internal virtual returns (uint256 streamId);
+
     /// @dev Creates the default stream but make it not cancelable.
     function createDefaultStreamNotCancelable() internal virtual returns (uint256 streamId);
 
     /// @dev Creates the default stream with the NFT transfer disabled.
     function createDefaultStreamNotTransferable() internal virtual returns (uint256 streamId);
+
+    /// @dev Creates the default stream with recipient as the sender.
+    function createDefaultStreamToSelf(address sender) internal virtual returns (uint256 streamId) {
+        return createDefaultStream(sender, sender);
+    }
 
     /// @dev Creates the default stream with the provided address.
     function createDefaultStreamWithAsset(IERC20 asset) internal virtual returns (uint256 streamId);

--- a/test/integration/shared/lockup/withdraw.t.sol
+++ b/test/integration/shared/lockup/withdraw.t.sol
@@ -51,4 +51,12 @@ abstract contract Withdraw_Integration_Shared_Test is Lockup_Integration_Shared_
     modifier whenStreamHasNotBeenCanceled() {
         _;
     }
+
+    modifier givenSenderContract() {
+        _;
+    }
+
+    modifier givenRecipientContract() {
+        _;
+    }
 }


### PR DESCRIPTION
Fixes #822 