### PR TITLE
fix: use `segmentCountMap` and `trancheCountMap` in forge scripts

### DIFF
--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -12,7 +12,7 @@ contract BaseScript is Script {
     using Strings for uint256;
     using stdJson for string;
 
-    /// @dev The default value for `maxSegmentCount` and `maxTrancheCount`.
+    /// @dev The default value for `segmentCountMap` and `trancheCountMap`.
     uint256 internal constant DEFAULT_MAX_COUNT = 500;
 
     /// @dev Included to enable compilation of the script without a $MNEMONIC environment variable.
@@ -23,12 +23,6 @@ contract BaseScript is Script {
 
     /// @dev The address of the transaction broadcaster.
     address internal broadcaster;
-
-    /// @dev The upper limit on the length of segments to ensure that transactions stay within the block gas limit.
-    uint256 internal maxSegmentCount;
-
-    /// @dev The upper limit on the length of tranches to ensure that transactions stay within the block gas limit.
-    uint256 internal maxTrancheCount;
 
     /// @dev Used to derive the broadcaster's address if $EOA is not defined.
     string internal mnemonic;
@@ -60,10 +54,10 @@ contract BaseScript is Script {
 
         // If there is no maximum value set for a specific chain, set a default value.
         if (segmentCountMap[block.chainid] == 0) {
-            maxSegmentCount = DEFAULT_MAX_COUNT;
+            segmentCountMap[block.chainid] = DEFAULT_MAX_COUNT;
         }
         if (trancheCountMap[block.chainid] == 0) {
-            maxTrancheCount = DEFAULT_MAX_COUNT;
+            trancheCountMap[block.chainid] = DEFAULT_MAX_COUNT;
         }
     }
 

--- a/script/DeployCore.s.sol
+++ b/script/DeployCore.s.sol
@@ -28,8 +28,8 @@ contract DeployCore is BaseScript {
         )
     {
         nftDescriptor = new SablierV2NFTDescriptor();
-        lockupDynamic = new SablierV2LockupDynamic(initialAdmin, nftDescriptor, maxSegmentCount);
+        lockupDynamic = new SablierV2LockupDynamic(initialAdmin, nftDescriptor, segmentCountMap[block.chainid]);
         lockupLinear = new SablierV2LockupLinear(initialAdmin, nftDescriptor);
-        lockupTranched = new SablierV2LockupTranched(initialAdmin, nftDescriptor, maxTrancheCount);
+        lockupTranched = new SablierV2LockupTranched(initialAdmin, nftDescriptor, trancheCountMap[block.chainid]);
     }
 }

--- a/script/DeployCore2.s.sol
+++ b/script/DeployCore2.s.sol
@@ -28,8 +28,8 @@ contract DeployCore2 is BaseScript {
             SablierV2LockupTranched lockupTranched
         )
     {
-        lockupDynamic = new SablierV2LockupDynamic(initialAdmin, nftDescriptor, maxSegmentCount);
+        lockupDynamic = new SablierV2LockupDynamic(initialAdmin, nftDescriptor, segmentCountMap[block.chainid]);
         lockupLinear = new SablierV2LockupLinear(initialAdmin, nftDescriptor);
-        lockupTranched = new SablierV2LockupTranched(initialAdmin, nftDescriptor, maxTrancheCount);
+        lockupTranched = new SablierV2LockupTranched(initialAdmin, nftDescriptor, trancheCountMap[block.chainid]);
     }
 }

--- a/script/DeployDeterministicCore.s.sol
+++ b/script/DeployDeterministicCore.s.sol
@@ -31,8 +31,10 @@ contract DeployDeterministicCore is BaseScript {
     {
         bytes32 salt = constructCreate2Salt();
         nftDescriptor = new SablierV2NFTDescriptor{ salt: salt }();
-        lockupDynamic = new SablierV2LockupDynamic{ salt: salt }(initialAdmin, nftDescriptor, maxSegmentCount);
+        lockupDynamic =
+            new SablierV2LockupDynamic{ salt: salt }(initialAdmin, nftDescriptor, segmentCountMap[block.chainid]);
         lockupLinear = new SablierV2LockupLinear{ salt: salt }(initialAdmin, nftDescriptor);
-        lockupTranched = new SablierV2LockupTranched{ salt: salt }(initialAdmin, nftDescriptor, maxTrancheCount);
+        lockupTranched =
+            new SablierV2LockupTranched{ salt: salt }(initialAdmin, nftDescriptor, trancheCountMap[block.chainid]);
     }
 }

--- a/script/DeployDeterministicCore2.s.sol
+++ b/script/DeployDeterministicCore2.s.sol
@@ -31,8 +31,10 @@ contract DeployDeterministicCore2 is BaseScript {
         )
     {
         bytes32 salt = constructCreate2Salt();
-        lockupDynamic = new SablierV2LockupDynamic{ salt: salt }(initialAdmin, nftDescriptor, maxSegmentCount);
+        lockupDynamic =
+            new SablierV2LockupDynamic{ salt: salt }(initialAdmin, nftDescriptor, segmentCountMap[block.chainid]);
         lockupLinear = new SablierV2LockupLinear{ salt: salt }(initialAdmin, nftDescriptor);
-        lockupTranched = new SablierV2LockupTranched{ salt: salt }(initialAdmin, nftDescriptor, maxTrancheCount);
+        lockupTranched =
+            new SablierV2LockupTranched{ salt: salt }(initialAdmin, nftDescriptor, trancheCountMap[block.chainid]);
     }
 }

--- a/script/DeployDeterministicLockupDynamic.s.sol
+++ b/script/DeployDeterministicLockupDynamic.s.sol
@@ -20,6 +20,7 @@ contract DeployDeterministicLockupDynamic is BaseScript {
         returns (SablierV2LockupDynamic lockupDynamic)
     {
         bytes32 salt = constructCreate2Salt();
-        lockupDynamic = new SablierV2LockupDynamic{ salt: salt }(initialAdmin, initialNFTDescriptor, maxSegmentCount);
+        lockupDynamic =
+            new SablierV2LockupDynamic{ salt: salt }(initialAdmin, initialNFTDescriptor, segmentCountMap[block.chainid]);
     }
 }

--- a/script/DeployDeterministicLockupTranched.s.sol
+++ b/script/DeployDeterministicLockupTranched.s.sol
@@ -20,6 +20,8 @@ contract DeployDeterministicLockupTranched is BaseScript {
         returns (SablierV2LockupTranched lockupTranched)
     {
         bytes32 salt = constructCreate2Salt();
-        lockupTranched = new SablierV2LockupTranched{ salt: salt }(initialAdmin, initialNFTDescriptor, maxTrancheCount);
+        lockupTranched = new SablierV2LockupTranched{ salt: salt }(
+            initialAdmin, initialNFTDescriptor, trancheCountMap[block.chainid]
+        );
     }
 }

--- a/script/DeployLockupDynamic.s.sol
+++ b/script/DeployLockupDynamic.s.sol
@@ -17,6 +17,6 @@ contract DeployLockupDynamic is BaseScript {
         broadcast
         returns (SablierV2LockupDynamic lockupDynamic)
     {
-        lockupDynamic = new SablierV2LockupDynamic(initialAdmin, initialNFTDescriptor, maxSegmentCount);
+        lockupDynamic = new SablierV2LockupDynamic(initialAdmin, initialNFTDescriptor, segmentCountMap[block.chainid]);
     }
 }

--- a/script/DeployLockupTranched.s.sol
+++ b/script/DeployLockupTranched.s.sol
@@ -17,6 +17,6 @@ contract DeployLockupTranched is BaseScript {
         broadcast
         returns (SablierV2LockupTranched lockupTranched)
     {
-        lockupTranched = new SablierV2LockupTranched(initialAdmin, initialNFTDescriptor, maxTrancheCount);
+        lockupTranched = new SablierV2LockupTranched(initialAdmin, initialNFTDescriptor, trancheCountMap[block.chainid]);
     }
 }


### PR DESCRIPTION
Since `maxSegmentCount` and `maxTrancheCount` have still been used in forge scripts, the contracts would be deployed with 0 value for `MAX_SEGEMENT_COUNT` and `MAX_TRANCHE_COUNT`. 