### PR TITLE
refactor: reorder constant functions in interface

### DIFF
--- a/src/interfaces/ISablierV2Lockup.sol
+++ b/src/interfaces/ISablierV2Lockup.sol
@@ -67,6 +67,11 @@ interface ISablierV2Lockup is
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @notice Retrieves the maximum broker fee that can be charged by the broker, denoted as a fixed-point
+    /// number where 1e18 is 100%.
+    /// @dev This value is hard coded as a constant.
+    function MAX_BROKER_FEE() external view returns (UD60x18);
+
     /// @notice Retrieves the address of the ERC-20 asset to be distributed.
     /// @dev Reverts if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
@@ -143,11 +148,6 @@ interface ISablierV2Lockup is
     /// @dev Reverts if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
     function isWarm(uint256 streamId) external view returns (bool result);
-
-    /// @notice Retrieves the maximum broker fee that can be charged by the broker, denoted as a fixed-point
-    /// number where 1e18 is 100%.
-    /// @dev This value is hard coded as a constant.
-    function MAX_BROKER_FEE() external view returns (UD60x18);
 
     /// @notice Counter for stream IDs, used in the create functions.
     function nextStreamId() external view returns (uint256);

--- a/src/interfaces/ISablierV2LockupDynamic.sol
+++ b/src/interfaces/ISablierV2LockupDynamic.sol
@@ -44,6 +44,10 @@ interface ISablierV2LockupDynamic is ISablierV2Lockup {
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @notice The maximum number of segments allowed in a stream.
+    /// @dev This is initialized at construction time and cannot be changed later.
+    function MAX_SEGMENT_COUNT() external view returns (uint256);
+
     /// @notice Retrieves the segments used to compose the dynamic distribution function.
     /// @dev Reverts if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
@@ -60,10 +64,6 @@ interface ISablierV2LockupDynamic is ISablierV2Lockup {
     /// @param streamId The stream ID for the query.
     /// @return timestamps See the documentation in {DataTypes}.
     function getTimestamps(uint256 streamId) external view returns (LockupDynamic.Timestamps memory timestamps);
-
-    /// @notice The maximum number of segments allowed in a stream.
-    /// @dev This is initialized at construction time and cannot be changed later.
-    function MAX_SEGMENT_COUNT() external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////////////////
                                NON-CONSTANT FUNCTIONS

--- a/src/interfaces/ISablierV2LockupTranched.sol
+++ b/src/interfaces/ISablierV2LockupTranched.sol
@@ -44,6 +44,10 @@ interface ISablierV2LockupTranched is ISablierV2Lockup {
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @notice The maximum number of tranches allowed in a stream.
+    /// @dev This is initialized at construction time and cannot be changed later.
+    function MAX_TRANCHE_COUNT() external view returns (uint256);
+
     /// @notice Retrieves the full stream details.
     /// @dev Reverts if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
@@ -60,10 +64,6 @@ interface ISablierV2LockupTranched is ISablierV2Lockup {
     /// @dev Reverts if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
     function getTranches(uint256 streamId) external view returns (LockupTranched.Tranche[] memory tranches);
-
-    /// @notice The maximum number of tranches allowed in a stream.
-    /// @dev This is initialized at construction time and cannot be changed later.
-    function MAX_TRANCHE_COUNT() external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////////////////
                                NON-CONSTANT FUNCTIONS


### PR DESCRIPTION
Let's put constants at the top from here on out.