### PR TITLE
ci: fix slack notify

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -76,11 +76,11 @@ jobs:
       name: "Fork tests"
 
   notify-on-failure:
-    if: always()
+    if: failure()
+    needs: ["lint", "build", "test-unit", "test-integration", "test-invariant", "test-fork"]
     runs-on: "ubuntu-latest"
     steps:
       - name: "Send Slack notification"
-        if: failure() # Runs only if a failure occurs in any previous job
         uses: "rtCamp/action-slack-notify@v2"
         env:
           SLACK_CHANNEL: "#ci-notifications"

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -32,11 +32,11 @@ jobs:
       name: "Utils tests"
 
   notify-on-failure:
-    if: always()
+    if: failure()
+    needs: ["lint", "build", "test-fork", "test-utils"]
     runs-on: "ubuntu-latest"
     steps:
       - name: "Send Slack notification"
-        if: failure() # Runs only if a failure occurs in any previous job
         uses: "rtCamp/action-slack-notify@v2"
         env:
           SLACK_CHANNEL: "#ci-notifications"


### PR DESCRIPTION
The [most recent CI Deep run](https://github.com/sablier-labs/v2-core/actions/runs/11310928833) failed, but the `#ci-notifications` Slack channel didn't get notified.

Hopefully, this PR will fix it.