### PR TITLE
chore: Fix mathematical formula notation in LL stream documentation

### DIFF
--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -127,7 +127,7 @@ library LockupMath {
     /// $$
     ///        ( x * sa + s, block timestamp < cliff time
     /// f(x) = (
-    ///        ( x * sa + s + c, block timestamp => cliff time
+    ///        ( x * sa + s + c, block timestamp >= cliff time
     /// $$
     ///
     /// Where:


### PR DESCRIPTION
 change "=>" to ">=" for proper inequality representation