### PR TITLE
Small fixes and polishes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ out-svg
 lcov.info
 package-lock.json
 pnpm-lock.yaml
-script/protocol/*.md
+script/*.md
 yarn.lock

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,7 +6,7 @@
     { access = "read", path = "./out-optimized" },
     { access = "read", path = "package.json" },
     { access = "read-write", path = "./benchmark/results" },
-    { access = "read-write", path = "./script/protocol"}
+    { access = "read-write", path = "./script/"}
   ]
   gas_limit = 9223372036854775807
   optimizer = true

--- a/tests/fork/LockupDynamic.t.sol
+++ b/tests/fork/LockupDynamic.t.sol
@@ -192,7 +192,7 @@ abstract contract Lockup_Dynamic_Fork_Test is Fork_Test {
         assertTrue(lockup.isStream(vars.streamId), "isStream");
         assertTrue(lockup.isTransferable(vars.streamId), "isTransferable");
         assertEq(lockup.getRecipient(vars.streamId), params.recipient, "recipient");
-        assertEq(lockup.getSegments(vars.streamId), params.segments, "segments");
+        assertEq(lockup.getSegments(vars.streamId), params.segments);
         assertEq(lockup.getSender(vars.streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(vars.streamId), params.startTime, "startTime");
         assertFalse(lockup.isDepleted(vars.streamId), "isDepleted");

--- a/tests/fork/LockupTranched.t.sol
+++ b/tests/fork/LockupTranched.t.sol
@@ -195,7 +195,7 @@ abstract contract Lockup_Tranched_Fork_Test is Fork_Test {
         assertEq(lockup.getRecipient(vars.streamId), params.recipient, "recipient");
         assertEq(lockup.getSender(vars.streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(vars.streamId), params.startTime, "startTime");
-        assertEq(lockup.getTranches(vars.streamId), params.tranches, "tranches");
+        assertEq(lockup.getTranches(vars.streamId), params.tranches);
         assertFalse(lockup.wasCanceled(vars.streamId), "wasCanceled");
 
         // Assert that the stream's status is correct.

--- a/tests/integration/concrete/lockup-dynamic/create-with-timestamps-ld/createWithTimestampsLD.t.sol
+++ b/tests/integration/concrete/lockup-dynamic/create-with-timestamps-ld/createWithTimestampsLD.t.sol
@@ -288,7 +288,7 @@ contract CreateWithTimestampsLD_Integration_Concrete_Test is CreateWithTimestamp
         // It should create the stream.
         assertEqStream(streamId);
         assertEq(lockup.getAsset(streamId), IERC20(asset), "asset");
-        assertEq(lockup.getSegments(streamId), defaults.segments(), "segments");
+        assertEq(lockup.getSegments(streamId), defaults.segments());
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
     }
 }

--- a/tests/integration/concrete/lockup-dynamic/get-segments/getSegments.t.sol
+++ b/tests/integration/concrete/lockup-dynamic/get-segments/getSegments.t.sol
@@ -25,6 +25,6 @@ contract GetSegments_Integration_Concrete_Test is Lockup_Dynamic_Integration_Con
     function test_GivenDynamicModel() external givenNotNull {
         LockupDynamic.Segment[] memory actualSegments = lockup.getSegments(defaultStreamId);
         LockupDynamic.Segment[] memory expectedSegments = defaults.segments();
-        assertEq(actualSegments, expectedSegments, "segments");
+        assertEq(actualSegments, expectedSegments);
     }
 }

--- a/tests/integration/concrete/lockup-tranched/create-with-durations-lt/createWithDurationsLT.t.sol
+++ b/tests/integration/concrete/lockup-tranched/create-with-durations-lt/createWithDurationsLT.t.sol
@@ -169,7 +169,7 @@ contract CreateWithDurationsLT_Integration_Concrete_Test is Lockup_Tranched_Inte
         assertEq(lockup.getSender(streamId), users.sender, "sender");
         assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
-        assertEq(lockup.getTranches(streamId), tranches, "tranches");
+        assertEq(lockup.getTranches(streamId), tranches);
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
 
         // Assert that the stream's status is "STREAMING".

--- a/tests/integration/concrete/lockup-tranched/create-with-timestamps-lt/createWithTimestampsLT.t.sol
+++ b/tests/integration/concrete/lockup-tranched/create-with-timestamps-lt/createWithTimestampsLT.t.sol
@@ -278,7 +278,7 @@ contract CreateWithTimestampsLT_Integration_Concrete_Test is CreateWithTimestamp
         // It should create the stream.
         assertEqStream(streamId);
         assertEq(lockup.getAsset(streamId), IERC20(asset), "asset");
-        assertEq(lockup.getTranches(streamId), defaults.tranches(), "tranches");
+        assertEq(lockup.getTranches(streamId), defaults.tranches());
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
     }
 }

--- a/tests/integration/concrete/lockup-tranched/get-tranches/getTranches.t.sol
+++ b/tests/integration/concrete/lockup-tranched/get-tranches/getTranches.t.sol
@@ -25,6 +25,6 @@ contract GetTranches_Integration_Concrete_Test is Lockup_Tranched_Integration_Co
     function test_GivenTranchedModel() external givenNotNull {
         LockupTranched.Tranche[] memory actualTranches = lockup.getTranches(defaultStreamId);
         LockupTranched.Tranche[] memory expectedTranches = defaults.tranches();
-        assertEq(actualTranches, expectedTranches, "tranches");
+        assertEq(actualTranches, expectedTranches);
     }
 }

--- a/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
@@ -89,7 +89,7 @@ contract CreateWithDurationsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrati
         assertEq(lockup.getSender(streamId), users.sender, "sender");
         assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
-        assertEq(lockup.getSegments(streamId), vars.segmentsWithTimestamps, "segments");
+        assertEq(lockup.getSegments(streamId), vars.segmentsWithTimestamps);
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
 
         // Assert that the stream's status is correct.

--- a/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
@@ -276,7 +276,7 @@ contract CreateWithTimestampsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrat
         assertEq(lockup.getSender(streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(streamId), params.timestamps.start, "startTime");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
-        assertEq(lockup.getSegments(streamId), segments, "segments");
+        assertEq(lockup.getSegments(streamId), segments);
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
 
         // Assert that the stream's status is correct.

--- a/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
@@ -89,7 +89,7 @@ contract CreateWithDurationsLT_Integration_Fuzz_Test is Lockup_Tranched_Integrat
         assertEq(lockup.getSender(streamId), users.sender, "sender");
         assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
-        assertEq(lockup.getTranches(streamId), vars.tranchesWithTimestamps, "tranches");
+        assertEq(lockup.getTranches(streamId), vars.tranchesWithTimestamps);
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
 
         // Assert that the stream's status is correct.

--- a/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
@@ -282,7 +282,7 @@ contract CreateWithTimestampsLT_Integration_Fuzz_Test is Lockup_Tranched_Integra
         assertEq(lockup.getSender(streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(streamId), params.timestamps.start, "startTime");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
-        assertEq(lockup.getTranches(streamId), tranches, "tranches");
+        assertEq(lockup.getTranches(streamId), tranches);
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
 
         // Assert that the stream's status is correct.

--- a/tests/utils/Assertions.sol
+++ b/tests/utils/Assertions.sol
@@ -16,19 +16,15 @@ abstract contract Assertions is PRBMathAssertions {
 
     event log_named_array(string key, LockupTranched.Tranche[] tranches);
 
-    event log_named_uint128(string key, uint128 value);
-
-    event log_named_uint40(string key, uint40 value);
-
     /*//////////////////////////////////////////////////////////////////////////
                                     FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @dev Compares two {Lockup.Amounts} struct entities.
-    function assertEq(Lockup.Amounts memory a, Lockup.Amounts memory b) internal {
-        assertEqUint128(a.deposited, b.deposited, "amounts.deposited");
-        assertEqUint128(a.refunded, b.refunded, "amounts.refunded");
-        assertEqUint128(a.withdrawn, b.withdrawn, "amounts.withdrawn");
+    function assertEq(Lockup.Amounts memory a, Lockup.Amounts memory b) internal pure {
+        assertEq(a.deposited, b.deposited, "amounts.deposited");
+        assertEq(a.refunded, b.refunded, "amounts.refunded");
+        assertEq(a.withdrawn, b.withdrawn, "amounts.withdrawn");
     }
 
     /// @dev Compares two {IERC20} values.
@@ -47,9 +43,9 @@ abstract contract Assertions is PRBMathAssertions {
     }
 
     /// @dev Compares two {Lockup.Timestamps} struct entities.
-    function assertEq(Lockup.Timestamps memory a, Lockup.Timestamps memory b) internal {
-        assertEqUint40(a.end, b.end, "timestamps.end");
-        assertEqUint40(a.start, b.start, "timestamps.start");
+    function assertEq(Lockup.Timestamps memory a, Lockup.Timestamps memory b) internal pure {
+        assertEq(a.end, b.end, "timestamps.end");
+        assertEq(a.start, b.start, "timestamps.start");
     }
 
     /// @dev Compares two {LockupDynamic.Segment} arrays.
@@ -59,14 +55,6 @@ abstract contract Assertions is PRBMathAssertions {
             emit log_named_array("   Left", a);
             emit log_named_array("  Right", b);
             fail();
-        }
-    }
-
-    /// @dev Compares two {LockupDynamic.Segment} arrays.
-    function assertEq(LockupDynamic.Segment[] memory a, LockupDynamic.Segment[] memory b, string memory err) internal {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log_named_string("Error", err);
-            assertEq(a, b);
         }
     }
 
@@ -80,20 +68,6 @@ abstract contract Assertions is PRBMathAssertions {
         }
     }
 
-    /// @dev Compares two {LockupTranched.Tranche} arrays.
-    function assertEq(
-        LockupTranched.Tranche[] memory a,
-        LockupTranched.Tranche[] memory b,
-        string memory err
-    )
-        internal
-    {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log_named_string("Error", err);
-            assertEq(a, b);
-        }
-    }
-
     /// @dev Compares two {Lockup.Status} enum values.
     function assertEq(Lockup.Status a, Lockup.Status b) internal pure {
         assertEq(uint256(a), uint256(b), "status");
@@ -102,42 +76,6 @@ abstract contract Assertions is PRBMathAssertions {
     /// @dev Compares two {Lockup.Status} enum values.
     function assertEq(Lockup.Status a, Lockup.Status b, string memory err) internal pure {
         assertEq(uint256(a), uint256(b), err);
-    }
-
-    /// @dev Compares two `uint128` numbers.
-    function assertEqUint128(uint128 a, uint128 b) internal {
-        if (a != b) {
-            emit log("Error: a == b not satisfied [uint128]");
-            emit log_named_uint128("   Left", a);
-            emit log_named_uint128("  Right", b);
-            fail();
-        }
-    }
-
-    /// @dev Compares two `uint128` numbers.
-    function assertEqUint128(uint128 a, uint128 b, string memory err) internal {
-        if (a != b) {
-            emit log_named_string("Error", err);
-            assertEqUint128(a, b);
-        }
-    }
-
-    /// @dev Compares two `uint40` numbers.
-    function assertEqUint40(uint40 a, uint40 b) internal {
-        if (a != b) {
-            emit log("Error: a == b not satisfied [uint40]");
-            emit log_named_uint40("   Left", a);
-            emit log_named_uint40("  Right", b);
-            fail();
-        }
-    }
-
-    /// @dev Compares two `uint40` numbers.
-    function assertEqUint40(uint40 a, uint40 b, string memory err) internal {
-        if (a != b) {
-            emit log_named_string("Error", err);
-            assertEqUint40(a, b);
-        }
     }
 
     /// @dev Compares two {Lockup.Status} enum values.


### PR DESCRIPTION
In this PR https://github.com/sablier-labs/v2-core/pull/1089/ the `script/protocol` dir was removed without updating the `fs_permissions` in `foundry.toml` and the `.gitignore` file.

Also, found out, we don't need all the assert functions declared in `Assertions`.
The `assertEq` functions for segments are already emitting the fact that we compare an array of segments/tranches.

Depends on: #1094 and #1095