### PR TITLE
feat: use `createWithTimestamps` in `claim`

### DIFF
--- a/script/periphery/CreateMerkleLL.s.sol
+++ b/script/periphery/CreateMerkleLL.s.sol
@@ -7,7 +7,7 @@ import { ISablierLockupLinear } from "../../src/core/interfaces/ISablierLockupLi
 import { LockupLinear } from "../../src/core/types/DataTypes.sol";
 import { ISablierMerkleFactory } from "../../src/periphery/interfaces/ISablierMerkleFactory.sol";
 import { ISablierMerkleLL } from "../../src/periphery/interfaces/ISablierMerkleLL.sol";
-import { MerkleBase } from "../../src/periphery/types/DataTypes.sol";
+import { MerkleBase, MerkleLL } from "../../src/periphery/types/DataTypes.sol";
 
 import { BaseScript } from "../Base.s.sol";
 
@@ -33,7 +33,11 @@ contract CreateMerkleLL is BaseScript {
             lockupLinear: ISablierLockupLinear(0x3962f6585946823440d274aD7C719B02b49DE51E),
             cancelable: true,
             transferable: true,
-            streamDurations: LockupLinear.Durations({ cliff: 0, total: 3600 }),
+            schedule: MerkleLL.Schedule({
+                startTime: 0, // i.e. block.timestamp
+                cliffDuration: 30 days,
+                totalDuration: 90 days
+            }),
             aggregateAmount: 10_000e18,
             recipientCount: 100
         });

--- a/script/periphery/CreateMerkleLL.s.sol
+++ b/script/periphery/CreateMerkleLL.s.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.22 <0.9.0;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { ISablierLockupLinear } from "../../src/core/interfaces/ISablierLockupLinear.sol";
-import { LockupLinear } from "../../src/core/types/DataTypes.sol";
 import { ISablierMerkleFactory } from "../../src/periphery/interfaces/ISablierMerkleFactory.sol";
 import { ISablierMerkleLL } from "../../src/periphery/interfaces/ISablierMerkleLL.sol";
 import { MerkleBase, MerkleLL } from "../../src/periphery/types/DataTypes.sol";

--- a/script/periphery/CreateMerkleLT.s.sol
+++ b/script/periphery/CreateMerkleLT.s.sol
@@ -39,6 +39,7 @@ contract CreateMerkleLT is BaseScript {
             lockupTranched: ISablierLockupTranched(0xf86B359035208e4529686A1825F2D5BeE38c28A8),
             cancelable: true,
             transferable: true,
+            streamStartTime: 0, // i.e. block.timestamp
             tranchesWithPercentages: tranchesWithPercentages,
             aggregateAmount: 10_000e18,
             recipientCount: 100

--- a/src/periphery/SablierMerkleFactory.sol
+++ b/src/periphery/SablierMerkleFactory.sol
@@ -5,7 +5,6 @@ import { uUNIT } from "@prb/math/src/UD2x18.sol";
 
 import { ISablierLockupLinear } from "../core/interfaces/ISablierLockupLinear.sol";
 import { ISablierLockupTranched } from "../core/interfaces/ISablierLockupTranched.sol";
-import { LockupLinear } from "../core/types/DataTypes.sol";
 
 import { ISablierMerkleFactory } from "./interfaces/ISablierMerkleFactory.sol";
 import { ISablierMerkleInstant } from "./interfaces/ISablierMerkleInstant.sol";

--- a/src/periphery/SablierMerkleLL.sol
+++ b/src/periphery/SablierMerkleLL.sol
@@ -73,8 +73,15 @@ contract SablierMerkleLL is
         } else {
             timestamps.start = schedule.startTime;
         }
-        timestamps.cliff = timestamps.start + schedule.cliffDuration;
-        timestamps.end = timestamps.start + schedule.endDuration;
+
+        // It is safe to use unchecked arithmetic because the `createWithTimestamps` function in the Lockup contract
+        // will nonetheless make the relevant checks.
+        unchecked {
+            if (schedule.cliffDuration > 0) {
+                timestamps.cliff = timestamps.start + schedule.cliffDuration;
+            }
+            timestamps.end = timestamps.start + schedule.endDuration;
+        }
 
         // Interaction: create the stream via {SablierLockupLinear}.
         uint256 streamId = LOCKUP_LINEAR.createWithTimestamps(

--- a/src/periphery/SablierMerkleLL.sol
+++ b/src/periphery/SablierMerkleLL.sol
@@ -80,7 +80,7 @@ contract SablierMerkleLL is
             if (schedule.cliffDuration > 0) {
                 timestamps.cliff = timestamps.start + schedule.cliffDuration;
             }
-            timestamps.end = timestamps.start + schedule.endDuration;
+            timestamps.end = timestamps.start + schedule.totalDuration;
         }
 
         // Interaction: create the stream via {SablierLockupLinear}.

--- a/src/periphery/SablierMerkleLL.sol
+++ b/src/periphery/SablierMerkleLL.sol
@@ -10,7 +10,7 @@ import { Broker, LockupLinear } from "../core/types/DataTypes.sol";
 
 import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { ISablierMerkleLL } from "./interfaces/ISablierMerkleLL.sol";
-import { MerkleBase } from "./types/DataTypes.sol";
+import { MerkleBase, MerkleLL } from "./types/DataTypes.sol";
 
 /// @title SablierMerkleLL
 /// @notice See the documentation in {ISablierMerkleLL}.
@@ -34,7 +34,7 @@ contract SablierMerkleLL is
     bool public immutable override TRANSFERABLE;
 
     /// @inheritdoc ISablierMerkleLL
-    LockupLinear.Durations public override streamDurations;
+    MerkleLL.Schedule public override schedule;
 
     /*//////////////////////////////////////////////////////////////////////////
                                     CONSTRUCTOR
@@ -47,14 +47,14 @@ contract SablierMerkleLL is
         ISablierLockupLinear lockupLinear,
         bool cancelable,
         bool transferable,
-        LockupLinear.Durations memory streamDurations_
+        MerkleLL.Schedule memory schedule_
     )
         SablierMerkleBase(baseParams)
     {
         CANCELABLE = cancelable;
         LOCKUP_LINEAR = lockupLinear;
         TRANSFERABLE = transferable;
-        streamDurations = streamDurations_;
+        schedule = schedule_;
 
         // Max approve the Lockup contract to spend funds from the MerkleLL contract.
         ASSET.forceApprove(address(LOCKUP_LINEAR), type(uint256).max);
@@ -66,16 +66,26 @@ contract SablierMerkleLL is
 
     /// @inheritdoc SablierMerkleBase
     function _claim(uint256 index, address recipient, uint128 amount) internal override {
+        // Calculate the timestamps for the stream.
+        LockupLinear.Timestamps memory timestamps;
+        if (schedule.startTime == 0) {
+            timestamps.start = uint40(block.timestamp);
+        } else {
+            timestamps.start = schedule.startTime;
+        }
+        timestamps.cliff = timestamps.start + schedule.cliffDuration;
+        timestamps.end = timestamps.start + schedule.endDuration;
+
         // Interaction: create the stream via {SablierLockupLinear}.
-        uint256 streamId = LOCKUP_LINEAR.createWithDurations(
-            LockupLinear.CreateWithDurations({
+        uint256 streamId = LOCKUP_LINEAR.createWithTimestamps(
+            LockupLinear.CreateWithTimestamps({
                 sender: admin,
                 recipient: recipient,
                 totalAmount: amount,
                 asset: ASSET,
                 cancelable: CANCELABLE,
                 transferable: TRANSFERABLE,
-                durations: streamDurations,
+                timestamps: timestamps,
                 broker: Broker({ account: address(0), fee: ud(0) })
             })
         );

--- a/src/periphery/SablierMerkleLT.sol
+++ b/src/periphery/SablierMerkleLT.sol
@@ -30,10 +30,10 @@ contract SablierMerkleLT is
     bool public immutable override CANCELABLE;
 
     /// @inheritdoc ISablierMerkleLT
-    uint40 public immutable override START_TIME;
+    ISablierLockupTranched public immutable override LOCKUP_TRANCHED;
 
     /// @inheritdoc ISablierMerkleLT
-    ISablierLockupTranched public immutable override LOCKUP_TRANCHED;
+    uint40 public immutable override STREAM_START_TIME;
 
     /// @inheritdoc ISablierMerkleLT
     uint64 public immutable override TOTAL_PERCENTAGE;
@@ -55,14 +55,14 @@ contract SablierMerkleLT is
         ISablierLockupTranched lockupTranched,
         bool cancelable,
         bool transferable,
-        uint40 startTime,
+        uint40 streamStartTime,
         MerkleLT.TrancheWithPercentage[] memory tranchesWithPercentages
     )
         SablierMerkleBase(baseParams)
     {
         CANCELABLE = cancelable;
-        START_TIME = startTime;
         LOCKUP_TRANCHED = lockupTranched;
+        STREAM_START_TIME = streamStartTime;
         TRANSFERABLE = transferable;
 
         uint256 count = tranchesWithPercentages.length;
@@ -136,10 +136,10 @@ contract SablierMerkleLT is
         returns (uint40 startTime, LockupTranched.Tranche[] memory tranches)
     {
         // Calculate the start time.
-        if (START_TIME == 0) {
+        if (STREAM_START_TIME == 0) {
             startTime = uint40(block.timestamp);
         } else {
-            startTime = START_TIME;
+            startTime = STREAM_START_TIME;
         }
 
         // Load the tranches in memory (to save gas).

--- a/src/periphery/SablierMerkleLT.sol
+++ b/src/periphery/SablierMerkleLT.sol
@@ -160,10 +160,17 @@ contract SablierMerkleLT is
             uint128 calculatedAmount = claimAmountUD.mul(percentage).intoUint128();
 
             // Create the tranche.
-            tranches[i] = LockupTranched.Tranche({
-                amount: calculatedAmount,
-                timestamp: startTime + tranchesWithPercentages[i].duration
-            });
+            if (i > 0) {
+                tranches[i] = LockupTranched.Tranche({
+                    amount: calculatedAmount,
+                    timestamp: tranches[i - 1].timestamp + tranchesWithPercentages[i].duration
+                });
+            } else {
+                tranches[i] = LockupTranched.Tranche({
+                    amount: calculatedAmount,
+                    timestamp: startTime + tranchesWithPercentages[i].duration
+                });
+            }
 
             // Add the calculated tranche amount.
             calculatedAmountsSum += calculatedAmount;

--- a/src/periphery/interfaces/ISablierMerkleFactory.sol
+++ b/src/periphery/interfaces/ISablierMerkleFactory.sol
@@ -8,7 +8,7 @@ import { LockupLinear } from "../../core/types/DataTypes.sol";
 import { ISablierMerkleInstant } from "./ISablierMerkleInstant.sol";
 import { ISablierMerkleLL } from "./ISablierMerkleLL.sol";
 import { ISablierMerkleLT } from "./ISablierMerkleLT.sol";
-import { MerkleBase, MerkleLT } from "../types/DataTypes.sol";
+import { MerkleBase, MerkleLL, MerkleLT } from "../types/DataTypes.sol";
 
 /// @title ISablierMerkleFactory
 /// @notice A contract that deploys Merkle Lockups and Merkle Instant campaigns. Both of these use Merkle proofs for
@@ -37,7 +37,7 @@ interface ISablierMerkleFactory {
         ISablierLockupLinear lockupLinear,
         bool cancelable,
         bool transferable,
-        LockupLinear.Durations streamDurations,
+        MerkleLL.Schedule schedule,
         uint256 aggregateAmount,
         uint256 recipientCount
     );
@@ -49,6 +49,7 @@ interface ISablierMerkleFactory {
         ISablierLockupTranched lockupTranched,
         bool cancelable,
         bool transferable,
+        uint40 streamStartTime,
         MerkleLT.TrancheWithPercentage[] tranchesWithPercentages,
         uint256 totalDuration,
         uint256 aggregateAmount,
@@ -96,7 +97,7 @@ interface ISablierMerkleFactory {
     /// @param lockupLinear The address of the {SablierLockupLinear} contract.
     /// @param cancelable Indicates if the stream will be cancelable after claiming.
     /// @param transferable Indicates if the stream will be transferable after claiming.
-    /// @param streamDurations The durations for each stream.
+    /// @param schedule The time variables to construct the stream timestampts.
     /// @param aggregateAmount The total amount of ERC-20 assets to be distributed to all recipients.
     /// @param recipientCount The total number of recipients who are eligible to claim.
     /// @return merkleLL The address of the newly created Merkle Lockup contract.
@@ -105,7 +106,7 @@ interface ISablierMerkleFactory {
         ISablierLockupLinear lockupLinear,
         bool cancelable,
         bool transferable,
-        LockupLinear.Durations memory streamDurations,
+        MerkleLL.Schedule memory schedule,
         uint256 aggregateAmount,
         uint256 recipientCount
     )
@@ -120,6 +121,7 @@ interface ISablierMerkleFactory {
     /// @param lockupTranched The address of the {SablierLockupTranched} contract.
     /// @param cancelable Indicates if the stream will be cancelable after claiming.
     /// @param transferable Indicates if the stream will be transferable after claiming.
+    /// @param streamStartTime The start time of the stream created in `claim`.
     /// @param tranchesWithPercentages The tranches with their respective unlock percentages.
     /// @param aggregateAmount The total amount of ERC-20 assets to be distributed to all recipients.
     /// @param recipientCount The total number of recipients who are eligible to claim.
@@ -129,6 +131,7 @@ interface ISablierMerkleFactory {
         ISablierLockupTranched lockupTranched,
         bool cancelable,
         bool transferable,
+        uint40 streamStartTime,
         MerkleLT.TrancheWithPercentage[] memory tranchesWithPercentages,
         uint256 aggregateAmount,
         uint256 recipientCount

--- a/src/periphery/interfaces/ISablierMerkleFactory.sol
+++ b/src/periphery/interfaces/ISablierMerkleFactory.sol
@@ -3,12 +3,11 @@ pragma solidity >=0.8.22;
 
 import { ISablierLockupLinear } from "../../core/interfaces/ISablierLockupLinear.sol";
 import { ISablierLockupTranched } from "../../core/interfaces/ISablierLockupTranched.sol";
-import { LockupLinear } from "../../core/types/DataTypes.sol";
 
+import { MerkleBase, MerkleLL, MerkleLT } from "../types/DataTypes.sol";
 import { ISablierMerkleInstant } from "./ISablierMerkleInstant.sol";
 import { ISablierMerkleLL } from "./ISablierMerkleLL.sol";
 import { ISablierMerkleLT } from "./ISablierMerkleLT.sol";
-import { MerkleBase, MerkleLL, MerkleLT } from "../types/DataTypes.sol";
 
 /// @title ISablierMerkleFactory
 /// @notice A contract that deploys Merkle Lockups and Merkle Instant campaigns. Both of these use Merkle proofs for
@@ -97,7 +96,7 @@ interface ISablierMerkleFactory {
     /// @param lockupLinear The address of the {SablierLockupLinear} contract.
     /// @param cancelable Indicates if the stream will be cancelable after claiming.
     /// @param transferable Indicates if the stream will be transferable after claiming.
-    /// @param schedule The time variables to construct the stream timestampts.
+    /// @param schedule The time variables to construct the stream timestamps.
     /// @param aggregateAmount The total amount of ERC-20 assets to be distributed to all recipients.
     /// @param recipientCount The total number of recipients who are eligible to claim.
     /// @return merkleLL The address of the newly created Merkle Lockup contract.
@@ -121,7 +120,7 @@ interface ISablierMerkleFactory {
     /// @param lockupTranched The address of the {SablierLockupTranched} contract.
     /// @param cancelable Indicates if the stream will be cancelable after claiming.
     /// @param transferable Indicates if the stream will be transferable after claiming.
-    /// @param streamStartTime The start time of the stream created in `claim`.
+    /// @param streamStartTime The start time of the streams created through `claim`.
     /// @param tranchesWithPercentages The tranches with their respective unlock percentages.
     /// @param aggregateAmount The total amount of ERC-20 assets to be distributed to all recipients.
     /// @param recipientCount The total number of recipients who are eligible to claim.

--- a/src/periphery/interfaces/ISablierMerkleLL.sol
+++ b/src/periphery/interfaces/ISablierMerkleLL.sol
@@ -30,6 +30,7 @@ interface ISablierMerkleLL is ISablierMerkleBase {
     /// @dev This is an immutable state variable.
     function TRANSFERABLE() external returns (bool);
 
-    /// @notice The total streaming duration of each stream.
-    function streamDurations() external view returns (uint40 cliff, uint40 duration);
+    /// @notice The start time, cliff duration and the end duration used to calculate the time variables in
+    /// `LockupLinear.CreateWithTimestamps`.
+    function schedule() external view returns (uint40 startTime, uint40 cliffDuration, uint40 endDuration);
 }

--- a/src/periphery/interfaces/ISablierMerkleLL.sol
+++ b/src/periphery/interfaces/ISablierMerkleLL.sol
@@ -32,5 +32,6 @@ interface ISablierMerkleLL is ISablierMerkleBase {
 
     /// @notice The start time, cliff duration and the end duration used to calculate the time variables in
     /// `LockupLinear.CreateWithTimestamps`.
+    /// @dev A start time value of zero will be considered as `block.timestamp`.
     function schedule() external view returns (uint40 startTime, uint40 cliffDuration, uint40 endDuration);
 }

--- a/src/periphery/interfaces/ISablierMerkleLT.sol
+++ b/src/periphery/interfaces/ISablierMerkleLT.sol
@@ -27,7 +27,7 @@ interface ISablierMerkleLT is ISablierMerkleBase {
     /// @notice The address of the {SablierLockupTranched} contract.
     function LOCKUP_TRANCHED() external view returns (ISablierLockupTranched);
 
-    /// @notice The start time of the stream created in the `claim` function.
+    /// @notice The start time of the streams created through `claim` function.
     /// @dev A start time value of zero will be considered as `block.timestamp`.
     function STREAM_START_TIME() external returns (uint40);
 

--- a/src/periphery/interfaces/ISablierMerkleLT.sol
+++ b/src/periphery/interfaces/ISablierMerkleLT.sol
@@ -24,6 +24,10 @@ interface ISablierMerkleLT is ISablierMerkleBase {
     /// @dev This is an immutable state variable.
     function CANCELABLE() external returns (bool);
 
+    /// @notice The start time of the stream created in the `claim` function.
+    /// @dev A start time value of zero will be considered as `block.timestamp`.
+    function START_TIME() external returns (uint40);
+
     /// @notice The address of the {SablierLockupTranched} contract.
     function LOCKUP_TRANCHED() external view returns (ISablierLockupTranched);
 

--- a/src/periphery/interfaces/ISablierMerkleLT.sol
+++ b/src/periphery/interfaces/ISablierMerkleLT.sol
@@ -24,12 +24,12 @@ interface ISablierMerkleLT is ISablierMerkleBase {
     /// @dev This is an immutable state variable.
     function CANCELABLE() external returns (bool);
 
-    /// @notice The start time of the stream created in the `claim` function.
-    /// @dev A start time value of zero will be considered as `block.timestamp`.
-    function START_TIME() external returns (uint40);
-
     /// @notice The address of the {SablierLockupTranched} contract.
     function LOCKUP_TRANCHED() external view returns (ISablierLockupTranched);
+
+    /// @notice The start time of the stream created in the `claim` function.
+    /// @dev A start time value of zero will be considered as `block.timestamp`.
+    function STREAM_START_TIME() external returns (uint40);
 
     /// @notice The total percentage of the tranches.
     function TOTAL_PERCENTAGE() external view returns (uint64);

--- a/src/periphery/types/DataTypes.sol
+++ b/src/periphery/types/DataTypes.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { UD2x18 } from "@prb/math/src/UD2x18.sol";
 
 import { Broker, LockupDynamic, LockupLinear, LockupTranched } from "../../core/types/DataTypes.sol";
-import { ISablierLockupTranched } from "../../core/interfaces/ISablierLockupTranched.sol";
 
 library BatchLockup {
     /// @notice A struct encapsulating all parameters of {SablierLockupDynamic.createWithDurations} except for the

--- a/src/periphery/types/DataTypes.sol
+++ b/src/periphery/types/DataTypes.sol
@@ -116,15 +116,6 @@ library MerkleLL {
 }
 
 library MerkleLT {
-    struct CreateMerkleLTParams {
-        MerkleBase.ConstructorParams baseParams;
-        ISablierLockupTranched lockupTranched;
-        bool cancelable;
-        bool transferable;
-        uint40 streamStartTime;
-        TrancheWithPercentage[] tranchesWithPercentages;
-    }
-
     /// @notice Struct encapsulating the unlock percentage and duration of a tranche.
     /// @dev Since users may have different amounts allocated, this struct makes it possible to calculate the amounts
     /// at claim time. An 18-decimal format is used to represent percentages: 100% = 1e18. For more information, see

--- a/src/periphery/types/DataTypes.sol
+++ b/src/periphery/types/DataTypes.sol
@@ -5,6 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { UD2x18 } from "@prb/math/src/UD2x18.sol";
 
 import { Broker, LockupDynamic, LockupLinear, LockupTranched } from "../../core/types/DataTypes.sol";
+import { ISablierLockupTranched } from "../../core/interfaces/ISablierLockupTranched.sol";
 
 library BatchLockup {
     /// @notice A struct encapsulating all parameters of {SablierLockupDynamic.createWithDurations} except for the
@@ -104,14 +105,26 @@ library MerkleLL {
     /// @notice Struct encapsulating the start time, cliff duration and the end duration used to construct the time
     /// variables in `LockupLinear.CreateWithTimestamps`.
     /// @dev A start time value of zero will be considered as `block.timestamp`.
+    /// @param startTime The start time of the stream.
+    /// @param cliffDuration The duration of the cliff.
+    /// @param totalDuration The total duration of the stream.
     struct Schedule {
         uint40 startTime;
         uint40 cliffDuration;
-        uint40 endDuration;
+        uint40 totalDuration;
     }
 }
 
 library MerkleLT {
+    struct CreateMerkleLTParams {
+        MerkleBase.ConstructorParams baseParams;
+        ISablierLockupTranched lockupTranched;
+        bool cancelable;
+        bool transferable;
+        uint40 streamStartTime;
+        TrancheWithPercentage[] tranchesWithPercentages;
+    }
+
     /// @notice Struct encapsulating the unlock percentage and duration of a tranche.
     /// @dev Since users may have different amounts allocated, this struct makes it possible to calculate the amounts
     /// at claim time. An 18-decimal format is used to represent percentages: 100% = 1e18. For more information, see

--- a/src/periphery/types/DataTypes.sol
+++ b/src/periphery/types/DataTypes.sol
@@ -100,6 +100,17 @@ library MerkleBase {
     }
 }
 
+library MerkleLL {
+    /// @notice Struct encapsulating the start time, cliff duration and the end duration used to construct the time
+    /// variables in `LockupLinear.CreateWithTimestamps`.
+    /// @dev A start time value of zero will be considered as `block.timestamp`.
+    struct Schedule {
+        uint40 startTime;
+        uint40 cliffDuration;
+        uint40 endDuration;
+    }
+}
+
 library MerkleLT {
     /// @notice Struct encapsulating the unlock percentage and duration of a tranche.
     /// @dev Since users may have different amounts allocated, this struct makes it possible to calculate the amounts

--- a/test/periphery/Periphery.t.sol
+++ b/test/periphery/Periphery.t.sol
@@ -71,7 +71,7 @@ contract Periphery_Test is Base_Test {
                 lockupLinear,
                 defaults.CANCELABLE(),
                 defaults.TRANSFERABLE(),
-                abi.encode(defaults.durations())
+                abi.encode(defaults.schedule())
             )
         );
         bytes32 creationBytecodeHash = keccak256(getMerkleLLBytecode(admin, asset_, merkleRoot, expiration));
@@ -105,6 +105,7 @@ contract Periphery_Test is Base_Test {
                 lockupTranched,
                 defaults.CANCELABLE(),
                 defaults.TRANSFERABLE(),
+                defaults.STREAM_START_TIME(),
                 abi.encode(defaults.tranchesWithPercentages())
             )
         );
@@ -151,7 +152,7 @@ contract Periphery_Test is Base_Test {
             lockupLinear,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
-            defaults.durations()
+            defaults.schedule()
         );
         if (!isTestOptimizedProfile()) {
             return bytes.concat(type(SablierMerkleLL).creationCode, constructorArgs);
@@ -175,6 +176,7 @@ contract Periphery_Test is Base_Test {
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
+            defaults.STREAM_START_TIME(),
             defaults.tranchesWithPercentages()
         );
         if (!isTestOptimizedProfile()) {

--- a/test/periphery/Periphery.t.sol
+++ b/test/periphery/Periphery.t.sol
@@ -105,7 +105,7 @@ contract Periphery_Test is Base_Test {
                 lockupTranched,
                 defaults.CANCELABLE(),
                 defaults.TRANSFERABLE(),
-                defaults.STREAM_START_TIME(),
+                defaults.STREAM_START_TIME_ZERO(),
                 abi.encode(defaults.tranchesWithPercentages())
             )
         );
@@ -176,7 +176,7 @@ contract Periphery_Test is Base_Test {
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
-            defaults.STREAM_START_TIME(),
+            defaults.STREAM_START_TIME_ZERO(),
             defaults.tranchesWithPercentages()
         );
         if (!isTestOptimizedProfile()) {

--- a/test/periphery/fork/merkle-campaign/MerkleLL.t.sol
+++ b/test/periphery/fork/merkle-campaign/MerkleLL.t.sol
@@ -118,7 +118,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
             lockupLinear: lockupLinear,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamDurations: defaults.durations(),
+            schedule: defaults.schedule(),
             aggregateAmount: vars.aggregateAmount,
             recipientCount: vars.recipientCount
         });
@@ -128,7 +128,7 @@ abstract contract MerkleLL_Fork_Test is Fork_Test {
             lockupLinear: lockupLinear,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamDurations: defaults.durations(),
+            schedule: defaults.schedule(),
             aggregateAmount: vars.aggregateAmount,
             recipientCount: vars.recipientCount
         });

--- a/test/periphery/fork/merkle-campaign/MerkleLT.t.sol
+++ b/test/periphery/fork/merkle-campaign/MerkleLT.t.sol
@@ -191,7 +191,10 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             recipient: vars.recipients[params.posBeforeSort],
             sender: params.admin,
             startTime: getBlockTimestamp(),
-            tranches: defaults.tranchesMerkleLT({ totalAmount: vars.amounts[params.posBeforeSort] }),
+            tranches: defaults.tranchesMerkleLT({
+                startTime: getBlockTimestamp(),
+                totalAmount: vars.amounts[params.posBeforeSort]
+            }),
             wasCanceled: false
         });
 

--- a/test/periphery/fork/merkle-campaign/MerkleLT.t.sol
+++ b/test/periphery/fork/merkle-campaign/MerkleLT.t.sol
@@ -119,7 +119,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             lockupTranched: lockupTranched,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamStartTime: defaults.STREAM_START_TIME(),
+            streamStartTime: defaults.STREAM_START_TIME_ZERO(),
             tranchesWithPercentages: defaults.tranchesWithPercentages(),
             totalDuration: defaults.TOTAL_DURATION(),
             aggregateAmount: vars.aggregateAmount,
@@ -131,7 +131,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             lockupTranched: lockupTranched,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamStartTime: defaults.STREAM_START_TIME(),
+            streamStartTime: defaults.STREAM_START_TIME_ZERO(),
             tranchesWithPercentages: defaults.tranchesWithPercentages(),
             aggregateAmount: vars.aggregateAmount,
             recipientCount: vars.recipientCount
@@ -192,7 +192,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             sender: params.admin,
             startTime: getBlockTimestamp(),
             tranches: defaults.tranchesMerkleLT({
-                startTime: getBlockTimestamp(),
+                streamStartTime: defaults.STREAM_START_TIME_ZERO(),
                 totalAmount: vars.amounts[params.posBeforeSort]
             }),
             wasCanceled: false

--- a/test/periphery/fork/merkle-campaign/MerkleLT.t.sol
+++ b/test/periphery/fork/merkle-campaign/MerkleLT.t.sol
@@ -119,6 +119,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             lockupTranched: lockupTranched,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
+            streamStartTime: defaults.STREAM_START_TIME(),
             tranchesWithPercentages: defaults.tranchesWithPercentages(),
             totalDuration: defaults.TOTAL_DURATION(),
             aggregateAmount: vars.aggregateAmount,
@@ -130,6 +131,7 @@ abstract contract MerkleLT_Fork_Test is Fork_Test {
             lockupTranched: lockupTranched,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
+            streamStartTime: defaults.STREAM_START_TIME(),
             tranchesWithPercentages: defaults.tranchesWithPercentages(),
             aggregateAmount: vars.aggregateAmount,
             recipientCount: vars.recipientCount

--- a/test/periphery/integration/merkle-campaign/MerkleCampaign.t.sol
+++ b/test/periphery/integration/merkle-campaign/MerkleCampaign.t.sol
@@ -187,7 +187,7 @@ abstract contract MerkleCampaign_Integration_Test is Periphery_Test {
             lockupTranched: lockupTranched,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamStartTime: defaults.STREAM_START_TIME(),
+            streamStartTime: defaults.STREAM_START_TIME_ZERO(),
             tranchesWithPercentages: defaults.tranchesWithPercentages(),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT()

--- a/test/periphery/integration/merkle-campaign/MerkleCampaign.t.sol
+++ b/test/periphery/integration/merkle-campaign/MerkleCampaign.t.sol
@@ -131,7 +131,7 @@ abstract contract MerkleCampaign_Integration_Test is Periphery_Test {
             lockupLinear: lockupLinear,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamDurations: defaults.durations(),
+            schedule: defaults.schedule(),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT()
         });
@@ -187,6 +187,7 @@ abstract contract MerkleCampaign_Integration_Test is Periphery_Test {
             lockupTranched: lockupTranched,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
+            streamStartTime: defaults.STREAM_START_TIME(),
             tranchesWithPercentages: defaults.tranchesWithPercentages(),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT()

--- a/test/periphery/integration/merkle-campaign/factory/create-merkle-ll/createMerkleLL.t.sol
+++ b/test/periphery/integration/merkle-campaign/factory/create-merkle-ll/createMerkleLL.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22 <0.9.0;
 
-import { LockupLinear } from "src/core/types/DataTypes.sol";
 import { ISablierMerkleLL } from "src/periphery/interfaces/ISablierMerkleLL.sol";
 import { Errors } from "src/periphery/libraries/Errors.sol";
 import { MerkleBase, MerkleLL } from "src/periphery/types/DataTypes.sol";

--- a/test/periphery/integration/merkle-campaign/factory/create-merkle-ll/createMerkleLL.t.sol
+++ b/test/periphery/integration/merkle-campaign/factory/create-merkle-ll/createMerkleLL.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.22 <0.9.0;
 import { LockupLinear } from "src/core/types/DataTypes.sol";
 import { ISablierMerkleLL } from "src/periphery/interfaces/ISablierMerkleLL.sol";
 import { Errors } from "src/periphery/libraries/Errors.sol";
-import { MerkleBase } from "src/periphery/types/DataTypes.sol";
+import { MerkleBase, MerkleLL } from "src/periphery/types/DataTypes.sol";
 
 import { MerkleCampaign_Integration_Test } from "../../MerkleCampaign.t.sol";
 
@@ -13,7 +13,7 @@ contract CreateMerkleLL_Integration_Test is MerkleCampaign_Integration_Test {
         MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
         bool cancelable = defaults.CANCELABLE();
         bool transferable = defaults.TRANSFERABLE();
-        LockupLinear.Durations memory streamDurations = defaults.durations();
+        MerkleLL.Schedule memory schedule = defaults.schedule();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientCount = defaults.RECIPIENT_COUNT();
 
@@ -30,7 +30,7 @@ contract CreateMerkleLL_Integration_Test is MerkleCampaign_Integration_Test {
             lockupLinear: lockupLinear,
             cancelable: cancelable,
             transferable: transferable,
-            streamDurations: streamDurations,
+            schedule: schedule,
             aggregateAmount: aggregateAmount,
             recipientCount: recipientCount
         });
@@ -45,7 +45,7 @@ contract CreateMerkleLL_Integration_Test is MerkleCampaign_Integration_Test {
         MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
         bool cancelable = defaults.CANCELABLE();
         bool transferable = defaults.TRANSFERABLE();
-        LockupLinear.Durations memory streamDurations = defaults.durations();
+        MerkleLL.Schedule memory schedule = defaults.schedule();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientCount = defaults.RECIPIENT_COUNT();
 
@@ -56,7 +56,7 @@ contract CreateMerkleLL_Integration_Test is MerkleCampaign_Integration_Test {
             lockupLinear: lockupLinear,
             cancelable: cancelable,
             transferable: transferable,
-            streamDurations: streamDurations,
+            schedule: schedule,
             aggregateAmount: aggregateAmount,
             recipientCount: recipientCount
         });
@@ -91,7 +91,7 @@ contract CreateMerkleLL_Integration_Test is MerkleCampaign_Integration_Test {
             lockupLinear: lockupLinear,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamDurations: defaults.durations(),
+            schedule: defaults.schedule(),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT()
         });

--- a/test/periphery/integration/merkle-campaign/factory/create-merkle-lt/createMerkleLT.t.sol
+++ b/test/periphery/integration/merkle-campaign/factory/create-merkle-lt/createMerkleLT.t.sol
@@ -12,6 +12,7 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
         MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
         bool cancelable = defaults.CANCELABLE();
         bool transferable = defaults.TRANSFERABLE();
+        uint40 streamStartTime = defaults.STREAM_START_TIME();
         MerkleLT.TrancheWithPercentage[] memory tranchesWithPercentages = defaults.tranchesWithPercentages();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientCount = defaults.RECIPIENT_COUNT();
@@ -29,6 +30,7 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
             lockupTranched,
             cancelable,
             transferable,
+            streamStartTime,
             tranchesWithPercentages,
             aggregateAmount,
             recipientCount
@@ -44,6 +46,7 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
         MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
         bool cancelable = defaults.CANCELABLE();
         bool transferable = defaults.TRANSFERABLE();
+        uint40 streamStartTime = defaults.STREAM_START_TIME();
         MerkleLT.TrancheWithPercentage[] memory tranchesWithPercentages = defaults.tranchesWithPercentages();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientCount = defaults.RECIPIENT_COUNT();
@@ -55,6 +58,7 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
             lockupTranched,
             cancelable,
             transferable,
+            streamStartTime,
             tranchesWithPercentages,
             aggregateAmount,
             recipientCount
@@ -76,25 +80,26 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
         vm.assume(admin != users.admin);
         address expectedLT = computeMerkleLTAddress(admin, expiration);
 
-        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams({
-            admin: admin,
-            asset_: dai,
-            merkleRoot: defaults.MERKLE_ROOT(),
-            expiration: expiration
-        });
+        // MerkleBase.ConstructorParams memory baseParams = defaults.baseParams({
+        //     admin: admin,
+        //     asset_: dai,
+        //     merkleRoot: defaults.MERKLE_ROOT(),
+        //     expiration: expiration
+        // });
 
-        vm.expectEmit({ emitter: address(merkleFactory) });
-        emit CreateMerkleLT({
-            merkleLT: ISablierMerkleLT(expectedLT),
-            baseParams: baseParams,
-            lockupTranched: lockupTranched,
-            cancelable: defaults.CANCELABLE(),
-            transferable: defaults.TRANSFERABLE(),
-            tranchesWithPercentages: defaults.tranchesWithPercentages(),
-            totalDuration: defaults.TOTAL_DURATION(),
-            aggregateAmount: defaults.AGGREGATE_AMOUNT(),
-            recipientCount: defaults.RECIPIENT_COUNT()
-        });
+        // vm.expectEmit({ emitter: address(merkleFactory) });
+        // emit CreateMerkleLT({
+        //     merkleLT: ISablierMerkleLT(expectedLT),
+        //     baseParams: baseParams,
+        //     lockupTranched: lockupTranched,
+        //     cancelable: defaults.CANCELABLE(),
+        //     transferable: defaults.TRANSFERABLE(),
+        //     streamStartTime: defaults.STREAM_START_TIME(),
+        //     tranchesWithPercentages: defaults.tranchesWithPercentages(),
+        //     totalDuration: defaults.TOTAL_DURATION(),
+        //     aggregateAmount: defaults.AGGREGATE_AMOUNT(),
+        //     recipientCount: defaults.RECIPIENT_COUNT()
+        // });
 
         address actualLT = address(createMerkleLT(admin, expiration));
         assertGt(actualLT.code.length, 0, "MerkleLT contract not created");

--- a/test/periphery/integration/merkle-campaign/factory/create-merkle-lt/createMerkleLT.t.sol
+++ b/test/periphery/integration/merkle-campaign/factory/create-merkle-lt/createMerkleLT.t.sol
@@ -12,7 +12,7 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
         MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
         bool cancelable = defaults.CANCELABLE();
         bool transferable = defaults.TRANSFERABLE();
-        uint40 streamStartTime = defaults.STREAM_START_TIME();
+        uint40 streamStartTime = defaults.STREAM_START_TIME_ZERO();
         MerkleLT.TrancheWithPercentage[] memory tranchesWithPercentages = defaults.tranchesWithPercentages();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientCount = defaults.RECIPIENT_COUNT();
@@ -46,7 +46,7 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
         MerkleBase.ConstructorParams memory baseParams = defaults.baseParams();
         bool cancelable = defaults.CANCELABLE();
         bool transferable = defaults.TRANSFERABLE();
-        uint40 streamStartTime = defaults.STREAM_START_TIME();
+        uint40 streamStartTime = defaults.STREAM_START_TIME_ZERO();
         MerkleLT.TrancheWithPercentage[] memory tranchesWithPercentages = defaults.tranchesWithPercentages();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientCount = defaults.RECIPIENT_COUNT();
@@ -80,26 +80,26 @@ contract CreateMerkleLT_Integration_Test is MerkleCampaign_Integration_Test {
         vm.assume(admin != users.admin);
         address expectedLT = computeMerkleLTAddress(admin, expiration);
 
-        // MerkleBase.ConstructorParams memory baseParams = defaults.baseParams({
-        //     admin: admin,
-        //     asset_: dai,
-        //     merkleRoot: defaults.MERKLE_ROOT(),
-        //     expiration: expiration
-        // });
+        MerkleBase.ConstructorParams memory baseParams = defaults.baseParams({
+            admin: admin,
+            asset_: dai,
+            merkleRoot: defaults.MERKLE_ROOT(),
+            expiration: expiration
+        });
 
-        // vm.expectEmit({ emitter: address(merkleFactory) });
-        // emit CreateMerkleLT({
-        //     merkleLT: ISablierMerkleLT(expectedLT),
-        //     baseParams: baseParams,
-        //     lockupTranched: lockupTranched,
-        //     cancelable: defaults.CANCELABLE(),
-        //     transferable: defaults.TRANSFERABLE(),
-        //     streamStartTime: defaults.STREAM_START_TIME(),
-        //     tranchesWithPercentages: defaults.tranchesWithPercentages(),
-        //     totalDuration: defaults.TOTAL_DURATION(),
-        //     aggregateAmount: defaults.AGGREGATE_AMOUNT(),
-        //     recipientCount: defaults.RECIPIENT_COUNT()
-        // });
+        vm.expectEmit({ emitter: address(merkleFactory) });
+        emit CreateMerkleLT({
+            merkleLT: ISablierMerkleLT(expectedLT),
+            baseParams: baseParams,
+            lockupTranched: lockupTranched,
+            cancelable: defaults.CANCELABLE(),
+            transferable: defaults.TRANSFERABLE(),
+            streamStartTime: defaults.STREAM_START_TIME_ZERO(),
+            tranchesWithPercentages: defaults.tranchesWithPercentages(),
+            totalDuration: defaults.TOTAL_DURATION(),
+            aggregateAmount: defaults.AGGREGATE_AMOUNT(),
+            recipientCount: defaults.RECIPIENT_COUNT()
+        });
 
         address actualLT = address(createMerkleLT(admin, expiration));
         assertGt(actualLT.code.length, 0, "MerkleLT contract not created");

--- a/test/periphery/integration/merkle-campaign/ll/claim/claim.t.sol
+++ b/test/periphery/integration/merkle-campaign/ll/claim/claim.t.sol
@@ -8,22 +8,22 @@ import { MerkleLL_Integration_Shared_Test } from "../MerkleLL.t.sol";
 import { Claim_Integration_Test } from "../../shared/claim/claim.t.sol";
 
 contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Integration_Shared_Test {
+    MerkleLL.Schedule internal schedule;
+
     function setUp() public override(Claim_Integration_Test, MerkleLL_Integration_Shared_Test) {
         super.setUp();
+        schedule = defaults.schedule();
     }
 
-    function test_Claim_TimestampsInThePast()
-        external
-        givenCampaignNotExpired
-        givenNotClaimed
-        givenIncludedInMerkleTree
-    {
-        MerkleLL.Schedule memory schedule = defaults.schedule();
-        schedule.startTime = getBlockTimestamp();
+    modifier whenScheduledStartTimeZero() {
+        _;
+    }
+
+    function test_WhenScheduledCliffDurationZero() external whenScheduledStartTimeZero {
         schedule.cliffDuration = 0;
 
         merkleLL = merkleFactory.createMerkleLL({
-            baseParams: defaults.baseParams(users.admin, dai, defaults.EXPIRATION(), defaults.MERKLE_ROOT()),
+            baseParams: defaults.baseParams(),
             lockupLinear: lockupLinear,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
@@ -31,22 +31,49 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT()
         });
+
+        // It should create a stream with block.timestamp as start time.
+        // It should create a stream with cliff as zero.
+        _test_Claim({ startTime: getBlockTimestamp(), cliffTime: 0 });
+    }
+
+    function test_WhenScheduledCliffDurationNotZero() external whenScheduledStartTimeZero {
+        // It should create a stream with block.timestamp as start time.
+        // It should create a stream with cliff as start time + cliff duration.
+        _test_Claim({ startTime: getBlockTimestamp(), cliffTime: getBlockTimestamp() + defaults.CLIFF_DURATION() });
+    }
+
+    function test_WhenScheduledStartTimeNotZero() external {
+        schedule.startTime = defaults.STREAM_START_TIME_NON_ZERO();
+
+        merkleLL = merkleFactory.createMerkleLL({
+            baseParams: defaults.baseParams(),
+            lockupLinear: lockupLinear,
+            cancelable: defaults.CANCELABLE(),
+            transferable: defaults.TRANSFERABLE(),
+            schedule: schedule,
+            aggregateAmount: defaults.AGGREGATE_AMOUNT(),
+            recipientCount: defaults.RECIPIENT_COUNT()
+        });
+
+        // It should create a stream with scheduled start time as start time.
+        _test_Claim({
+            startTime: defaults.STREAM_START_TIME_NON_ZERO(),
+            cliffTime: defaults.STREAM_START_TIME_NON_ZERO() + defaults.CLIFF_DURATION()
+        });
+    }
+
+    /// @dev Helper function to test claim.
+    function _test_Claim(uint40 startTime, uint40 cliffTime) private {
         deal({ token: address(dai), to: address(merkleLL), give: defaults.AGGREGATE_AMOUNT() });
 
-        vm.warp(defaults.END_TIME() + 1);
-
-        _test_Claim(schedule.startTime, 0);
-    }
-
-    function test_Claim() external override givenCampaignNotExpired givenNotClaimed givenIncludedInMerkleTree {
-        _test_Claim(getBlockTimestamp(), getBlockTimestamp() + defaults.CLIFF_DURATION());
-    }
-
-    function _test_Claim(uint40 startTime, uint40 cliffTime) private {
         uint256 expectedStreamId = lockupLinear.nextStreamId();
 
+        // It should emit a {Claim} event.
         vm.expectEmit({ emitter: address(merkleLL) });
         emit Claim(defaults.INDEX1(), users.recipient1, defaults.CLAIM_AMOUNT(), expectedStreamId);
+
+        // Claim the airstream.
         merkleLL.claim(defaults.INDEX1(), users.recipient1, defaults.CLAIM_AMOUNT(), defaults.index1Proof());
 
         LockupLinear.StreamLL memory actualStream = lockupLinear.getStream(expectedStreamId);

--- a/test/periphery/integration/merkle-campaign/ll/claim/claim.t.sol
+++ b/test/periphery/integration/merkle-campaign/ll/claim/claim.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { Lockup, LockupLinear } from "src/core/types/DataTypes.sol";
+import { MerkleLL } from "src/periphery/types/DataTypes.sol";
 
 import { MerkleLL_Integration_Shared_Test } from "../MerkleLL.t.sol";
 import { Claim_Integration_Test } from "../../shared/claim/claim.t.sol";
@@ -9,6 +10,55 @@ import { Claim_Integration_Test } from "../../shared/claim/claim.t.sol";
 contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Integration_Shared_Test {
     function setUp() public override(Claim_Integration_Test, MerkleLL_Integration_Shared_Test) {
         super.setUp();
+    }
+
+    function test_ClaimLL_TimestampsInThePast()
+        external
+        givenCampaignNotExpired
+        givenNotClaimed
+        givenIncludedInMerkleTree
+    {
+        MerkleLL.Schedule memory schedule = defaults.schedule();
+        schedule.startTime = getBlockTimestamp();
+        schedule.cliffDuration = 0;
+
+        merkleLL = merkleFactory.createMerkleLL({
+            baseParams: defaults.baseParams(users.admin, dai, defaults.EXPIRATION(), defaults.MERKLE_ROOT()),
+            lockupLinear: lockupLinear,
+            cancelable: defaults.CANCELABLE(),
+            transferable: defaults.TRANSFERABLE(),
+            schedule: schedule,
+            aggregateAmount: defaults.AGGREGATE_AMOUNT(),
+            recipientCount: defaults.RECIPIENT_COUNT()
+        });
+        deal({ token: address(dai), to: address(merkleLL), give: defaults.AGGREGATE_AMOUNT() });
+
+        uint256 expectedStreamId = lockupLinear.nextStreamId();
+
+        vm.warp(defaults.END_TIME() + 1);
+
+        vm.expectEmit({ emitter: address(merkleLL) });
+        emit Claim(defaults.INDEX1(), users.recipient1, defaults.CLAIM_AMOUNT(), expectedStreamId);
+        merkleLL.claim(defaults.INDEX1(), users.recipient1, defaults.CLAIM_AMOUNT(), defaults.index1Proof());
+
+        LockupLinear.StreamLL memory actualStream = lockupLinear.getStream(expectedStreamId);
+        LockupLinear.StreamLL memory expectedStream = LockupLinear.StreamLL({
+            amounts: Lockup.Amounts({ deposited: defaults.CLAIM_AMOUNT(), refunded: 0, withdrawn: 0 }),
+            asset: dai,
+            cliffTime: 0,
+            endTime: schedule.startTime + defaults.TOTAL_DURATION(),
+            isCancelable: defaults.CANCELABLE(),
+            isDepleted: false,
+            isStream: true,
+            isTransferable: defaults.TRANSFERABLE(),
+            recipient: users.recipient1,
+            sender: users.admin,
+            startTime: schedule.startTime,
+            wasCanceled: false
+        });
+
+        assertEq(actualStream, expectedStream);
+        assertTrue(merkleLL.hasClaimed(defaults.INDEX1()), "not claimed");
     }
 
     function test_ClaimLL() external givenCampaignNotExpired givenNotClaimed givenIncludedInMerkleTree {

--- a/test/periphery/integration/merkle-campaign/ll/claim/claim.tree
+++ b/test/periphery/integration/merkle-campaign/ll/claim/claim.tree
@@ -1,0 +1,13 @@
+Claim_MerkleLL_Integration_Test
+├── when scheduled start time zero
+│   ├── when scheduled cliff duration zero
+│   │   ├── it should create a stream with block.timestamp as start time
+│   │   ├── it should create a stream with cliff as zero
+│   │   └── it should emit a {Claim} event
+│   └── when scheduled cliff duration not zero
+│       ├── it should create a stream with block.timestamp as start time
+│       ├── it should create a stream with cliff as start time + cliff duration
+│       └── it should emit a {Claim} event
+└── when scheduled start time not zero
+    ├── it should create a stream with scheduled start time as start time
+    └── it should emit a {Claim} event

--- a/test/periphery/integration/merkle-campaign/ll/constructor.t.sol
+++ b/test/periphery/integration/merkle-campaign/ll/constructor.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22 <0.9.0;
 
-import { LockupLinear } from "src/core/types/DataTypes.sol";
 import { SablierMerkleLL } from "src/periphery/SablierMerkleLL.sol";
+import { MerkleLL } from "src/periphery/types/DataTypes.sol";
 
 import { MerkleCampaign_Integration_Test } from "../MerkleCampaign.t.sol";
 
@@ -15,7 +15,7 @@ contract Constructor_MerkleLL_Integration_Test is MerkleCampaign_Integration_Tes
         string actualIpfsCID;
         string actualName;
         bool actualCancelable;
-        LockupLinear.Durations actualDurations;
+        MerkleLL.Schedule actualSchedule;
         uint40 actualExpiration;
         address actualLockupLinear;
         bytes32 actualMerkleRoot;
@@ -24,7 +24,7 @@ contract Constructor_MerkleLL_Integration_Test is MerkleCampaign_Integration_Tes
         uint256 expectedAllowance;
         address expectedAsset;
         bool expectedCancelable;
-        LockupLinear.Durations expectedDurations;
+        MerkleLL.Schedule expectedSchedule;
         uint40 expectedExpiration;
         string expectedIpfsCID;
         address expectedLockupLinear;
@@ -35,7 +35,7 @@ contract Constructor_MerkleLL_Integration_Test is MerkleCampaign_Integration_Tes
 
     function test_Constructor() external {
         SablierMerkleLL constructedLL = new SablierMerkleLL(
-            defaults.baseParams(), lockupLinear, defaults.CANCELABLE(), defaults.TRANSFERABLE(), defaults.durations()
+            defaults.baseParams(), lockupLinear, defaults.CANCELABLE(), defaults.TRANSFERABLE(), defaults.schedule()
         );
 
         Vars memory vars;
@@ -56,10 +56,12 @@ contract Constructor_MerkleLL_Integration_Test is MerkleCampaign_Integration_Tes
         vars.expectedCancelable = defaults.CANCELABLE();
         assertEq(vars.actualCancelable, vars.expectedCancelable, "cancelable");
 
-        (vars.actualDurations.cliff, vars.actualDurations.total) = constructedLL.streamDurations();
-        vars.expectedDurations = defaults.durations();
-        assertEq(vars.actualDurations.cliff, vars.expectedDurations.cliff, "durations.cliff");
-        assertEq(vars.actualDurations.total, vars.expectedDurations.total, "durations.total");
+        (vars.actualSchedule.startTime, vars.actualSchedule.cliffDuration, vars.actualSchedule.totalDuration) =
+            constructedLL.schedule();
+        vars.expectedSchedule = defaults.schedule();
+        assertEq(vars.actualSchedule.startTime, vars.expectedSchedule.startTime, "schedule.startTime");
+        assertEq(vars.actualSchedule.cliffDuration, vars.expectedSchedule.cliffDuration, "schedule.cliffDuration");
+        assertEq(vars.actualSchedule.totalDuration, vars.expectedSchedule.totalDuration, "schedule.totalDuration");
 
         vars.actualExpiration = constructedLL.EXPIRATION();
         vars.expectedExpiration = defaults.EXPIRATION();

--- a/test/periphery/integration/merkle-campaign/ll/constructor.t.sol
+++ b/test/periphery/integration/merkle-campaign/ll/constructor.t.sol
@@ -56,13 +56,6 @@ contract Constructor_MerkleLL_Integration_Test is MerkleCampaign_Integration_Tes
         vars.expectedCancelable = defaults.CANCELABLE();
         assertEq(vars.actualCancelable, vars.expectedCancelable, "cancelable");
 
-        (vars.actualSchedule.startTime, vars.actualSchedule.cliffDuration, vars.actualSchedule.totalDuration) =
-            constructedLL.schedule();
-        vars.expectedSchedule = defaults.schedule();
-        assertEq(vars.actualSchedule.startTime, vars.expectedSchedule.startTime, "schedule.startTime");
-        assertEq(vars.actualSchedule.cliffDuration, vars.expectedSchedule.cliffDuration, "schedule.cliffDuration");
-        assertEq(vars.actualSchedule.totalDuration, vars.expectedSchedule.totalDuration, "schedule.totalDuration");
-
         vars.actualExpiration = constructedLL.EXPIRATION();
         vars.expectedExpiration = defaults.EXPIRATION();
         assertEq(vars.actualExpiration, vars.expectedExpiration, "expiration");
@@ -82,6 +75,13 @@ contract Constructor_MerkleLL_Integration_Test is MerkleCampaign_Integration_Tes
         vars.actualName = constructedLL.name();
         vars.expectedName = defaults.NAME_BYTES32();
         assertEq(bytes32(abi.encodePacked(vars.actualName)), vars.expectedName, "name");
+
+        (vars.actualSchedule.startTime, vars.actualSchedule.cliffDuration, vars.actualSchedule.totalDuration) =
+            constructedLL.schedule();
+        vars.expectedSchedule = defaults.schedule();
+        assertEq(vars.actualSchedule.startTime, vars.expectedSchedule.startTime, "schedule.startTime");
+        assertEq(vars.actualSchedule.cliffDuration, vars.expectedSchedule.cliffDuration, "schedule.cliffDuration");
+        assertEq(vars.actualSchedule.totalDuration, vars.expectedSchedule.totalDuration, "schedule.totalDuration");
 
         vars.actualTransferable = constructedLL.TRANSFERABLE();
         vars.expectedTransferable = defaults.TRANSFERABLE();

--- a/test/periphery/integration/merkle-campaign/lt/claim/claim.t.sol
+++ b/test/periphery/integration/merkle-campaign/lt/claim/claim.t.sol
@@ -30,7 +30,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
-            defaults.STREAM_START_TIME(),
+            defaults.STREAM_START_TIME_ZERO(),
             tranchesWithPercentages,
             defaults.AGGREGATE_AMOUNT(),
             defaults.RECIPIENT_COUNT()
@@ -60,7 +60,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
-            defaults.STREAM_START_TIME(),
+            defaults.STREAM_START_TIME_ZERO(),
             tranchesWithPercentages,
             defaults.AGGREGATE_AMOUNT(),
             defaults.RECIPIENT_COUNT()
@@ -87,7 +87,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
         _;
     }
 
-    function test_Claim_TimestampsInThePast()
+    function test_WhenStreamStartTimeZero()
         external
         whenTotalPercentageOneHundred
         givenCampaignNotExpired
@@ -95,42 +95,50 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
         givenIncludedInMerkleTree
         whenCalculatedAmountsSumEqualsClaimAmount
     {
-        uint40 streamStartTime = getBlockTimestamp();
+        // It should create a stream with block.timestamp as start time.
+        _test_Claim({ streamStartTime: 0, startTime: getBlockTimestamp() });
+    }
+
+    function test_WhenStreamStartTimeNotZero()
+        external
+        whenTotalPercentageOneHundred
+        givenCampaignNotExpired
+        givenNotClaimed
+        givenIncludedInMerkleTree
+        whenCalculatedAmountsSumEqualsClaimAmount
+    {
         merkleLT = merkleFactory.createMerkleLT({
-            baseParams: defaults.baseParams(users.admin, dai, defaults.EXPIRATION(), defaults.MERKLE_ROOT()),
+            baseParams: defaults.baseParams(),
             lockupTranched: lockupTranched,
             cancelable: defaults.CANCELABLE(),
             transferable: defaults.TRANSFERABLE(),
-            streamStartTime: streamStartTime,
+            streamStartTime: defaults.STREAM_START_TIME_NON_ZERO(),
             tranchesWithPercentages: defaults.tranchesWithPercentages(),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientCount: defaults.RECIPIENT_COUNT()
         });
+
+        // It should create a stream with `STREAM_START_TIME` as start time.
+        _test_Claim({
+            streamStartTime: defaults.STREAM_START_TIME_NON_ZERO(),
+            startTime: defaults.STREAM_START_TIME_NON_ZERO()
+        });
+    }
+
+    /// @dev Helper function to test claim.
+    function _test_Claim(uint40 streamStartTime, uint40 startTime) private {
         deal({ token: address(dai), to: address(merkleLT), give: defaults.AGGREGATE_AMOUNT() });
 
-        vm.warp(defaults.END_TIME() + 1);
-
-        _test_Claim(streamStartTime);
-    }
-
-    function test_Claim()
-        external
-        override
-        whenTotalPercentageOneHundred
-        givenCampaignNotExpired
-        givenNotClaimed
-        givenIncludedInMerkleTree
-        whenCalculatedAmountsSumEqualsClaimAmount
-    {
-        _test_Claim(getBlockTimestamp());
-    }
-
-    function _test_Claim(uint40 startTime) private {
         uint256 expectedStreamId = lockupTranched.nextStreamId();
+
+        // It should emit a {Claim} event.
         vm.expectEmit({ emitter: address(merkleLT) });
         emit Claim(defaults.INDEX1(), users.recipient1, defaults.CLAIM_AMOUNT(), expectedStreamId);
 
+        // Claim the airstream.
         merkleLT.claim(defaults.INDEX1(), users.recipient1, defaults.CLAIM_AMOUNT(), defaults.index1Proof());
+
+        // It should create a stream with `STREAM_START_TIME` as start time.
         LockupTranched.StreamLT memory actualStream = lockupTranched.getStream(expectedStreamId);
         LockupTranched.StreamLT memory expectedStream = LockupTranched.StreamLT({
             amounts: Lockup.Amounts({ deposited: defaults.CLAIM_AMOUNT(), refunded: 0, withdrawn: 0 }),
@@ -143,7 +151,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
             recipient: users.recipient1,
             sender: users.admin,
             startTime: startTime,
-            tranches: defaults.tranchesMerkleLT(startTime, defaults.CLAIM_AMOUNT()),
+            tranches: defaults.tranchesMerkleLT({ streamStartTime: streamStartTime, totalAmount: defaults.CLAIM_AMOUNT() }),
             wasCanceled: false
         });
 

--- a/test/periphery/integration/merkle-campaign/lt/claim/claim.t.sol
+++ b/test/periphery/integration/merkle-campaign/lt/claim/claim.t.sol
@@ -30,6 +30,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
+            defaults.STREAM_START_TIME(),
             tranchesWithPercentages,
             defaults.AGGREGATE_AMOUNT(),
             defaults.RECIPIENT_COUNT()
@@ -59,6 +60,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
+            defaults.STREAM_START_TIME(),
             tranchesWithPercentages,
             defaults.AGGREGATE_AMOUNT(),
             defaults.RECIPIENT_COUNT()

--- a/test/periphery/integration/merkle-campaign/lt/claim/claim.tree
+++ b/test/periphery/integration/merkle-campaign/lt/claim/claim.tree
@@ -1,9 +1,13 @@
-claim.t.sol
-├── when the total percentage does not equal 100%
-│   ├── when the total percentage is less than 100%
+Claim_MerkleLT_Integration_Test
+├── when the total percentage does not equal 100
+│   ├── when the total percentage is less than 100
 │   │   └── it should revert
-│   └── when the total percentage is greater than 100%
+│   └── when the total percentage is greater than 100
 │       └── it should revert
-└── when the total percentage equals 100%
-    ├── it should create a stream
-    └── it should emit a {Claim} event
+└── when the total percentage equals 100
+    ├── when stream start time zero
+    │   ├── it should create a stream with block.timestamp as start time
+    │   └── it should emit a {Claim} event
+    └── when stream start time not zero
+        ├── it should create a stream with `STREAM_START_TIME` as start time
+        └── it should emit a {Claim} event

--- a/test/periphery/integration/merkle-campaign/lt/constructor.t.sol
+++ b/test/periphery/integration/merkle-campaign/lt/constructor.t.sol
@@ -18,6 +18,7 @@ contract Constructor_MerkleLT_Integration_Test is MerkleCampaign_Integration_Tes
         uint40 actualExpiration;
         address actualLockupTranched;
         bytes32 actualMerkleRoot;
+        uint40 actualStreamStartTime;
         uint64 actualTotalPercentage;
         MerkleLT.TrancheWithPercentage[] actualTranchesWithPercentages;
         bool actualTransferable;
@@ -30,6 +31,7 @@ contract Constructor_MerkleLT_Integration_Test is MerkleCampaign_Integration_Tes
         address expectedLockupTranched;
         bytes32 expectedMerkleRoot;
         bytes32 expectedName;
+        uint40 expectedStreamStartTime;
         uint64 expectedTotalPercentage;
         MerkleLT.TrancheWithPercentage[] expectedTranchesWithPercentages;
         bool expectedTransferable;
@@ -41,57 +43,62 @@ contract Constructor_MerkleLT_Integration_Test is MerkleCampaign_Integration_Tes
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
+            defaults.STREAM_START_TIME(),
             defaults.tranchesWithPercentages()
         );
 
         Vars memory vars;
 
-        vars.actualAdmin = constructedLT.admin();
-        vars.expectedAdmin = users.admin;
-        assertEq(vars.actualAdmin, vars.expectedAdmin, "admin");
-
-        vars.actualAllowance = dai.allowance(address(constructedLT), address(lockupTranched));
-        vars.expectedAllowance = MAX_UINT256;
-        assertEq(vars.actualAllowance, vars.expectedAllowance, "allowance");
-
         vars.actualAsset = address(constructedLT.ASSET());
         vars.expectedAsset = address(dai);
         assertEq(vars.actualAsset, vars.expectedAsset, "asset");
-
-        vars.actualCancelable = constructedLT.CANCELABLE();
-        vars.expectedCancelable = defaults.CANCELABLE();
-        assertEq(vars.actualCancelable, vars.expectedCancelable, "cancelable");
 
         vars.actualExpiration = constructedLT.EXPIRATION();
         vars.expectedExpiration = defaults.EXPIRATION();
         assertEq(vars.actualExpiration, vars.expectedExpiration, "expiration");
 
+        vars.actualAdmin = constructedLT.admin();
+        vars.expectedAdmin = users.admin;
+        assertEq(vars.actualAdmin, vars.expectedAdmin, "admin");
+
         vars.actualIpfsCID = constructedLT.ipfsCID();
         vars.expectedIpfsCID = defaults.IPFS_CID();
         assertEq(vars.actualIpfsCID, vars.expectedIpfsCID, "ipfsCID");
-
-        vars.actualLockupTranched = address(constructedLT.LOCKUP_TRANCHED());
-        vars.expectedLockupTranched = address(lockupTranched);
-        assertEq(vars.actualLockupTranched, vars.expectedLockupTranched, "lockupTranched");
-
-        vars.actualName = constructedLT.name();
-        vars.expectedName = defaults.NAME_BYTES32();
-        assertEq(bytes32(abi.encodePacked(vars.actualName)), vars.expectedName, "name");
 
         vars.actualMerkleRoot = constructedLT.MERKLE_ROOT();
         vars.expectedMerkleRoot = defaults.MERKLE_ROOT();
         assertEq(vars.actualMerkleRoot, vars.expectedMerkleRoot, "merkleRoot");
 
+        vars.actualName = constructedLT.name();
+        vars.expectedName = defaults.NAME_BYTES32();
+        assertEq(bytes32(abi.encodePacked(vars.actualName)), vars.expectedName, "name");
+
+        vars.actualCancelable = constructedLT.CANCELABLE();
+        vars.expectedCancelable = defaults.CANCELABLE();
+        assertEq(vars.actualCancelable, vars.expectedCancelable, "cancelable");
+
+        vars.actualLockupTranched = address(constructedLT.LOCKUP_TRANCHED());
+        vars.expectedLockupTranched = address(lockupTranched);
+        assertEq(vars.actualLockupTranched, vars.expectedLockupTranched, "lockupTranched");
+
+        vars.actualStreamStartTime = constructedLT.STREAM_START_TIME();
+        vars.expectedStreamStartTime = defaults.STREAM_START_TIME();
+        assertEq(vars.actualStreamStartTime, vars.expectedStreamStartTime, "streamStartTime");
+
         vars.actualTotalPercentage = constructedLT.TOTAL_PERCENTAGE();
         vars.expectedTotalPercentage = defaults.TOTAL_PERCENTAGE();
         assertEq(vars.actualTotalPercentage, vars.expectedTotalPercentage, "totalPercentage");
+
+        vars.actualTransferable = constructedLT.TRANSFERABLE();
+        vars.expectedTransferable = defaults.TRANSFERABLE();
+        assertEq(vars.actualTransferable, vars.expectedTransferable, "transferable");
 
         vars.actualTranchesWithPercentages = constructedLT.getTranchesWithPercentages();
         vars.expectedTranchesWithPercentages = defaults.tranchesWithPercentages();
         assertEq(vars.actualTranchesWithPercentages, vars.expectedTranchesWithPercentages, "tranchesWithPercentages");
 
-        vars.actualTransferable = constructedLT.TRANSFERABLE();
-        vars.expectedTransferable = defaults.TRANSFERABLE();
-        assertEq(vars.actualTransferable, vars.expectedTransferable, "transferable");
+        vars.actualAllowance = dai.allowance(address(constructedLT), address(lockupTranched));
+        vars.expectedAllowance = MAX_UINT256;
+        assertEq(vars.actualAllowance, vars.expectedAllowance, "allowance");
     }
 }

--- a/test/periphery/integration/merkle-campaign/lt/constructor.t.sol
+++ b/test/periphery/integration/merkle-campaign/lt/constructor.t.sol
@@ -43,7 +43,7 @@ contract Constructor_MerkleLT_Integration_Test is MerkleCampaign_Integration_Tes
             lockupTranched,
             defaults.CANCELABLE(),
             defaults.TRANSFERABLE(),
-            defaults.STREAM_START_TIME(),
+            defaults.STREAM_START_TIME_ZERO(),
             defaults.tranchesWithPercentages()
         );
 
@@ -82,7 +82,7 @@ contract Constructor_MerkleLT_Integration_Test is MerkleCampaign_Integration_Tes
         assertEq(vars.actualLockupTranched, vars.expectedLockupTranched, "lockupTranched");
 
         vars.actualStreamStartTime = constructedLT.STREAM_START_TIME();
-        vars.expectedStreamStartTime = defaults.STREAM_START_TIME();
+        vars.expectedStreamStartTime = defaults.STREAM_START_TIME_ZERO();
         assertEq(vars.actualStreamStartTime, vars.expectedStreamStartTime, "streamStartTime");
 
         vars.actualTotalPercentage = constructedLT.TOTAL_PERCENTAGE();

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -38,7 +38,6 @@ contract Defaults is Constants, Merkle {
     uint128 public constant REFUND_AMOUNT = DEPOSIT_AMOUNT - CLIFF_AMOUNT;
     uint256 public constant SEGMENT_COUNT = 2;
     uint40 public immutable START_TIME;
-    uint40 public immutable STREAM_START_TIME = 0; // used only in merkle campaigns
     uint128 public constant TOTAL_AMOUNT = 10_030.090270812437311935e18; // deposit + broker fee
     uint40 public constant TOTAL_DURATION = 10_000 seconds;
     uint256 public constant TRANCHE_COUNT = 3;
@@ -65,6 +64,8 @@ contract Defaults is Constants, Merkle {
     bytes32 public MERKLE_ROOT;
     string public constant NAME = "Airdrop Campaign";
     bytes32 public constant NAME_BYTES32 = bytes32(abi.encodePacked("Airdrop Campaign"));
+    uint40 public immutable STREAM_START_TIME_NON_ZERO = JULY_1_2024 - 2 days;
+    uint40 public immutable STREAM_START_TIME_ZERO = 0;
     uint64 public constant TOTAL_PERCENTAGE = uUNIT;
     bool public constant TRANSFERABLE = false;
 
@@ -503,29 +504,28 @@ contract Defaults is Constants, Merkle {
     }
 
     function schedule() public pure returns (MerkleLL.Schedule memory schedule_) {
-        schedule_.startTime = STREAM_START_TIME;
+        schedule_.startTime = STREAM_START_TIME_ZERO;
         schedule_.cliffDuration = CLIFF_DURATION;
         schedule_.totalDuration = TOTAL_DURATION;
     }
 
-    function tranchesMerkleLT() public view returns (LockupTranched.Tranche[] memory tranches_) {
-        tranches_ = new LockupTranched.Tranche[](2);
-        tranches_[0] = LockupTranched.Tranche({ amount: 2500e18, timestamp: uint40(block.timestamp) + CLIFF_DURATION });
-        tranches_[1] = LockupTranched.Tranche({ amount: 7500e18, timestamp: uint40(block.timestamp) + TOTAL_DURATION });
-    }
-
-    /// @dev Mirros the logic from {SablierMerkleLT._calculateTranches}.
+    /// @dev Mirros the logic from {SablierMerkleLT._calculateStartTimeAndTranches}.
     function tranchesMerkleLT(
-        uint40 startTime,
+        uint40 streamStartTime,
         uint128 totalAmount
     )
         public
         view
         returns (LockupTranched.Tranche[] memory tranches_)
     {
-        tranches_ = tranchesMerkleLT();
-        tranches_[0].timestamp = startTime + CLIFF_DURATION;
-        tranches_[1].timestamp = startTime + TOTAL_DURATION;
+        tranches_ = new LockupTranched.Tranche[](2);
+        if (streamStartTime == 0) {
+            tranches_[0].timestamp = uint40(block.timestamp) + CLIFF_DURATION;
+            tranches_[1].timestamp = uint40(block.timestamp) + TOTAL_DURATION;
+        } else {
+            tranches_[0].timestamp = streamStartTime + CLIFF_DURATION;
+            tranches_[1].timestamp = streamStartTime + TOTAL_DURATION;
+        }
 
         uint128 amount0 = ud(totalAmount).mul(tranchesWithPercentages()[0].unlockPercentage.intoUD60x18()).intoUint128();
         uint128 amount1 = ud(totalAmount).mul(tranchesWithPercentages()[1].unlockPercentage.intoUD60x18()).intoUint128();

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -7,7 +7,7 @@ import { ud2x18, uUNIT } from "@prb/math/src/UD2x18.sol";
 import { UD60x18, ud, ZERO } from "@prb/math/src/UD60x18.sol";
 
 import { Broker, Lockup, LockupDynamic, LockupLinear, LockupTranched } from "../../src/core/types/DataTypes.sol";
-import { BatchLockup, MerkleBase, MerkleLT } from "../../src/periphery/types/DataTypes.sol";
+import { BatchLockup, MerkleBase, MerkleLL, MerkleLT } from "../../src/periphery/types/DataTypes.sol";
 
 import { ArrayBuilder } from "./ArrayBuilder.sol";
 import { Constants } from "./Constants.sol";
@@ -38,6 +38,7 @@ contract Defaults is Constants, Merkle {
     uint128 public constant REFUND_AMOUNT = DEPOSIT_AMOUNT - CLIFF_AMOUNT;
     uint256 public constant SEGMENT_COUNT = 2;
     uint40 public immutable START_TIME;
+    uint40 public immutable STREAM_START_TIME = 0; // used only in merkle campaigns
     uint128 public constant TOTAL_AMOUNT = 10_030.090270812437311935e18; // deposit + broker fee
     uint40 public constant TOTAL_DURATION = 10_000 seconds;
     uint256 public constant TRANCHE_COUNT = 3;
@@ -499,6 +500,12 @@ contract Defaults is Constants, Merkle {
 
     function getLeaves() public view returns (uint256[] memory) {
         return LEAVES;
+    }
+
+    function schedule() public pure returns (MerkleLL.Schedule memory schedule_) {
+        schedule_.startTime = STREAM_START_TIME;
+        schedule_.cliffDuration = CLIFF_DURATION;
+        schedule_.totalDuration = TOTAL_DURATION;
     }
 
     function tranchesMerkleLT() public view returns (LockupTranched.Tranche[] memory tranches_) {

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -515,8 +515,17 @@ contract Defaults is Constants, Merkle {
     }
 
     /// @dev Mirros the logic from {SablierMerkleLT._calculateTranches}.
-    function tranchesMerkleLT(uint128 totalAmount) public view returns (LockupTranched.Tranche[] memory tranches_) {
+    function tranchesMerkleLT(
+        uint40 startTime,
+        uint128 totalAmount
+    )
+        public
+        view
+        returns (LockupTranched.Tranche[] memory tranches_)
+    {
         tranches_ = tranchesMerkleLT();
+        tranches_[0].timestamp = startTime + CLIFF_DURATION;
+        tranches_[1].timestamp = startTime + TOTAL_DURATION;
 
         uint128 amount0 = ud(totalAmount).mul(tranchesWithPercentages()[0].unlockPercentage.intoUD60x18()).intoUint128();
         uint128 amount1 = ud(totalAmount).mul(tranchesWithPercentages()[1].unlockPercentage.intoUD60x18()).intoUint128();

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -10,7 +10,7 @@ import { Lockup, LockupDynamic, LockupLinear, LockupTranched } from "../../src/c
 import { ISablierMerkleInstant } from "../../src/periphery/interfaces/ISablierMerkleInstant.sol";
 import { ISablierMerkleLL } from "../../src/periphery/interfaces/ISablierMerkleLL.sol";
 import { ISablierMerkleLT } from "../../src/periphery/interfaces/ISablierMerkleLT.sol";
-import { MerkleBase, MerkleLL,MerkleLT } from "../../src/periphery/types/DataTypes.sol";
+import { MerkleBase, MerkleLL, MerkleLT } from "../../src/periphery/types/DataTypes.sol";
 
 /// @notice Abstract contract containing all the events emitted by the protocol.
 abstract contract Events {
@@ -137,5 +137,4 @@ abstract contract Events {
         uint256 aggregateAmount,
         uint256 recipientCount
     );
-
 }

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -10,7 +10,7 @@ import { Lockup, LockupDynamic, LockupLinear, LockupTranched } from "../../src/c
 import { ISablierMerkleInstant } from "../../src/periphery/interfaces/ISablierMerkleInstant.sol";
 import { ISablierMerkleLL } from "../../src/periphery/interfaces/ISablierMerkleLL.sol";
 import { ISablierMerkleLT } from "../../src/periphery/interfaces/ISablierMerkleLT.sol";
-import { MerkleBase, MerkleLT } from "../../src/periphery/types/DataTypes.sol";
+import { MerkleBase, MerkleLL,MerkleLT } from "../../src/periphery/types/DataTypes.sol";
 
 /// @notice Abstract contract containing all the events emitted by the protocol.
 abstract contract Events {
@@ -120,7 +120,7 @@ abstract contract Events {
         ISablierLockupLinear lockupLinear,
         bool cancelable,
         bool transferable,
-        LockupLinear.Durations streamDurations,
+        MerkleLL.Schedule schedule,
         uint256 aggregateAmount,
         uint256 recipientCount
     );
@@ -131,9 +131,11 @@ abstract contract Events {
         ISablierLockupTranched lockupTranched,
         bool cancelable,
         bool transferable,
+        uint40 streamStartTime,
         MerkleLT.TrancheWithPercentage[] tranchesWithPercentages,
         uint256 totalDuration,
         uint256 aggregateAmount,
         uint256 recipientCount
     );
+
 }


### PR DESCRIPTION
Closes #996 

Some problems in the issue:
- In `MerkleLL` the case when cliff duration is 0 was not covered
- In `MerkleLT`the `startTime + MerkleLT.TrancheWithPercentage.duration // recursively` was not correct, but only for the first tranche