### PR TITLE
chore: correct ignore paths in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,9 @@ coverage:
   status:
     patch: off
 ignore:
-  - "scripts"
-  - "scripts/solidity"
-  - "src/libraries/NFTSVG.sol"
-  - "src/libraries/SVGElements.sol"
-  - "src/mocks"
-  - "src/tests"
-  - "tests"
+  - "lockup/src/libraries/NFTSVG.sol"
+  - "lockup/src/libraries/SVGElements.sol"
+  - "**/scripts/**"
+  - "**/src/mocks/**"
+  - "**/src/tests/**"
+  - "**/tests/**"


### PR DESCRIPTION
Closes https://github.com/sablier-labs/lockup/issues/1319

The coverage is now >97%.

<img width="503" height="196" alt="image" src="https://github.com/user-attachments/assets/033606f4-312e-4b26-b7cd-9c5665170e5b" />
