### PR TITLE
test(utils): add Comptroller fork tests

### DIFF
--- a/foundry.base.toml
+++ b/foundry.base.toml
@@ -32,6 +32,7 @@
 
 # Speed up compilation and tests during development
 [profile.lite]
+  fuzz.runs = 10
   optimizer = false
 
 # Compile only the production code

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -125,6 +125,9 @@ contract Comptroller_Fork_Test is Base_Test {
 
     /// @dev It should transfer fees from Comptroller, Lockup and Flow to the provided fee recipient.
     function testForkFuzz_TransferFees(address feeRecipient) external whenFeeRecipientNotZero {
+        // Skip if fee recipient is zero address.
+        vm.assume(feeRecipient != address(0));
+
         uint256 initialFeeRecipientBalance = feeRecipient.balance;
 
         // Calculate expected fee amount as the sum of balances of comptroller and protocol addresses.

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { Upgrades } from "@openzeppelin/foundry-upgrades/src/Upgrades.sol";
+import { IComptrollerable } from "src/interfaces/IComptrollerable.sol";
+import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
+import { SablierComptroller } from "src/SablierComptroller.sol";
+
+import { Base_Test } from "tests/Base.t.sol";
+import { BaseScriptMock } from "tests/mocks/BaseScriptMock.sol";
+
+contract Comptroller_Fork_Test is Base_Test {
+    /*//////////////////////////////////////////////////////////////////////////
+                                  STATE VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    BaseScriptMock internal baseScript;
+    address[] internal protocolAddresses;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       SET-UP
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function setUp() public override {
+        // Fork Ethereum Mainnet at the latest block number.
+        vm.createSelectFork({ urlOrAlias: "ethereum" });
+
+        // Deploy the `BaseScriptMock` contract.
+        baseScript = new BaseScriptMock();
+
+        // Load comptroller address from the mainnet.
+        comptroller = ISablierComptroller(0x0000008ABbFf7a84a2fE09f9A9b74D3BC2072399);
+
+        // Load Lockup and Flow addresses from the mainnet.
+        protocolAddresses = new address[](2);
+        protocolAddresses[0] = 0xcF8ce57fa442ba50aCbC57147a62aD03873FfA73;
+        protocolAddresses[1] = 0x7a86d3e6894f9c5B5f25FFBDAaE658CFc7569623;
+
+        // Set comptroller admin as the caller.
+        setMsgSender(baseScript.getAdmin());
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       TESTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Checklist:
+    /// - It should return zero value for Staking protocol.
+    /// - It should return non-zero value for Lockup, Flow and Airdrops.
+    function testForkFuzz_CalculateMinFeeWei(uint8 protocolIndex) external view {
+        // Bound the protocol enum to a valid enum value.
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+
+        // It should return the min fee in wei.
+        uint256 minFeeInWei = comptroller.calculateMinFeeWei(protocol);
+        if (protocol == ISablierComptroller.Protocol.Staking) {
+            assertEq(minFeeInWei, 0, "Staking: minFeeInWei > 0");
+        } else {
+            assertGt(minFeeInWei, 0, "Lockup, Flow, Airdrops: minFeeInWei == 0");
+        }
+    }
+
+    /// @dev It tests the state variables that will rarely be changed.
+    function testFork_Constructor() external view {
+        // Assert the comptroller admin.
+        assertEq(comptroller.admin(), baseScript.getAdmin(), "admin");
+
+        // Assert the max fee in usd.
+        assertEq(comptroller.MAX_FEE_USD(), MAX_FEE_USD, "max fee USD");
+
+        // Assert the oracle address.
+        assertEq(comptroller.oracle(), baseScript.getChainlinkOracle(), "oracle");
+    }
+
+    /// @dev It should return non-zero value for all values of feeUSD.
+    function testForkFuzz_ConvertUSDFeeToWei(uint128 feeUSD) external view {
+        // It should convert the USD fee to wei.
+        uint256 feeInWei = comptroller.convertUSDFeeToWei(feeUSD);
+        assertGt(feeInWei, 0, "feeInWei == 0");
+    }
+
+    /// @dev It should use `execute` function to change the comptroller on the protocol contracts.
+    function testFork_Execute() external {
+        // Deploy a new comptroller.
+        SablierComptroller newComptroller = new SablierComptroller(admin);
+
+        bytes memory payload = abi.encodeCall(IComptrollerable.setComptroller, (newComptroller));
+
+        // Use `execute` function to change comptroller for each of the protocols.
+        for (uint256 i; i < protocolAddresses.length; ++i) {
+            // It should emit an {Execute} event.
+            vm.expectEmit({ emitter: address(comptroller) });
+            emit ISablierComptroller.Execute({
+                target: protocolAddresses[i],
+                data: abi.encodeCall(IComptrollerable.setComptroller, (newComptroller)),
+                result: ""
+            });
+
+            comptroller.execute({ target: protocolAddresses[i], data: payload });
+
+            // It should change the comptroller.
+            assertEq(
+                address(IComptrollerable(protocolAddresses[i]).comptroller()),
+                address(newComptroller),
+                "New comptroller"
+            );
+        }
+    }
+
+    /// @dev It should change the min fee in USD for a given protocol.
+    function testForkFuzz_SetMinFeeUSD(uint8 protocolIndex, uint128 newMinFeeUSD) external whenNewFeeNotExceedMaxFee {
+        // Bound custom fee USD to the max fee USD.
+        newMinFeeUSD = boundUint128(newMinFeeUSD, 0, uint128(MAX_FEE_USD));
+
+        // Bound the protocol enum to a valid enum value.
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+
+        // Set min fee USD.
+        comptroller.setMinFeeUSD(protocol, newMinFeeUSD);
+
+        // It should set the min fee USD.
+        assertEq(comptroller.getMinFeeUSD(protocol), newMinFeeUSD, "min fee USD");
+    }
+
+    /// @dev It should transfer fees from Comptroller, Lockup and Flow to the provided fee recipient.
+    function testForkFuzz_TransferFees(address feeRecipient) external whenFeeRecipientNotZero {
+        uint256 initialFeeRecipientBalance = feeRecipient.balance;
+
+        // Calculate expected fee amount as the sum of balances of comptroller and protocol addresses.
+        uint256 expectedFeeAmount = address(comptroller).balance;
+        for (uint256 i; i < protocolAddresses.length; ++i) {
+            expectedFeeAmount += protocolAddresses[i].balance;
+        }
+
+        // It should emit a {TransferFees} event.
+        vm.expectEmit({ emitter: address(comptroller) });
+        emit ISablierComptroller.TransferFees({ feeRecipient: feeRecipient, feeAmount: expectedFeeAmount });
+
+        // Transfer fees to the fee recipient.
+        comptroller.transferFees(protocolAddresses, feeRecipient);
+
+        // Assert that the fee is transferred to the fee recipient.
+        assertEq(feeRecipient.balance, initialFeeRecipientBalance + expectedFeeAmount, "Fee Recipient balance");
+    }
+
+    /// @dev It should change the implementation address for the Comptroller proxy.
+    function testFork_UpgradeToAndCall() external {
+        // Deploy a new implementation that supports {IERC1822Proxiable} interface.
+        address newImplementation = address(new SablierComptroller(admin));
+
+        // Upgrade to the new implementation.
+        UUPSUpgradeable(address(comptroller)).upgradeToAndCall(newImplementation, "");
+
+        // It should set the new implementation.
+        address actualComptrollerImpl = payable(Upgrades.getImplementationAddress(address(comptroller)));
+        address expectedComptrollerImpl = newImplementation;
+        assertEq(actualComptrollerImpl, expectedComptrollerImpl, "implementation");
+    }
+}

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -73,13 +73,6 @@ contract Comptroller_Fork_Test is Base_Test {
         assertEq(comptroller.oracle(), baseScript.getChainlinkOracle(), "oracle");
     }
 
-    /// @dev It should return non-zero value for all values of feeUSD.
-    function testForkFuzz_ConvertUSDFeeToWei(uint128 feeUSD) external view {
-        // It should convert the USD fee to wei.
-        uint256 feeInWei = comptroller.convertUSDFeeToWei(feeUSD);
-        assertGt(feeInWei, 0, "feeInWei == 0");
-    }
-
     /// @dev It should use `execute` function to change the comptroller on the protocol contracts.
     function testFork_Execute() external {
         // Deploy a new comptroller.
@@ -109,9 +102,9 @@ contract Comptroller_Fork_Test is Base_Test {
     }
 
     /// @dev It should change the min fee in USD for a given protocol.
-    function testForkFuzz_SetMinFeeUSD(uint8 protocolIndex, uint128 newMinFeeUSD) external whenNewFeeNotExceedMaxFee {
+    function testForkFuzz_SetMinFeeUSD(uint8 protocolIndex, uint256 newMinFeeUSD) external whenNewFeeNotExceedMaxFee {
         // Bound custom fee USD to the max fee USD.
-        newMinFeeUSD = boundUint128(newMinFeeUSD, 0, uint128(MAX_FEE_USD));
+        newMinFeeUSD = bound(newMinFeeUSD, 0, MAX_FEE_USD);
 
         // Bound the protocol enum to a valid enum value.
         ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
@@ -156,7 +149,7 @@ contract Comptroller_Fork_Test is Base_Test {
         UUPSUpgradeable(address(comptroller)).upgradeToAndCall(newImplementation, "");
 
         // It should set the new implementation.
-        address actualComptrollerImpl = payable(Upgrades.getImplementationAddress(address(comptroller)));
+        address actualComptrollerImpl = Upgrades.getImplementationAddress(address(comptroller));
         address expectedComptrollerImpl = newImplementation;
         assertEq(actualComptrollerImpl, expectedComptrollerImpl, "implementation");
     }

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -16,6 +16,7 @@ contract Comptroller_Fork_Test is Base_Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     BaseScriptMock internal baseScript;
+    address internal currentMainnetAdmin;
     address[] internal protocolAddresses;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -25,6 +26,9 @@ contract Comptroller_Fork_Test is Base_Test {
     function setUp() public override {
         // Fork Ethereum Mainnet at the latest block number.
         vm.createSelectFork({ urlOrAlias: "ethereum" });
+
+        // Set the current mainnet admin address.
+        currentMainnetAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
 
         // Deploy the `BaseScriptMock` contract.
         baseScript = new BaseScriptMock();
@@ -38,7 +42,7 @@ contract Comptroller_Fork_Test is Base_Test {
         protocolAddresses[1] = 0x7a86d3e6894f9c5B5f25FFBDAaE658CFc7569623;
 
         // Set comptroller admin as the caller.
-        setMsgSender(baseScript.getAdmin());
+        setMsgSender(currentMainnetAdmin);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -64,7 +68,7 @@ contract Comptroller_Fork_Test is Base_Test {
     /// @dev It tests the state variables that will rarely be changed.
     function testFork_Constructor() external view {
         // Assert the comptroller admin.
-        assertEq(comptroller.admin(), baseScript.getAdmin(), "admin");
+        assertEq(comptroller.admin(), currentMainnetAdmin, "admin");
 
         // Assert the max fee in usd.
         assertEq(comptroller.MAX_FEE_USD(), MAX_FEE_USD, "max fee USD");
@@ -76,7 +80,7 @@ contract Comptroller_Fork_Test is Base_Test {
     /// @dev It should use `execute` function to change the comptroller on the protocol contracts.
     function testFork_Execute() external {
         // Deploy a new comptroller.
-        SablierComptroller newComptroller = new SablierComptroller(admin);
+        SablierComptroller newComptroller = new SablierComptroller(currentMainnetAdmin);
 
         bytes memory payload = abi.encodeCall(IComptrollerable.setComptroller, (newComptroller));
 

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -120,10 +120,10 @@ contract Comptroller_Fork_Test is Base_Test {
         assertEq(comptroller.getMinFeeUSD(protocol), newMinFeeUSD, "min fee USD");
     }
 
-    /// @dev It should transfer fees from Comptroller, Lockup and Flow to the provided fee recipient.
+    /// @dev It should transfer fees from Lockup and Flow to the provided fee recipient.
     function testForkFuzz_TransferFees(address feeRecipient) external whenFeeRecipientNotZero {
-        // Skip if fee recipient is zero address.
-        vm.assume(feeRecipient != address(0));
+        // Skip if fee recipient is zero address, or a contract that cannot receive ETH.
+        vm.assume(feeRecipient != address(0) && feeRecipient.code.length == 0);
 
         uint256 initialFeeRecipientBalance = feeRecipient.balance;
 

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -86,11 +86,11 @@ contract Comptroller_Fork_Test is Base_Test {
             vm.expectEmit({ emitter: address(comptroller) });
             emit ISablierComptroller.Execute({
                 target: protocolAddresses[i],
-                data: abi.encodeCall(IComptrollerable.setComptroller, (newComptroller)),
+                targetCallData: abi.encodeCall(IComptrollerable.setComptroller, (newComptroller)),
                 result: ""
             });
 
-            comptroller.execute({ target: protocolAddresses[i], data: payload });
+            comptroller.execute({ target: protocolAddresses[i], targetCallData: payload });
 
             // It should change the comptroller.
             assertEq(

--- a/utils/tests/integration/fuzz/base-script/BaseScript.t.sol
+++ b/utils/tests/integration/fuzz/base-script/BaseScript.t.sol
@@ -4,10 +4,8 @@ pragma solidity >=0.8.22;
 import { StdAssertions } from "forge-std/src/StdAssertions.sol";
 import { StdConstants, Vm } from "forge-std/src/StdConstants.sol";
 
-import { BaseScript } from "src/tests/BaseScript.sol";
 import { ChainId } from "src/tests/ChainId.sol";
-
-contract BaseScriptMock is BaseScript { }
+import { BaseScriptMock } from "tests/mocks/BaseScriptMock.sol";
 
 contract BaseScript_Fuzz_Test is StdAssertions {
     BaseScriptMock internal baseScript;

--- a/utils/tests/mocks/BaseScriptMock.sol
+++ b/utils/tests/mocks/BaseScriptMock.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { BaseScript } from "src/tests/BaseScript.sol";
+
+contract BaseScriptMock is BaseScript { }


### PR DESCRIPTION
Closes https://github.com/sablier-labs/evm-utils/issues/56

After this PR is merged, I will commit the same tests to [evm-utils](https://github.com/sablier-labs/evm-utils) repo since it would be a good idea to include Comptroller fork tests in weekly CIs.