### PR TITLE
refactor: get underlying token

### DIFF
--- a/src/LockupNFTDescriptor.sol
+++ b/src/LockupNFTDescriptor.sol
@@ -70,10 +70,10 @@ contract LockupNFTDescriptor is ILockupNFTDescriptor {
         vars.tokenSymbol = safeTokenSymbol(vars.token);
         vars.depositedAmount = vars.lockup.getDepositedAmount(streamId);
 
-        // Retrieve the token's address based on the Lockup contract version.
+        // Retrieve the underlying token contract's address.
         if (vars.lockupModel.equal("Sablier Lockup")) {
-            // For Lockup contract versions v2.0.0 and later, use the `getToken` function.
-            vars.token = address(vars.lockup.getToken(streamId));
+            // For Lockup contract versions v2.0.0 and later, use the `getUnderlyingToken` function.
+            vars.token = address(vars.lockup.getUnderlyingToken(streamId));
         }
         // For Lockup contract versions earlier than v2.0.0, use the `getAsset` function.
         else {

--- a/src/abstracts/SablierLockupBase.sol
+++ b/src/abstracts/SablierLockupBase.sol
@@ -74,11 +74,6 @@ abstract contract SablierLockupBase is
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ISablierLockupBase
-    function getToken(uint256 streamId) external view override notNull(streamId) returns (IERC20 token) {
-        token = _streams[streamId].token;
-    }
-
-    /// @inheritdoc ISablierLockupBase
     function getDepositedAmount(uint256 streamId)
         external
         view
@@ -130,6 +125,11 @@ abstract contract SablierLockupBase is
     /// @inheritdoc ISablierLockupBase
     function getStartTime(uint256 streamId) external view override notNull(streamId) returns (uint40 startTime) {
         startTime = _streams[streamId].startTime;
+    }
+
+    /// @inheritdoc ISablierLockupBase
+    function getUnderlyingToken(uint256 streamId) external view override notNull(streamId) returns (IERC20 token) {
+        token = _streams[streamId].token;
     }
 
     /// @inheritdoc ISablierLockupBase

--- a/src/interfaces/ISablierLockupBase.sol
+++ b/src/interfaces/ISablierLockupBase.sol
@@ -79,11 +79,6 @@ interface ISablierLockupBase is
     /// @dev This value is hard coded as a constant.
     function MAX_BROKER_FEE() external view returns (UD60x18);
 
-    /// @notice Retrieves the address of the ERC-20 token being distributed.
-    /// @dev Reverts if `streamId` references a null stream.
-    /// @param streamId The stream ID for the query.
-    function getToken(uint256 streamId) external view returns (IERC20 token);
-
     /// @notice Retrieves the amount deposited in the stream, denoted in units of the token's decimals.
     /// @dev Reverts if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
@@ -119,6 +114,11 @@ interface ISablierLockupBase is
     /// @dev Reverts if `streamId` references a null stream.
     /// @param streamId The stream ID for the query.
     function getStartTime(uint256 streamId) external view returns (uint40 startTime);
+
+    /// @notice Retrieves the address of the underlying ERC-20 token being distributed.
+    /// @dev Reverts if `streamId` references a null stream.
+    /// @param streamId The stream ID for the query.
+    function getUnderlyingToken(uint256 streamId) external view returns (IERC20 token);
 
     /// @notice Retrieves the amount withdrawn from the stream, denoted in units of the token's decimals.
     /// @dev Reverts if `streamId` references a null stream.

--- a/tests/fork/LockupDynamic.t.sol
+++ b/tests/fork/LockupDynamic.t.sol
@@ -185,17 +185,17 @@ abstract contract Lockup_Dynamic_Fork_Test is Fork_Test {
         vars.isCancelable = vars.isSettled ? false : true;
 
         // Assert that the stream has been created.
-        assertEq(lockup.getToken(vars.streamId), FORK_TOKEN, "token");
         assertEq(lockup.getDepositedAmount(vars.streamId), vars.createAmounts.deposit, "depositedAmount");
         assertEq(lockup.getEndTime(vars.streamId), vars.timestamps.end, "endTime");
         assertEq(lockup.isCancelable(vars.streamId), vars.isCancelable, "isCancelable");
+        assertFalse(lockup.isDepleted(vars.streamId), "isDepleted");
         assertTrue(lockup.isStream(vars.streamId), "isStream");
         assertTrue(lockup.isTransferable(vars.streamId), "isTransferable");
         assertEq(lockup.getRecipient(vars.streamId), params.recipient, "recipient");
-        assertEq(lockup.getSegments(vars.streamId), params.segments);
         assertEq(lockup.getSender(vars.streamId), params.sender, "sender");
+        assertEq(lockup.getSegments(vars.streamId), params.segments);
         assertEq(lockup.getStartTime(vars.streamId), params.startTime, "startTime");
-        assertFalse(lockup.isDepleted(vars.streamId), "isDepleted");
+        assertEq(lockup.getUnderlyingToken(vars.streamId), FORK_TOKEN, "underlyingToken");
         assertFalse(lockup.wasCanceled(vars.streamId), "wasCanceled");
 
         // Assert that the stream's status is correct.

--- a/tests/fork/LockupLinear.t.sol
+++ b/tests/fork/LockupLinear.t.sol
@@ -220,17 +220,17 @@ abstract contract Lockup_Linear_Fork_Test is Fork_Test {
         vars.isCancelable = vars.isSettled ? false : true;
 
         // Assert that the stream has been created.
-        assertEq(lockup.getToken(vars.streamId), FORK_TOKEN, "token");
         assertEq(lockup.getCliffTime(vars.streamId), params.cliffTime, "cliffTime");
         assertEq(lockup.getDepositedAmount(vars.streamId), vars.createAmounts.deposit, "depositedAmount");
-        assertEq(lockup.getEndTime(vars.streamId), params.timestamps.end, "endTime");
         assertEq(lockup.isCancelable(vars.streamId), vars.isCancelable, "isCancelable");
         assertFalse(lockup.isDepleted(vars.streamId), "isDepleted");
         assertTrue(lockup.isStream(vars.streamId), "isStream");
         assertTrue(lockup.isTransferable(vars.streamId), "isTransferable");
+        assertEq(lockup.getEndTime(vars.streamId), params.timestamps.end, "endTime");
         assertEq(lockup.getRecipient(vars.streamId), params.recipient, "recipient");
         assertEq(lockup.getSender(vars.streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(vars.streamId), params.timestamps.start, "startTime");
+        assertEq(lockup.getUnderlyingToken(vars.streamId), FORK_TOKEN, "underlyingToken");
         assertEq(lockup.getUnlockAmounts(vars.streamId).start, params.unlockAmounts.start, "unlockAmounts.start");
         assertEq(lockup.getUnlockAmounts(vars.streamId).cliff, params.unlockAmounts.cliff, "unlockAmounts.cliff");
         assertFalse(lockup.wasCanceled(vars.streamId), "wasCanceled");

--- a/tests/fork/LockupTranched.t.sol
+++ b/tests/fork/LockupTranched.t.sol
@@ -185,17 +185,17 @@ abstract contract Lockup_Tranched_Fork_Test is Fork_Test {
         vars.isCancelable = vars.isSettled ? false : true;
 
         // Assert that the stream has been created.
-        assertEq(lockup.getToken(vars.streamId), FORK_TOKEN, "token");
-        assertEq(lockup.getDepositedAmount(vars.streamId), vars.createAmounts.deposit, "depositedAmount");
-        assertEq(lockup.getEndTime(vars.streamId), vars.timestamps.end, "endTime");
         assertEq(lockup.isCancelable(vars.streamId), vars.isCancelable, "isCancelable");
         assertFalse(lockup.isDepleted(vars.streamId), "isDepleted");
         assertTrue(lockup.isStream(vars.streamId), "isStream");
         assertTrue(lockup.isTransferable(vars.streamId), "isTransferable");
+        assertEq(lockup.getDepositedAmount(vars.streamId), vars.createAmounts.deposit, "depositedAmount");
+        assertEq(lockup.getEndTime(vars.streamId), vars.timestamps.end, "endTime");
         assertEq(lockup.getRecipient(vars.streamId), params.recipient, "recipient");
         assertEq(lockup.getSender(vars.streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(vars.streamId), params.startTime, "startTime");
         assertEq(lockup.getTranches(vars.streamId), params.tranches);
+        assertEq(lockup.getUnderlyingToken(vars.streamId), FORK_TOKEN, "underlyingToken");
         assertFalse(lockup.wasCanceled(vars.streamId), "wasCanceled");
 
         // Assert that the stream's status is correct.

--- a/tests/integration/concrete/lockup-base/getters/getters.t.sol
+++ b/tests/integration/concrete/lockup-base/getters/getters.t.sol
@@ -159,17 +159,17 @@ contract Getters_Integration_Concrete_Test is Integration_Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                     GET-TOKEN
+                                GET-UNDERLYING-TOKEN
     //////////////////////////////////////////////////////////////////////////*/
 
-    function test_GetTokenRevertGiven_Null() external {
-        expectRevert_Null({ callData: abi.encodeCall(lockup.getToken, nullStreamId) });
+    function test_GetUnderlyingTokenRevertGiven_Null() external {
+        expectRevert_Null({ callData: abi.encodeCall(lockup.getUnderlyingToken, nullStreamId) });
     }
 
-    function test_GetTokenGivenNotNull() external view {
-        IERC20 actualToken = lockup.getToken(defaultStreamId);
-        IERC20 expectedToken = dai;
-        assertEq(actualToken, expectedToken, "token");
+    function test_GetUnderlyingTokenGivenNotNull() external view {
+        IERC20 actualUnderlyingToken = lockup.getUnderlyingToken(defaultStreamId);
+        IERC20 expectedUnderlyingToken = dai;
+        assertEq(actualUnderlyingToken, expectedUnderlyingToken, "underlyingToken");
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/tests/integration/concrete/lockup-base/getters/getters.tree
+++ b/tests/integration/concrete/lockup-base/getters/getters.tree
@@ -49,7 +49,7 @@ Getters_Integration_Concrete_Test::getStartTime
 └── given not null
    └── it should return the correct start time
 
-Getters_Integration_Concrete_Test::getToken
+Getters_Integration_Concrete_Test::getUnderlyingToken
 ├── given null
 │  └── it should revert
 └── given not null

--- a/tests/integration/concrete/lockup-dynamic/create-with-durations-ld/createWithDurationsLD.t.sol
+++ b/tests/integration/concrete/lockup-dynamic/create-with-durations-ld/createWithDurationsLD.t.sol
@@ -167,17 +167,17 @@ contract CreateWithDurationsLD_Integration_Concrete_Test is Lockup_Dynamic_Integ
 
         // Assert that the stream has been created.
         assertEq(lockup.getDepositedAmount(streamId), defaults.DEPOSIT_AMOUNT(), "depositedAmount");
-        assertEq(lockup.getSender(streamId), users.sender, "sender");
-        assertEq(lockup.getRecipient(streamId), users.recipient, "recipient");
-        assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
-        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isCancelable(streamId), "isCancelable");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
-        assertEq(lockup.getToken(streamId), dai, "token");
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
+        assertEq(lockup.getRecipient(streamId), users.recipient, "recipient");
+        assertEq(lockup.getSender(streamId), users.sender, "sender");
+        assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
+        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
         // Assert that the stream's status is "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);

--- a/tests/integration/concrete/lockup-dynamic/create-with-timestamps-ld/createWithTimestampsLD.t.sol
+++ b/tests/integration/concrete/lockup-dynamic/create-with-timestamps-ld/createWithTimestampsLD.t.sol
@@ -287,7 +287,7 @@ contract CreateWithTimestampsLD_Integration_Concrete_Test is CreateWithTimestamp
 
         // It should create the stream.
         assertEqStream(streamId);
-        assertEq(lockup.getToken(streamId), IERC20(token), "token");
+        assertEq(lockup.getUnderlyingToken(streamId), IERC20(token), "underlyingToken");
         assertEq(lockup.getSegments(streamId), defaults.segments());
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
     }

--- a/tests/integration/concrete/lockup-linear/create-with-durations-ll/createWithDurationsLL.t.sol
+++ b/tests/integration/concrete/lockup-linear/create-with-durations-ll/createWithDurationsLL.t.sol
@@ -103,20 +103,20 @@ contract CreateWithDurationsLL_Integration_Concrete_Test is Lockup_Linear_Integr
         uint256 streamId = createDefaultStreamWithDurations();
 
         // It should create the stream.
-        assertEq(lockup.getToken(streamId), dai, "token");
+        assertEq(lockup.getCliffTime(streamId), cliffTime, "cliffTime");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), true, "isCancelable");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
+        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_LINEAR);
         assertEq(lockup.getRecipient(streamId), users.recipient, "recipient");
         assertEq(lockup.getSender(streamId), users.sender, "sender");
         assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
-        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
-        assertEq(lockup.getCliffTime(streamId), cliffTime, "cliffTime");
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertEq(lockup.getUnlockAmounts(streamId).start, _defaultParams.unlockAmounts.start, "unlockAmounts.start");
         assertEq(lockup.getUnlockAmounts(streamId).cliff, _defaultParams.unlockAmounts.cliff, "unlockAmounts.cliff");
-        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_LINEAR);
+        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
         // Assert that the stream's status is "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);

--- a/tests/integration/concrete/lockup-linear/create-with-timestamps-ll/createWithTimestampsLL.t.sol
+++ b/tests/integration/concrete/lockup-linear/create-with-timestamps-ll/createWithTimestampsLL.t.sol
@@ -238,9 +238,9 @@ contract CreateWithTimestampsLL_Integration_Concrete_Test is CreateWithTimestamp
 
         // It should create the stream.
         assertEqStream(streamId);
-        assertEq(lockup.getToken(streamId), IERC20(token), "token");
         assertEq(lockup.getCliffTime(streamId), cliffTime, "cliffTime");
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_LINEAR);
+        assertEq(lockup.getUnderlyingToken(streamId), IERC20(token), "underlyingToken");
         assertEq(lockup.getUnlockAmounts(streamId).start, _defaultParams.unlockAmounts.start, "unlockAmounts.start");
         assertEq(lockup.getUnlockAmounts(streamId).cliff, _defaultParams.unlockAmounts.cliff, "unlockAmounts.cliff");
     }

--- a/tests/integration/concrete/lockup-tranched/create-with-durations-lt/createWithDurationsLT.t.sol
+++ b/tests/integration/concrete/lockup-tranched/create-with-durations-lt/createWithDurationsLT.t.sol
@@ -159,18 +159,18 @@ contract CreateWithDurationsLT_Integration_Concrete_Test is Lockup_Tranched_Inte
 
         // Assert that the stream has been created.
         assertEq(lockup.getDepositedAmount(streamId), defaults.DEPOSIT_AMOUNT(), "depositedAmount");
-        assertEq(lockup.getToken(streamId), dai, "token");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), true, "isCancelable");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
+        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
         assertEq(lockup.getRecipient(streamId), users.recipient, "recipient");
         assertEq(lockup.getSender(streamId), users.sender, "sender");
         assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
-        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
         assertEq(lockup.getTranches(streamId), tranches);
-        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
+        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
         // Assert that the stream's status is "STREAMING".
         Lockup.Status actualStatus = lockup.statusOf(streamId);

--- a/tests/integration/concrete/lockup-tranched/create-with-timestamps-lt/createWithTimestampsLT.t.sol
+++ b/tests/integration/concrete/lockup-tranched/create-with-timestamps-lt/createWithTimestampsLT.t.sol
@@ -277,8 +277,8 @@ contract CreateWithTimestampsLT_Integration_Concrete_Test is CreateWithTimestamp
 
         // It should create the stream.
         assertEqStream(streamId);
-        assertEq(lockup.getToken(streamId), IERC20(token), "token");
-        assertEq(lockup.getTranches(streamId), defaults.tranches());
         assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
+        assertEq(lockup.getTranches(streamId), defaults.tranches());
+        assertEq(lockup.getUnderlyingToken(streamId), IERC20(token), "underlyingToken");
     }
 }

--- a/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithDurationsLD.t.sol
@@ -79,18 +79,18 @@ contract CreateWithDurationsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrati
 
         // It should create the stream.
         assertEq(lockup.getDepositedAmount(streamId), vars.createAmounts.deposit, "depositedAmount");
-        assertEq(lockup.getToken(streamId), dai, "token");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), vars.isCancelable, "isCancelable");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
+        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
         assertEq(lockup.getRecipient(streamId), users.recipient, "recipient");
         assertEq(lockup.getSender(streamId), users.sender, "sender");
-        assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
-        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
         assertEq(lockup.getSegments(streamId), vars.segmentsWithTimestamps);
-        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
+        assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
+        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
         // Assert that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);

--- a/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
+++ b/tests/integration/fuzz/lockup-dynamic/createWithTimestampsLD.t.sol
@@ -266,18 +266,18 @@ contract CreateWithTimestampsLD_Integration_Fuzz_Test is Lockup_Dynamic_Integrat
 
         // It should create the stream.
         assertEq(lockup.getDepositedAmount(streamId), vars.createAmounts.deposit, "depositedAmount");
-        assertEq(lockup.getToken(streamId), dai, "token");
         assertEq(lockup.getEndTime(streamId), params.timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), vars.isCancelable, "isCancelable");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
+        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
         assertEq(lockup.getRecipient(streamId), params.recipient, "recipient");
         assertEq(lockup.getSender(streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(streamId), params.timestamps.start, "startTime");
-        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertEq(lockup.getSegments(streamId), segments);
-        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_DYNAMIC);
+        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
         // Assert that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);

--- a/tests/integration/fuzz/lockup-linear/createWithDurationsLL.t.sol
+++ b/tests/integration/fuzz/lockup-linear/createWithDurationsLL.t.sol
@@ -76,19 +76,19 @@ contract CreateWithDurationsLL_Integration_Fuzz_Test is Lockup_Linear_Integratio
         uint256 streamId = createDefaultStreamWithDurations();
 
         // It should create the stream.
+        assertEq(lockup.getCliffTime(streamId), cliffTime, "cliffTime");
         assertEq(lockup.getDepositedAmount(streamId), defaults.DEPOSIT_AMOUNT(), "depositedAmount");
-        assertEq(lockup.getToken(streamId), dai, "token");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), true, "isCancelable");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
+        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_LINEAR);
         assertEq(lockup.getRecipient(streamId), users.recipient, "recipient");
         assertEq(lockup.getSender(streamId), users.sender, "sender");
         assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
         assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
-        assertEq(lockup.getCliffTime(streamId), cliffTime, "cliffTime");
-        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_LINEAR);
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
         assertEq(lockup.getUnlockAmounts(streamId).start, unlockAmounts.start, "unlockAmounts.start");
         assertEq(lockup.getUnlockAmounts(streamId).cliff, unlockAmounts.cliff, "unlockAmounts.cliff");
 

--- a/tests/integration/fuzz/lockup-linear/createWithTimestampsLL.t.sol
+++ b/tests/integration/fuzz/lockup-linear/createWithTimestampsLL.t.sol
@@ -207,21 +207,21 @@ contract CreateWithTimestampsLL_Integration_Fuzz_Test is Lockup_Linear_Integrati
         vars.actualStreamId = lockup.createWithTimestampsLL(params, unlockAmounts, cliffTime);
 
         // It should create the stream.
+        assertEq(lockup.getCliffTime(vars.actualStreamId), cliffTime, "cliffTime");
         assertEq(lockup.getDepositedAmount(vars.actualStreamId), vars.createAmounts.deposit, "depositedAmount");
-        assertEq(lockup.getToken(vars.actualStreamId), dai, "token");
         assertEq(lockup.getEndTime(vars.actualStreamId), params.timestamps.end, "endTime");
         assertEq(lockup.isCancelable(vars.actualStreamId), params.cancelable, "isCancelable");
         assertFalse(lockup.isDepleted(vars.actualStreamId), "isDepleted");
         assertTrue(lockup.isStream(vars.actualStreamId), "isStream");
         assertTrue(lockup.isTransferable(vars.actualStreamId), "isTransferable");
+        assertEq(lockup.getLockupModel(vars.actualStreamId), Lockup.Model.LOCKUP_LINEAR);
         assertEq(lockup.getRecipient(vars.actualStreamId), params.recipient, "recipient");
         assertEq(lockup.getSender(vars.actualStreamId), params.sender, "sender");
         assertEq(lockup.getStartTime(vars.actualStreamId), params.timestamps.start, "startTime");
-        assertFalse(lockup.wasCanceled(vars.actualStreamId), "wasCanceled");
+        assertEq(lockup.getUnderlyingToken(vars.actualStreamId), dai, "underlyingToken");
         assertEq(lockup.getUnlockAmounts(vars.actualStreamId).start, unlockAmounts.start, "unlockAmounts.start");
         assertEq(lockup.getUnlockAmounts(vars.actualStreamId).cliff, unlockAmounts.cliff, "unlockAmounts.cliff");
-        assertEq(lockup.getCliffTime(vars.actualStreamId), cliffTime, "cliffTime");
-        assertEq(lockup.getLockupModel(vars.actualStreamId), Lockup.Model.LOCKUP_LINEAR);
+        assertFalse(lockup.wasCanceled(vars.actualStreamId), "wasCanceled");
 
         // Assert that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(vars.actualStreamId);

--- a/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithDurationsLT.t.sol
@@ -79,18 +79,18 @@ contract CreateWithDurationsLT_Integration_Fuzz_Test is Lockup_Tranched_Integrat
 
         // It should create the stream.
         assertEq(lockup.getDepositedAmount(streamId), vars.createAmounts.deposit, "depositedAmount");
-        assertEq(lockup.getToken(streamId), dai, "token");
         assertEq(lockup.getEndTime(streamId), timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), vars.isCancelable, "isCancelable");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
+        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
         assertEq(lockup.getRecipient(streamId), users.recipient, "recipient");
         assertEq(lockup.getSender(streamId), users.sender, "sender");
         assertEq(lockup.getStartTime(streamId), timestamps.start, "startTime");
-        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
         assertEq(lockup.getTranches(streamId), vars.tranchesWithTimestamps);
-        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
+        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
         // Assert that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);

--- a/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
+++ b/tests/integration/fuzz/lockup-tranched/createWithTimestampsLT.t.sol
@@ -272,18 +272,18 @@ contract CreateWithTimestampsLT_Integration_Fuzz_Test is Lockup_Tranched_Integra
 
         // It should create the stream.
         assertEq(lockup.getDepositedAmount(streamId), vars.createAmounts.deposit, "depositedAmount");
-        assertEq(lockup.getToken(streamId), dai, "token");
         assertEq(lockup.getEndTime(streamId), params.timestamps.end, "endTime");
         assertEq(lockup.isCancelable(streamId), vars.isCancelable, "isCancelable");
         assertFalse(lockup.isDepleted(streamId), "isDepleted");
         assertTrue(lockup.isStream(streamId), "isStream");
         assertTrue(lockup.isTransferable(streamId), "isTransferable");
+        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
         assertEq(lockup.getRecipient(streamId), params.recipient, "recipient");
         assertEq(lockup.getSender(streamId), params.sender, "sender");
         assertEq(lockup.getStartTime(streamId), params.timestamps.start, "startTime");
-        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
         assertEq(lockup.getTranches(streamId), tranches);
-        assertEq(lockup.getLockupModel(streamId), Lockup.Model.LOCKUP_TRANCHED);
+        assertEq(lockup.getUnderlyingToken(streamId), dai, "underlyingToken");
+        assertFalse(lockup.wasCanceled(streamId), "wasCanceled");
 
         // Assert that the stream's status is correct.
         vars.actualStatus = lockup.statusOf(streamId);


### PR DESCRIPTION
In https://github.com/sablier-labs/v2-core/pull/1097, @andreivladbrg renamed `getAsset` to `getToken`.

`getToken` can be easily confused with the ERC-721 NFT functions.

It'd be better to rename it to `getUnderlyingToken`.