### PR TITLE
build: lower optimizer runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@
   ]
   gas_limit = 9223372036854775807
   optimizer = true
-  optimizer_runs = 1000
+  optimizer_runs = 800
   out = "out"
   script = "script"
   sender = "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sablier/lockup",
   "description": "Core smart contracts of the Lockup token distribution protocol",
   "license": "BUSL-1.1",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "author": {
     "name": "Sablier Labs Ltd",
     "url": "https://sablier.com"

--- a/tests/utils/BaseScript.t.sol
+++ b/tests/utils/BaseScript.t.sol
@@ -17,7 +17,7 @@ contract BaseScript_Test is StdAssertions {
 
     function test_ConstructCreate2Salt() public view {
         string memory chainId = block.chainid.toString();
-        string memory version = "1.2.0";
+        string memory version = "2.0.0";
         string memory salt = string.concat("ChainID ", chainId, ", Version ", version);
 
         bytes32 actualSalt = baseScript.constructCreate2Salt();


### PR DESCRIPTION
The size of the `SablierLockup` contract passes the limit:

```
| SablierLockup                 |           25,069 |            26,085 |               -493 |              23,067 |
```

So we need to lower the optimizer runs to 800.
Also, update the package json version to `2.0.0`