### PR TITLE
feat: add deploy commands

### DIFF
--- a/airdrops/justfile
+++ b/airdrops/justfile
@@ -4,3 +4,9 @@ import "./node_modules/@sablier/devkit/just/evm.just"
 # Run just --list to see all available commands
 default:
   @just --list
+
+deploy *args:
+    FOUNDRY_PROFILE=optimized \
+        forge script scripts/solidity/DeployDeterministicFactories.s.sol \
+        -vvv --broadcast {{ args }}
+  

--- a/flow/justfile
+++ b/flow/justfile
@@ -4,3 +4,8 @@ import "./node_modules/@sablier/devkit/just/evm.just"
 # Run just --list to see all available commands
 default:
   @just --list
+
+deploy *args:
+    FOUNDRY_PROFILE=optimized \
+        forge script scripts/solidity/DeployDeterministicProtocol.s.sol \
+        -vvv --broadcast {{ args }}

--- a/justfile
+++ b/justfile
@@ -101,6 +101,16 @@ coverage package:
 coverage-all:
     just for-each coverage
 
+# Deploy package contracts
+[group("foundry")]
+deploy package *args:
+    just {{ package }}/deploy {{ args }}
+
+# Deploy all contracts for all packages
+[group("foundry")]
+deploy-all *args:
+    just for-each deploy {{ args }}
+
 # Run tests for a specific package
 [group("foundry")]
 test package *args:
@@ -147,11 +157,12 @@ test-optimized-all:
 
 # Helper to run recipe in each package
 [private]
-for-each recipe:
-    just airdrops/{{ recipe }}
-    just flow/{{ recipe }}
-    just lockup/{{ recipe }}
-    just utils/{{ recipe }}
+for-each recipe *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for dir in airdrops flow lockup utils; do
+        just "$dir/{{ recipe }}" {{ args }}
+    done
 
 # Setup .env symlinks in all packages
 [private]

--- a/lockup/justfile
+++ b/lockup/justfile
@@ -4,3 +4,8 @@ import "./node_modules/@sablier/devkit/just/evm.just"
 # Run just --list to see all available commands
 default:
   @just --list
+
+deploy *args:
+    FOUNDRY_PROFILE=optimized \
+        forge script scripts/solidity/DeployDeterministicProtocol.s.sol \
+        -vvv --broadcast {{ args }}

--- a/utils/justfile
+++ b/utils/justfile
@@ -4,3 +4,8 @@ import "./node_modules/@sablier/devkit/just/evm.just"
 # Run just --list to see all available commands
 default:
   @just --list
+
+deploy *args:
+    FOUNDRY_PROFILE=optimized \
+        forge script scripts/solidity/DeployDeterministicComptrollerProxy.s.sol \
+        -vvv --broadcast {{ args }}


### PR DESCRIPTION
Closes https://github.com/sablier-labs/lockup/issues/1311

If you want to test commands without broadcasting, you can temporarily remove the flag locally.

In the next release we would simply run for all protocols:

```sh
just deploy-all --rpc-url <chain> --verify --etherscan-api-key $ETHERSCAN_API_KEY
```