### PR TITLE
Use absolute paths to import src contracts in test files

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -3,14 +3,14 @@ pragma solidity >=0.8.22 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { ISablierV2Comptroller } from "../src/interfaces/ISablierV2Comptroller.sol";
-import { ISablierV2LockupDynamic } from "../src/interfaces/ISablierV2LockupDynamic.sol";
-import { ISablierV2LockupLinear } from "../src/interfaces/ISablierV2LockupLinear.sol";
-import { ISablierV2NFTDescriptor } from "../src/interfaces/ISablierV2NFTDescriptor.sol";
-import { SablierV2Comptroller } from "../src/SablierV2Comptroller.sol";
-import { SablierV2LockupDynamic } from "../src/SablierV2LockupDynamic.sol";
-import { SablierV2LockupLinear } from "../src/SablierV2LockupLinear.sol";
-import { SablierV2NFTDescriptor } from "../src/SablierV2NFTDescriptor.sol";
+import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
+import { ISablierV2LockupDynamic } from "src/interfaces/ISablierV2LockupDynamic.sol";
+import { ISablierV2LockupLinear } from "src/interfaces/ISablierV2LockupLinear.sol";
+import { ISablierV2NFTDescriptor } from "src/interfaces/ISablierV2NFTDescriptor.sol";
+import { SablierV2Comptroller } from "src/SablierV2Comptroller.sol";
+import { SablierV2LockupDynamic } from "src/SablierV2LockupDynamic.sol";
+import { SablierV2LockupLinear } from "src/SablierV2LockupLinear.sol";
+import { SablierV2NFTDescriptor } from "src/SablierV2NFTDescriptor.sol";
 
 import { ERC20Mock } from "./mocks/erc20/ERC20Mock.sol";
 import { ERC20MissingReturn } from "./mocks/erc20/ERC20MissingReturn.sol";

--- a/test/mocks/AdminableMock.sol
+++ b/test/mocks/AdminableMock.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22;
 
-import { Adminable } from "../../src/abstracts/Adminable.sol";
-import { IAdminable } from "../../src/interfaces/IAdminable.sol";
+import { Adminable } from "src/abstracts/Adminable.sol";
+import { IAdminable } from "src/interfaces/IAdminable.sol";
 
 contract AdminableMock is Adminable {
     constructor(address initialAdmin) {

--- a/test/mocks/NFTDescriptorMock.sol
+++ b/test/mocks/NFTDescriptorMock.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.22;
 
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
-import { NFTSVG } from "../../src/libraries/NFTSVG.sol";
-import { SVGElements } from "../../src/libraries/SVGElements.sol";
-import { Lockup } from "../../src/types/DataTypes.sol";
-import { SablierV2NFTDescriptor } from "../../src/SablierV2NFTDescriptor.sol";
+import { NFTSVG } from "src/libraries/NFTSVG.sol";
+import { SVGElements } from "src/libraries/SVGElements.sol";
+import { Lockup } from "src/types/DataTypes.sol";
+import { SablierV2NFTDescriptor } from "src/SablierV2NFTDescriptor.sol";
 
 /// @dev This mock is needed for:
 /// - Running the tests against the `--via-ir` precompiles

--- a/test/mocks/hooks/GoodRecipient.sol
+++ b/test/mocks/hooks/GoodRecipient.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ISablierV2Recipient } from "../../../src/interfaces/hooks/ISablierV2Recipient.sol";
+import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
 
 contract GoodRecipient is ISablierV2Recipient {
     function onLockupStreamCanceled(

--- a/test/mocks/hooks/GoodSender.sol
+++ b/test/mocks/hooks/GoodSender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ISablierV2Sender } from "../../../src/interfaces/hooks/ISablierV2Sender.sol";
+import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";
 
 contract GoodSender is ISablierV2Sender {
     function onLockupStreamWithdrawn(uint256 streamId, address caller, address to, uint128 amount) external pure {

--- a/test/mocks/hooks/ReentrantRecipient.sol
+++ b/test/mocks/hooks/ReentrantRecipient.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ISablierV2Lockup } from "../../../src/interfaces/ISablierV2Lockup.sol";
-import { ISablierV2Recipient } from "../../../src/interfaces/hooks/ISablierV2Recipient.sol";
+import { ISablierV2Lockup } from "src/interfaces/ISablierV2Lockup.sol";
+import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
 
 contract ReentrantRecipient is ISablierV2Recipient {
     function onLockupStreamCanceled(

--- a/test/mocks/hooks/ReentrantSender.sol
+++ b/test/mocks/hooks/ReentrantSender.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ISablierV2Lockup } from "../../../src/interfaces/ISablierV2Lockup.sol";
-import { ISablierV2Sender } from "../../../src/interfaces/hooks/ISablierV2Sender.sol";
+import { ISablierV2Lockup } from "src/interfaces/ISablierV2Lockup.sol";
+import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";
 
 contract ReentrantSender is ISablierV2Sender {
     function onLockupStreamWithdrawn(uint256 streamId, address caller, address to, uint128 amount) external {

--- a/test/mocks/hooks/RevertingRecipient.sol
+++ b/test/mocks/hooks/RevertingRecipient.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ISablierV2Recipient } from "../../../src/interfaces/hooks/ISablierV2Recipient.sol";
+import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
 
 contract RevertingRecipient is ISablierV2Recipient {
     function onLockupStreamCanceled(

--- a/test/mocks/hooks/RevertingSender.sol
+++ b/test/mocks/hooks/RevertingSender.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ISablierV2Sender } from "../../../src/interfaces/hooks/ISablierV2Sender.sol";
+import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";
 
 contract RevertingSender is ISablierV2Sender {
     function onLockupStreamWithdrawn(uint256 streamId, address caller, address to, uint128 amount) external pure {

--- a/test/unit/concrete/comptroller/Comptroller.t.sol
+++ b/test/unit/concrete/comptroller/Comptroller.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22 <0.9.0;
 
-import { SablierV2Comptroller } from "../../../../src/SablierV2Comptroller.sol";
+import { SablierV2Comptroller } from "src/SablierV2Comptroller.sol";
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/test/utils/Assertions.sol
+++ b/test/utils/Assertions.sol
@@ -5,7 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { PRBMathAssertions } from "@prb/math/test/utils/Assertions.sol";
 import { PRBTest } from "@prb/test/src/PRBTest.sol";
 
-import { Lockup, LockupDynamic, LockupLinear } from "../../src/types/DataTypes.sol";
+import { Lockup, LockupDynamic, LockupLinear } from "src/types/DataTypes.sol";
 
 abstract contract Assertions is PRBTest, PRBMathAssertions {
     /*//////////////////////////////////////////////////////////////////////////

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -6,7 +6,7 @@ import { PRBMathCastingUint40 as CastingUint40 } from "@prb/math/src/casting/Uin
 import { SD59x18 } from "@prb/math/src/SD59x18.sol";
 import { UD60x18, ud } from "@prb/math/src/UD60x18.sol";
 
-import { LockupDynamic } from "../../src/types/DataTypes.sol";
+import { LockupDynamic } from "src/types/DataTypes.sol";
 
 import { Defaults } from "./Defaults.sol";
 

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -5,7 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { UD2x18, ud2x18 } from "@prb/math/src/UD2x18.sol";
 import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
-import { Broker, Lockup, LockupDynamic, LockupLinear } from "../../src/types/DataTypes.sol";
+import { Broker, Lockup, LockupDynamic, LockupLinear } from "src/types/DataTypes.sol";
 
 import { Constants } from "./Constants.sol";
 import { Users } from "./Types.sol";

--- a/test/utils/DeployOptimized.sol
+++ b/test/utils/DeployOptimized.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.22 <0.9.0;
 
 import { StdCheats } from "forge-std/src/StdCheats.sol";
 
-import { ISablierV2Comptroller } from "../../src/interfaces/ISablierV2Comptroller.sol";
-import { ISablierV2LockupDynamic } from "../../src/interfaces/ISablierV2LockupDynamic.sol";
-import { ISablierV2LockupLinear } from "../../src/interfaces/ISablierV2LockupLinear.sol";
-import { ISablierV2NFTDescriptor } from "../../src/interfaces/ISablierV2NFTDescriptor.sol";
+import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
+import { ISablierV2LockupDynamic } from "src/interfaces/ISablierV2LockupDynamic.sol";
+import { ISablierV2LockupLinear } from "src/interfaces/ISablierV2LockupLinear.sol";
+import { ISablierV2NFTDescriptor } from "src/interfaces/ISablierV2NFTDescriptor.sol";
 
 abstract contract DeployOptimized is StdCheats {
     /// @dev Deploys {SablierV2Comptroller} from an optimized source compiled with `--via-ir`.

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -4,9 +4,9 @@ pragma solidity >=0.8.22;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
-import { ISablierV2Comptroller } from "../../src/interfaces/ISablierV2Comptroller.sol";
-import { ISablierV2NFTDescriptor } from "../../src/interfaces/ISablierV2NFTDescriptor.sol";
-import { Lockup, LockupDynamic, LockupLinear } from "../../src/types/DataTypes.sol";
+import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
+import { ISablierV2NFTDescriptor } from "src/interfaces/ISablierV2NFTDescriptor.sol";
+import { Lockup, LockupDynamic, LockupLinear } from "src/types/DataTypes.sol";
 
 /// @notice Abstract contract containing all the events emitted by the protocol.
 abstract contract Events {

--- a/test/utils/Fuzzers.sol
+++ b/test/utils/Fuzzers.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.22;
 import { PRBMathCastingUint128 as CastingUint128 } from "@prb/math/src/casting/Uint128.sol";
 import { UD60x18, ud, uUNIT } from "@prb/math/src/UD60x18.sol";
 
-import { Lockup, LockupDynamic } from "../../src/types/DataTypes.sol";
+import { Lockup, LockupDynamic } from "src/types/DataTypes.sol";
 
 import { Constants } from "./Constants.sol";
 import { Defaults } from "./Defaults.sol";

--- a/test/utils/Precompiles.sol
+++ b/test/utils/Precompiles.sol
@@ -2,11 +2,11 @@
 // solhint-disable max-line-length,no-inline-assembly,reason-string
 pragma solidity >=0.8.22;
 
-import { ISablierV2Comptroller } from "../../src/interfaces/ISablierV2Comptroller.sol";
-import { ISablierV2LockupDynamic } from "../../src/interfaces/ISablierV2LockupDynamic.sol";
-import { ISablierV2LockupLinear } from "../../src/interfaces/ISablierV2LockupLinear.sol";
-import { ISablierV2NFTDescriptor } from "../../src/interfaces/ISablierV2NFTDescriptor.sol";
-import { SablierV2NFTDescriptor } from "../../src/SablierV2NFTDescriptor.sol";
+import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
+import { ISablierV2LockupDynamic } from "src/interfaces/ISablierV2LockupDynamic.sol";
+import { ISablierV2LockupLinear } from "src/interfaces/ISablierV2LockupLinear.sol";
+import { ISablierV2NFTDescriptor } from "src/interfaces/ISablierV2NFTDescriptor.sol";
+import { SablierV2NFTDescriptor } from "src/SablierV2NFTDescriptor.sol";
 
 /// @notice This is useful for external integrations seeking to test against the exact deployed bytecode, as recompiling
 /// with via IR enabled would be time-consuming.

--- a/test/utils/Precompiles.t.sol
+++ b/test/utils/Precompiles.t.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.22 <0.9.0;
 
 import { LibString } from "solady/src/utils/LibString.sol";
 
-import { ISablierV2Comptroller } from "../../src/interfaces/ISablierV2Comptroller.sol";
-import { ISablierV2LockupDynamic } from "../../src/interfaces/ISablierV2LockupDynamic.sol";
-import { ISablierV2LockupLinear } from "../../src/interfaces/ISablierV2LockupLinear.sol";
-import { ISablierV2NFTDescriptor } from "../../src/interfaces/ISablierV2NFTDescriptor.sol";
+import { ISablierV2Comptroller } from "src/interfaces/ISablierV2Comptroller.sol";
+import { ISablierV2LockupDynamic } from "src/interfaces/ISablierV2LockupDynamic.sol";
+import { ISablierV2LockupLinear } from "src/interfaces/ISablierV2LockupLinear.sol";
+import { ISablierV2NFTDescriptor } from "src/interfaces/ISablierV2NFTDescriptor.sol";
 
 import { Base_Test } from "../Base.t.sol";
 import { Precompiles } from "./Precompiles.sol";

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -7,7 +7,7 @@ import { PRBMathUtils } from "@prb/math/test/utils/Utils.sol";
 import { Vm } from "@prb/test/src/PRBTest.sol";
 import { StdUtils } from "forge-std/src/StdUtils.sol";
 
-import { LockupDynamic } from "../../src/types/DataTypes.sol";
+import { LockupDynamic } from "src/types/DataTypes.sol";
 
 abstract contract Utils is StdUtils, PRBMathUtils {
     /// @dev The virtual address of the Foundry VM.


### PR DESCRIPTION
It improves readability.