### PR TITLE
test: keep gas usage below foundry 1B limit

### DIFF
--- a/test/integration/concrete/lockup-dynamic/create-with-durations/createWithDurations.t.sol
+++ b/test/integration/concrete/lockup-dynamic/create-with-durations/createWithDurations.t.sol
@@ -33,17 +33,13 @@ contract CreateWithDurations_LockupDynamic_Integration_Concrete_Test is
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_LoopCalculationOverflowsBlockGasLimit() external whenNotDelegateCalled {
-        LockupDynamic.SegmentWithDuration[] memory segments = new LockupDynamic.SegmentWithDuration[](250_000);
-        vm.expectRevert(bytes(""));
+    function test_RevertWhen_SegmentCountTooHigh() external whenNotDelegateCalled {
+        LockupDynamic.SegmentWithDuration[] memory segments = new LockupDynamic.SegmentWithDuration[](25_000);
+        vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2LockupDynamic_SegmentCountTooHigh.selector, 25_000));
         createDefaultStreamWithDurations(segments);
     }
 
-    function test_RevertWhen_DurationsZero()
-        external
-        whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
-    {
+    function test_RevertWhen_DurationsZero() external whenNotDelegateCalled whenSegmentCountNotTooHigh {
         uint40 startTime = getBlockTimestamp();
         LockupDynamic.SegmentWithDuration[] memory segments = defaults.createWithDurationsLD().segments;
         segments[1].duration = 0;
@@ -62,7 +58,7 @@ contract CreateWithDurations_LockupDynamic_Integration_Concrete_Test is
     function test_RevertWhen_TimestampsCalculationsOverflows_StartTimeNotLessThanFirstSegmentTimestamp()
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenSegmentCountNotTooHigh
         whenDurationsNotZero
     {
         unchecked {
@@ -83,7 +79,7 @@ contract CreateWithDurations_LockupDynamic_Integration_Concrete_Test is
     function test_RevertWhen_TimestampsCalculationsOverflows_SegmentTimestampsNotOrdered()
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenSegmentCountNotTooHigh
         whenDurationsNotZero
     {
         unchecked {
@@ -118,7 +114,7 @@ contract CreateWithDurations_LockupDynamic_Integration_Concrete_Test is
     function test_CreateWithDurations()
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenSegmentCountNotTooHigh
         whenDurationsNotZero
         whenTimestampsCalculationsDoNotOverflow
     {

--- a/test/integration/concrete/lockup-dynamic/create-with-durations/createWithDurations.tree
+++ b/test/integration/concrete/lockup-dynamic/create-with-durations/createWithDurations.tree
@@ -2,9 +2,9 @@ createWithDurations.t.sol
 ├── when delegate called
 │  └── it should revert
 └── when not delegate called
-   ├── when the loop calculations overflow the block gas limit
+   ├── when the segment count is too high
    │  └── it should revert
-   └── when the loop calculations do not overflow the block gas limit
+   └── when the segment count is not too high
        ├── when at least one of the durations at index one or greater is zero
        │  └── it should revert
        └── when none of the durations is zero

--- a/test/integration/concrete/lockup-tranched/create-with-durations/createWithDurations.t.sol
+++ b/test/integration/concrete/lockup-tranched/create-with-durations/createWithDurations.t.sol
@@ -31,17 +31,13 @@ contract CreateWithDurations_LockupTranched_Integration_Concrete_Test is
     }
 
     /// @dev it should revert.
-    function test_RevertWhen_LoopCalculationOverflowsBlockGasLimit() external whenNotDelegateCalled {
+    function test_RevertWhen_TrancheCountTooHigh() external whenNotDelegateCalled {
         LockupTranched.TrancheWithDuration[] memory tranches = new LockupTranched.TrancheWithDuration[](25_000);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2LockupTranched_TrancheCountTooHigh.selector, 25_000));
         createDefaultStreamWithDurations(tranches);
     }
 
-    function test_RevertWhen_DurationsZero()
-        external
-        whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
-    {
+    function test_RevertWhen_DurationsZero() external whenNotDelegateCalled whenTrancheCountNotTooHigh {
         uint40 startTime = getBlockTimestamp();
         LockupTranched.TrancheWithDuration[] memory tranches = defaults.createWithDurationsLT().tranches;
         tranches[2].duration = 0;
@@ -60,7 +56,7 @@ contract CreateWithDurations_LockupTranched_Integration_Concrete_Test is
     function test_RevertWhen_TimestampsCalculationsOverflows_StartTimeNotLessThanFirstTrancheTimestamp()
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenTrancheCountNotTooHigh
         whenDurationsNotZero
     {
         unchecked {
@@ -81,7 +77,7 @@ contract CreateWithDurations_LockupTranched_Integration_Concrete_Test is
     function test_RevertWhen_TimestampsCalculationsOverflows_TrancheTimestampsNotOrdered()
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenTrancheCountNotTooHigh
         whenDurationsNotZero
     {
         unchecked {
@@ -112,7 +108,7 @@ contract CreateWithDurations_LockupTranched_Integration_Concrete_Test is
     function test_CreateWithDurations()
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenTrancheCountNotTooHigh
         whenDurationsNotZero
         whenTimestampsCalculationsDoNotOverflow
     {

--- a/test/integration/concrete/lockup-tranched/create-with-durations/createWithDurations.tree
+++ b/test/integration/concrete/lockup-tranched/create-with-durations/createWithDurations.tree
@@ -2,9 +2,9 @@ createWithDurations.t.sol
 ├── when delegate called
 │  └── it should revert
 └── when not delegate called
-   ├── when the loop calculations overflow the block gas limit
+   ├── when the tranche count is too high
    │  └── it should revert
-   └── when the loop calculations do not overflow the block gas limit
+   └── when the tranche count is not too high
        ├── when at least one of the durations at index one or greater is zero
        │  └── it should revert
        └── when none of the durations is zero

--- a/test/integration/fuzz/lockup-dynamic/createWithDurations.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/createWithDurations.t.sol
@@ -37,7 +37,7 @@ contract CreateWithDurations_LockupDynamic_Integration_Fuzz_Test is
     function testFuzz_CreateWithDurations(LockupDynamic.SegmentWithDuration[] memory segments)
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenSegmentCountNotTooHigh
         whenDurationsNotZero
         whenTimestampsCalculationsDoNotOverflow
     {

--- a/test/integration/fuzz/lockup-dynamic/createWithTimestamps.t.sol
+++ b/test/integration/fuzz/lockup-dynamic/createWithTimestamps.t.sol
@@ -31,7 +31,7 @@ contract CreateWithTimestamps_LockupDynamic_Integration_Fuzz_Test is
         whenSegmentCountNotZero
     {
         uint256 defaultMax = defaults.MAX_SEGMENT_COUNT();
-        segmentCount = _bound(segmentCount, defaultMax + 1, defaultMax * 10);
+        segmentCount = _bound(segmentCount, defaultMax + 1, defaultMax * 2);
         LockupDynamic.Segment[] memory segments = new LockupDynamic.Segment[](segmentCount);
         vm.expectRevert(
             abi.encodeWithSelector(Errors.SablierV2LockupDynamic_SegmentCountTooHigh.selector, segmentCount)

--- a/test/integration/fuzz/lockup-tranched/createWithDurations.t.sol
+++ b/test/integration/fuzz/lockup-tranched/createWithDurations.t.sol
@@ -37,7 +37,7 @@ contract CreateWithDurations_LockupTranched_Integration_Fuzz_Test is
     function testFuzz_CreateWithDurations(LockupTranched.TrancheWithDuration[] memory tranches)
         external
         whenNotDelegateCalled
-        whenLoopCalculationsDoNotOverflowBlockGasLimit
+        whenTrancheCountNotTooHigh
         whenDurationsNotZero
         whenTimestampsCalculationsDoNotOverflow
     {

--- a/test/integration/shared/lockup/createWithDurations.t.sol
+++ b/test/integration/shared/lockup/createWithDurations.t.sol
@@ -18,11 +18,11 @@ abstract contract CreateWithDurations_Integration_Shared_Test is Lockup_Integrat
         _;
     }
 
-    modifier whenLoopCalculationsDoNotOverflowBlockGasLimit() {
+    modifier whenNotDelegateCalled() {
         _;
     }
 
-    modifier whenNotDelegateCalled() {
+    modifier whenSegmentCountNotTooHigh() {
         _;
     }
 
@@ -31,6 +31,10 @@ abstract contract CreateWithDurations_Integration_Shared_Test is Lockup_Integrat
     }
 
     modifier whenTotalDurationCalculationDoesNotOverflow() {
+        _;
+    }
+
+    modifier whenTrancheCountNotTooHigh() {
         _;
     }
 }


### PR DESCRIPTION
### Changelog
- Closes https://github.com/sablier-labs/v2-core/issues/956
- Replaced `test_RevertWhen_LoopCalculationOverflowsBlockGasLimit` with `test_RevertWhen_SegmentCountTooHigh` since the function reverts if the count exceeds the max count defined in the contract. https://github.com/sablier-labs/v2-core/blob/3ee63dbeb570b133eb4095e211a5e736704c144c/src/libraries/Helpers.sol#L138

So we may not need the loop test anymore.