### PR TITLE
test: integration tests for withdraw hooks

### DIFF
--- a/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
+++ b/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: UNLICENSED
+// solhint-disable max-line-length
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ISablierV2Recipient } from "src/interfaces/hooks/ISablierV2Recipient.sol";
+import { ISablierV2Sender } from "src/interfaces/hooks/ISablierV2Sender.sol";
+
+import { Integration_Test } from "../../../Integration.t.sol";
+import { Withdraw_Integration_Shared_Test } from "../../../shared/lockup/withdraw.t.sol";
+
+abstract contract WithdrawHooks_Integration_Concrete_Test is Integration_Test, Withdraw_Integration_Shared_Test {
+    function setUp() public virtual override(Integration_Test, Withdraw_Integration_Shared_Test) {
+        Withdraw_Integration_Shared_Test.setUp();
+    }
+
+    modifier givenDifferentSenderAndRecipient() {
+        _;
+    }
+
+    function test_WithdrawHooks_CallerUnknown()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenDifferentSenderAndRecipient
+    {
+        address unknownCaller = address(0xCAFE);
+
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
+
+        // Make `unknownCaller` the caller in this test.
+        changePrank({ msgSender: unknownCaller });
+
+        // Simulate the passage of time.
+        vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, unknownCaller, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Expect a call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, unknownCaller, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_CallerApprovedOperator()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenDifferentSenderAndRecipient
+    {
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
+
+        // Approve the operator to handle the stream.
+        changePrank({ msgSender: address(goodRecipient) });
+        lockup.approve({ to: users.operator, tokenId: streamId });
+
+        // Make the operator the caller in this test.
+        changePrank({ msgSender: users.operator });
+
+        // Simulate the passage of time.
+        vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, users.operator, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Expect a call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, users.operator, address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_CallerSender()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenDifferentSenderAndRecipient
+    {
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
+
+        // Make the sender the caller in this test.
+        changePrank({ msgSender: address(goodSender) });
+
+        // Simulate the passage of time.
+        vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect 1 call to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, address(goodSender), address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Expect 0 calls to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn,
+                (streamId, address(goodSender), address(goodRecipient), withdrawAmount)
+                ),
+            count: 0
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_CallerRecipient()
+        external
+        givenSenderContract
+        givenRecipientContract
+        givenDifferentSenderAndRecipient
+    {
+        // Create the stream with sender and recipient as contracts.
+        uint256 streamId = createDefaultStreamWithUsers(address(goodRecipient), address(goodSender));
+
+        // Make the recipient the caller in this test.
+        changePrank({ msgSender: address(goodRecipient) });
+
+        // Simulate the passage of time.
+        vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect 0 calls to the recipient hook.
+        vm.expectCall({
+            callee: address(goodRecipient),
+            data: abi.encodeCall(
+                ISablierV2Recipient.onLockupStreamWithdrawn,
+                (streamId, address(goodRecipient), address(goodRecipient), withdrawAmount)
+                ),
+            count: 0
+        });
+
+        // Expect 1 call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn,
+                (streamId, address(goodRecipient), address(goodRecipient), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodRecipient), amount: withdrawAmount });
+    }
+
+    modifier givenSameSenderAndRecipient() {
+        _;
+    }
+
+    function test_WithdrawHooks_SenderHook_CallerUnknown() external givenSenderContract givenSameSenderAndRecipient {
+        address unknownCaller = address(0xCAFE);
+
+        // Create the stream with recipient which is same as the sender contract.
+        uint256 streamId = createDefaultStreamToSender(address(goodSender));
+
+        // Make unknownCaller the caller in this test.
+        changePrank({ msgSender: unknownCaller });
+
+        // Simulate the passage of time.
+        vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, unknownCaller, address(goodSender), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_SenderHook_CallerApprovedOperator()
+        external
+        givenSenderContract
+        givenSameSenderAndRecipient
+    {
+        // Create the stream with recipient which is same as the sender contract.
+        uint256 streamId = createDefaultStreamToSender(address(goodSender));
+
+        // Approve the operator to handle the stream.
+        changePrank({ msgSender: address(goodSender) });
+        lockup.approve({ to: users.operator, tokenId: streamId });
+
+        // Make the operator the caller in this test.
+        changePrank({ msgSender: users.operator });
+
+        // Simulate the passage of time.
+        vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect a call to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn, (streamId, users.operator, address(goodSender), withdrawAmount)
+                ),
+            count: 1
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
+    }
+
+    function test_WithdrawHooks_SenderHook_CallerSender() external givenSenderContract givenSameSenderAndRecipient {
+        // Create the stream with the sender as the recipient.
+        uint256 streamId = createDefaultStreamToSender(address(goodSender));
+
+        // Approve the operator to handle the stream.
+        changePrank({ msgSender: address(goodSender) });
+
+        // Simulate the passage of time.
+        vm.warp({ newTimestamp: defaults.WARP_26_PERCENT() });
+
+        // Set the withdraw amount to the default amount.
+        uint128 withdrawAmount = defaults.WITHDRAW_AMOUNT();
+
+        // Expect 0 calls to the sender hook.
+        vm.expectCall({
+            callee: address(goodSender),
+            data: abi.encodeCall(
+                ISablierV2Sender.onLockupStreamWithdrawn,
+                (streamId, address(goodSender), address(goodSender), withdrawAmount)
+                ),
+            count: 0
+        });
+
+        // Make the withdrawal.
+        lockup.withdraw({ streamId: streamId, to: address(goodSender), amount: withdrawAmount });
+    }
+}

--- a/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.tree
+++ b/test/integration/concrete/lockup/withdraw-hooks/withdrawHooks.tree
@@ -1,0 +1,21 @@
+withdrawHooks.t.sol
+├── given the recipient is different than the sender
+│   ├── when the caller is unknown
+│   │   ├── it should make one hook call to the sender
+│   │   └── it should make one hook call to the recipient
+│   ├── when the caller is an approved third party
+│   │   ├── it should make one hook call to the sender
+│   │   └── it should make one hook call to the recipient
+│   ├── when the caller is the sender
+│   │   ├── it should not make any hook call to the sender
+│   │   └── it should make one hook call to the recipient
+│   └── when the caller is the recipient
+│       ├── it should make one hook call to the sender
+│       └── it should not make any hook call to the recipient
+└── given the recipient is same as the sender
+    ├── when the caller is unknown
+    │   └── it should make one hook call to the sender
+    ├── when the caller is an approved third party
+    │   └── it should make one hook call to the sender
+    └── when the caller is the sender
+        └── it should not make any hook call to the sender

--- a/test/integration/concrete/lockup/withdraw/withdraw.t.sol
+++ b/test/integration/concrete/lockup/withdraw/withdraw.t.sol
@@ -197,10 +197,6 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test, Withdr
         test_Withdraw_CallerRecipient(defaultStreamId, users.sender);
     }
 
-    modifier givenSenderContract() {
-        _;
-    }
-
     function test_Withdraw_SenderDoesNotImplementHook()
         external
         whenNotDelegateCalled
@@ -457,10 +453,6 @@ abstract contract Withdraw_Integration_Concrete_Test is Integration_Test, Withdr
         whenStreamHasNotBeenCanceled
     {
         test_Withdraw_CallerSender(defaultStreamId, users.recipient);
-    }
-
-    modifier givenRecipientContract() {
-        _;
     }
 
     function test_Withdraw_RecipientDoesNotImplementHook()

--- a/test/integration/shared/lockup-dynamic/LockupDynamic.t.sol
+++ b/test/integration/shared/lockup-dynamic/LockupDynamic.t.sol
@@ -147,4 +147,19 @@ abstract contract LockupDynamic_Integration_Shared_Test is Lockup_Integration_Sh
         params.totalAmount = totalAmount;
         streamId = lockupDynamic.createWithTimestamps(params);
     }
+
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStreamWithUsers(
+        address recipient,
+        address sender
+    )
+        internal
+        override
+        returns (uint256 streamId)
+    {
+        LockupDynamic.CreateWithTimestamps memory params = _params.createWithTimestamps;
+        params.sender = sender;
+        params.recipient = recipient;
+        streamId = lockupDynamic.createWithTimestamps(params);
+    }
 }

--- a/test/integration/shared/lockup-linear/LockupLinear.t.sol
+++ b/test/integration/shared/lockup-linear/LockupLinear.t.sol
@@ -113,4 +113,19 @@ abstract contract LockupLinear_Integration_Shared_Test is Lockup_Integration_Sha
         params.totalAmount = totalAmount;
         streamId = lockupLinear.createWithTimestamps(params);
     }
+
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStreamWithUsers(
+        address recipient,
+        address sender
+    )
+        internal
+        override
+        returns (uint256 streamId)
+    {
+        LockupLinear.CreateWithTimestamps memory params = _params.createWithTimestamps;
+        params.sender = sender;
+        params.recipient = recipient;
+        streamId = lockupLinear.createWithTimestamps(params);
+    }
 }

--- a/test/integration/shared/lockup-tranched/LockupTranched.t.sol
+++ b/test/integration/shared/lockup-tranched/LockupTranched.t.sol
@@ -156,4 +156,19 @@ abstract contract LockupTranched_Integration_Shared_Test is Lockup_Integration_S
         params.totalAmount = totalAmount;
         streamId = lockupTranched.createWithTimestamps(params);
     }
+
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStreamWithUsers(
+        address recipient,
+        address sender
+    )
+        internal
+        override
+        returns (uint256 streamId)
+    {
+        LockupTranched.CreateWithTimestamps memory params = _params.createWithTimestamps;
+        params.sender = sender;
+        params.recipient = recipient;
+        streamId = lockupTranched.createWithTimestamps(params);
+    }
 }

--- a/test/integration/shared/lockup/Lockup.t.sol
+++ b/test/integration/shared/lockup/Lockup.t.sol
@@ -41,6 +41,11 @@ abstract contract Lockup_Integration_Shared_Test is Base_Test {
     /// @dev Creates the default stream with the NFT transfer disabled.
     function createDefaultStreamNotTransferable() internal virtual returns (uint256 streamId);
 
+    /// @dev Creates the default stream with recipient as the sender.
+    function createDefaultStreamToSender(address sender) internal virtual returns (uint256 streamId) {
+        return createDefaultStreamWithUsers(sender, sender);
+    }
+
     /// @dev Creates the default stream with the provided address.
     function createDefaultStreamWithAsset(IERC20 asset) internal virtual returns (uint256 streamId);
 
@@ -61,4 +66,13 @@ abstract contract Lockup_Integration_Shared_Test is Base_Test {
 
     /// @dev Creates the default stream with the provided total amount.
     function createDefaultStreamWithTotalAmount(uint128 totalAmount) internal virtual returns (uint256 streamId);
+
+    /// @dev Creates the default stream with the provided sender and recipient.
+    function createDefaultStreamWithUsers(
+        address recipient,
+        address sender
+    )
+        internal
+        virtual
+        returns (uint256 streamId);
 }

--- a/test/integration/shared/lockup/withdraw.t.sol
+++ b/test/integration/shared/lockup/withdraw.t.sol
@@ -19,6 +19,14 @@ abstract contract Withdraw_Integration_Shared_Test is Lockup_Integration_Shared_
         _;
     }
 
+    modifier givenRecipientContract() {
+        _;
+    }
+
+    modifier givenSenderContract() {
+        _;
+    }
+
     modifier givenStreamNotDepleted() {
         vm.warp({ newTimestamp: defaults.START_TIME() });
         _;

--- a/test/utils/Assertions.sol
+++ b/test/utils/Assertions.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable event-name-camelcase
 pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";


### PR DESCRIPTION
- As identified by @PaulRBerg in https://github.com/sablier-labs/v2-core/pull/826#issuecomment-2027572212, this PR brings back the tests for withdraw hooks
- Adds `solhint-disable event-name-camelcase` rule in Assertions