### PR TITLE
ci: slack notify integration

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -74,3 +74,15 @@ jobs:
       foundry-profile: "test-optimized"
       match-path: "test/fork/**/*.sol"
       name: "Fork tests"
+
+  notify_on_failure:
+    if: failure() # This job only runs if a failure occurs in any previous jobs
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Send Slack notification"
+        uses: "rtCamp/action-slack-notify@v2"
+        env:
+          SLACK_CHANNEL: "#ci-notifications"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: "GitHub CI"
+          SLACK_MESSAGE: "CI Workflow failed for ${{ github.repository }} on branch ${{ github.ref }} at job ${{ github.job }}."

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -75,8 +75,8 @@ jobs:
       match-path: "test/fork/**/*.sol"
       name: "Fork tests"
 
-  notify_on_failure:
-    if: failure() # This job only runs if a failure occurs in any previous jobs
+  notify-on-failure:
+    if: failure() # Runs only if a failure occurs in any previous jobs
     runs-on: "ubuntu-latest"
     steps:
       - name: "Send Slack notification"

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -1,8 +1,8 @@
 name: "CI Fork and Util tests"
 
 on:
-    schedule:
-      - cron: "0 3 * * 1,3,5" # at 3:00 AM UTC on Monday, Wednesday and Friday
+  schedule:
+    - cron: "0 3 * * 1,3,5" # at 3:00 AM UTC on Monday, Wednesday and Friday
 
 jobs:
   lint:
@@ -12,16 +12,16 @@ jobs:
     uses: "sablier-labs/reusable-workflows/.github/workflows/forge-build.yml@main"
 
   test-fork:
-      needs: ["lint", "build"]
-      secrets:
-        MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
-      uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
-      with:
-        foundry-fuzz-runs: 100
-        foundry-profile: "test-optimized"
-        fuzz-seed: true
-        match-path: "test/fork/**/*.sol"
-        name: "Fork tests"
+    needs: ["lint", "build"]
+    secrets:
+      MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-fuzz-runs: 100
+      foundry-profile: "test-optimized"
+      fuzz-seed: true
+      match-path: "test/fork/**/*.sol"
+      name: "Fork tests"
 
   test-utils:
     needs: ["lint", "build"]
@@ -30,3 +30,15 @@ jobs:
       foundry-profile: "test-optimized"
       match-path: "test/utils/**/*.sol"
       name: "Utils tests"
+
+  notify-on-failure:
+    if: failure() # Runs only if a failure occurs in any previous jobs
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Send Slack notification"
+        uses: "rtCamp/action-slack-notify@v2"
+        env:
+          SLACK_CHANNEL: "#ci-notifications"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: "GitHub CI"
+          SLACK_MESSAGE: "CI Workflow failed for ${{ github.repository }} on branch ${{ github.ref }} at job ${{ github.job }}."


### PR DESCRIPTION
Closes [this Notion task](https://www.notion.so/sablier/Set-up-notifications-for-failed-CI-runs-96249855570245e4bf746b58c7ab3f4c).

Using https://github.com/marketplace/actions/slack-notify to send a notification to the `#ci-notifications` channel on Slack whenever there's a failure in the scheduled workflow CI Deep.

@smol-ninja should this also be added to the fork tests workflow, as well as the `staging` branch?