### PR TITLE
Schedule precompile tests to mon, wed and fri

### DIFF
--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -1,4 +1,4 @@
-name: "CI Fork tests"
+name: "CI Fork and Util tests"
 
 on:
     schedule:
@@ -22,3 +22,11 @@ jobs:
         fuzz-seed: true
         match-path: "test/fork/**/*.sol"
         name: "Fork tests"
+
+  test-utils:
+    needs: ["lint", "build"]
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-profile: "test-optimized"
+      match-path: "test/utils/**/*.sol"
+      name: "Utils tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,6 @@ jobs:
       match-path: "test/integration/**/*.sol"
       name: "Integration tests"
 
-  test-utils:
-    needs: ["lint", "build"]
-    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
-    with:
-      foundry-profile: "test-optimized"
-      match-path: "test/utils/**/*.sol"
-      name: "Utils tests"
-
   test-invariant:
     needs: ["lint", "build"]
     uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"


### PR DESCRIPTION
Closes https://github.com/sablier-labs/v2-core/issues/832.

I have moved precompile tests alongside fork tests which run periodically on Monday, Wednesday and Friday. Should I rename `ci-fork` file to encapsulate both fork and precompile tests?