### PR TITLE
fix: don't use PRB math in LL calculation

### DIFF
--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -215,7 +215,8 @@ library LockupMath {
             uint256 streamableAmount = depositedAmount - unlockAmountsSum;
 
             // Scaled numerator: floor(elapsed/g) * streamableAmount * g * 1e18.
-            uint256 streamedPortionScaled = elapsedTimeInGranularityUnits * streamableAmount * uint256(granularity) * 1e18;
+            uint256 streamedPortionScaled =
+                elapsedTimeInGranularityUnits * streamableAmount * uint256(granularity) * 1e18;
 
             // Unlock amounts plus the streamed portion.
             uint128 streamedAmount =

--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.22;
 
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { PRBMathCastingUint128 as CastingUint128 } from "@prb/math/src/casting/Uint128.sol";
 import { PRBMathCastingUint40 as CastingUint40 } from "@prb/math/src/casting/Uint40.sol";
 import { SD59x18 } from "@prb/math/src/SD59x18.sol";
-
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { LockupDynamic } from "../types/LockupDynamic.sol";
 import { LockupLinear } from "../types/LockupLinear.sol";

--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -141,9 +141,9 @@ library LockupMath {
     /// $$
     ///
     ///     ⌊time elapsed / granularity⌋ * granularity
-    /// x =
-    /// ───────────────────────────────────────────
+    /// x = －－－－－－－－－－－－－－－－－－－－－－－－－
     ///                streamable time
+    ///
     /// $$
     ///
     /// The floor division in the numerator creates discrete unlock steps at every granularity seconds.
@@ -199,27 +199,26 @@ library LockupMath {
             // granularity.
             uint256 elapsedTimeInGranularityUnits;
 
-            // Calculate the streamable period scaled.
-            uint256 streamableTotalDurationScaled;
+            // Calculate the streamable duration.
+            uint256 streamableTotalDuration;
 
             if (cliffTime == 0) {
                 elapsedTimeInGranularityUnits = (blockTimestamp - startTime) / granularity;
-                streamableTotalDurationScaled = uint256(endTime - startTime) * 1e18;
+                streamableTotalDuration = uint256(endTime - startTime);
             } else {
                 elapsedTimeInGranularityUnits = (blockTimestamp - cliffTime) / granularity;
-                streamableTotalDurationScaled = uint256(endTime - cliffTime) * 1e18;
+                streamableTotalDuration = uint256(endTime - cliffTime);
             }
 
             // Calculate the streamable amount.
             uint256 streamableAmount = depositedAmount - unlockAmountsSum;
 
-            // Scaled numerator: floor(elapsed/g) * streamableAmount * g * 1e18.
-            uint256 streamedPortionScaled =
-                elapsedTimeInGranularityUnits * streamableAmount * uint256(granularity) * 1e18;
+            // Calculate the streamed portion: floor(elapsed/g) * streamableAmount * g / streamableTotalDuration.
+            uint256 streamedPortion =
+                elapsedTimeInGranularityUnits * streamableAmount * uint256(granularity) / streamableTotalDuration;
 
-            // Unlock amounts plus the streamed portion.
-            uint128 streamedAmount =
-                unlockAmountsSum + SafeCast.toUint128(streamedPortionScaled / streamableTotalDurationScaled);
+            // The streamed amount is the sum of the unlock amounts plus the streamed portion.
+            uint128 streamedAmount = unlockAmountsSum + SafeCast.toUint128(streamedPortion);
 
             // Although the streamed amount should never exceed the deposited amount, this condition is checked
             // without asserting to avoid locking tokens in case of a bug. If this situation occurs, the withdrawn

--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.22;
 
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { PRBMathCastingUint128 as CastingUint128 } from "@prb/math/src/casting/Uint128.sol";
 import { PRBMathCastingUint40 as CastingUint40 } from "@prb/math/src/casting/Uint40.sol";
 import { SD59x18 } from "@prb/math/src/SD59x18.sol";
@@ -217,8 +216,9 @@ library LockupMath {
             uint256 streamedPortion =
                 elapsedTimeInGranularityUnits * streamableAmount * uint256(granularity) / streamableTotalDuration;
 
-            // The streamed amount is the sum of the unlock amounts plus the streamed portion.
-            uint128 streamedAmount = unlockAmountsSum + SafeCast.toUint128(streamedPortion);
+            // The streamed amount is the sum of the unlock amounts plus the streamed portion. The cast to uint128 is
+            // safe because `floor(elapsed/g) * g < streamableTotalDuration`, so `streamedPortion < streamableAmount`.
+            uint128 streamedAmount = unlockAmountsSum + uint128(streamedPortion);
 
             // Although the streamed amount should never exceed the deposited amount, this condition is checked
             // without asserting to avoid locking tokens in case of a bug. If this situation occurs, the withdrawn

--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -4,7 +4,8 @@ pragma solidity >=0.8.22;
 import { PRBMathCastingUint128 as CastingUint128 } from "@prb/math/src/casting/Uint128.sol";
 import { PRBMathCastingUint40 as CastingUint40 } from "@prb/math/src/casting/Uint40.sol";
 import { SD59x18 } from "@prb/math/src/SD59x18.sol";
-import { convert as toScaledUD60x18, UD60x18, ud } from "@prb/math/src/UD60x18.sol";
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { LockupDynamic } from "../types/LockupDynamic.sol";
 import { LockupLinear } from "../types/LockupLinear.sol";
@@ -139,9 +140,11 @@ library LockupMath {
     /// - $x$ is the elapsed time percentage with discrete unlocks:
     ///
     /// $$
-    ///        ⌊time elapsed / granularity⌋
-    /// x = ────────────────────────────────────
-    ///       streamable time / granularity
+    ///
+    ///     ⌊time elapsed / granularity⌋ * granularity
+    /// x =
+    /// ───────────────────────────────────────────
+    ///                streamable time
     /// $$
     ///
     /// The floor division in the numerator creates discrete unlock steps at every granularity seconds.
@@ -195,30 +198,28 @@ library LockupMath {
 
             // Calculate the time elapsed in granularity units as the floor division of time elapsed and unlock
             // granularity.
-            UD60x18 elapsedTimeInGranularityUnits;
+            uint256 elapsedTimeInGranularityUnits;
 
-            // Calculate the streamable period in granularity units as exact division of streamable period and
-            // granularity.
-            UD60x18 streamablePeriodInGranularityUnits;
+            // Calculate the streamable period scaled.
+            uint256 streamableTotalDurationScaled;
 
-            // The time elapsed in granularity units is scaled to 1e18 to match the scale of the streamable time
-            // in granularity units.
             if (cliffTime == 0) {
-                elapsedTimeInGranularityUnits = toScaledUD60x18((blockTimestamp - startTime) / granularity);
-                streamablePeriodInGranularityUnits = ud(endTime - startTime).div(ud(granularity));
+                elapsedTimeInGranularityUnits = (blockTimestamp - startTime) / granularity;
+                streamableTotalDurationScaled = uint256(endTime - startTime) * 1e18;
             } else {
-                elapsedTimeInGranularityUnits = toScaledUD60x18((blockTimestamp - cliffTime) / granularity);
-                streamablePeriodInGranularityUnits = ud(endTime - cliffTime).div(ud(granularity));
+                elapsedTimeInGranularityUnits = (blockTimestamp - cliffTime) / granularity;
+                streamableTotalDurationScaled = uint256(endTime - cliffTime) * 1e18;
             }
 
             // Calculate the streamable amount.
-            UD60x18 streamableAmount = ud(depositedAmount - unlockAmountsSum);
+            uint256 streamableAmount = depositedAmount - unlockAmountsSum;
 
-            // The streamed amount is the sum of the unlock amounts plus the product of elapsed time percentage and the
-            // streamable amount.
-            uint128 streamedAmount = unlockAmountsSum
-                + elapsedTimeInGranularityUnits.mul(streamableAmount).div(streamablePeriodInGranularityUnits)
-                    .intoUint128();
+            // Scaled numerator: floor(elapsed/g) * streamableAmount * g * 1e18.
+            uint256 streamedPortionScaled = elapsedTimeInGranularityUnits * streamableAmount * granularity * 1e18;
+
+            // Unlock amounts plus the streamed portion.
+            uint128 streamedAmount =
+                unlockAmountsSum + SafeCast.toUint128(streamedPortionScaled / streamableTotalDurationScaled);
 
             // Although the streamed amount should never exceed the deposited amount, this condition is checked
             // without asserting to avoid locking tokens in case of a bug. If this situation occurs, the withdrawn

--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -214,7 +214,7 @@ library LockupMath {
 
             // Calculate the streamed portion: floor(elapsed/g) * streamableAmount * g / streamableTotalDuration.
             uint256 streamedPortion =
-                elapsedTimeInGranularityUnits * streamableAmount * uint256(granularity) / streamableTotalDuration;
+                elapsedTimeInGranularityUnits * streamableAmount * granularity / streamableTotalDuration;
 
             // The streamed amount is the sum of the unlock amounts plus the streamed portion. The cast to uint128 is
             // safe because `floor(elapsed/g) * g < streamableTotalDuration`, so `streamedPortion < streamableAmount`.

--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -215,7 +215,7 @@ library LockupMath {
             uint256 streamableAmount = depositedAmount - unlockAmountsSum;
 
             // Scaled numerator: floor(elapsed/g) * streamableAmount * g * 1e18.
-            uint256 streamedPortionScaled = elapsedTimeInGranularityUnits * streamableAmount * granularity * 1e18;
+            uint256 streamedPortionScaled = elapsedTimeInGranularityUnits * streamableAmount * uint256(granularity) * 1e18;
 
             // Unlock amounts plus the streamed portion.
             uint128 streamedAmount =

--- a/lockup/tests/utils/Calculations.sol
+++ b/lockup/tests/utils/Calculations.sol
@@ -34,35 +34,33 @@ abstract contract Calculations is BaseUtils {
             return depositAmount;
         }
 
-        unchecked {
-            uint128 previousSegmentAmounts;
-            uint40 currentSegmentTimestamp = segments[0].timestamp;
-            uint256 index = 0;
-            while (currentSegmentTimestamp < blockTimestamp) {
-                previousSegmentAmounts += segments[index].amount;
-                index += 1;
-                currentSegmentTimestamp = segments[index].timestamp;
-            }
-
-            SD59x18 currentSegmentAmount = segments[index].amount.intoSD59x18();
-            SD59x18 currentSegmentExponent = segments[index].exponent.intoSD59x18();
+        uint128 previousSegmentAmounts;
+        uint40 currentSegmentTimestamp = segments[0].timestamp;
+        uint256 index = 0;
+        while (currentSegmentTimestamp < blockTimestamp) {
+            previousSegmentAmounts += segments[index].amount;
+            index += 1;
             currentSegmentTimestamp = segments[index].timestamp;
-
-            uint40 previousTimestamp;
-            if (index > 0) {
-                previousTimestamp = segments[index - 1].timestamp;
-            } else {
-                previousTimestamp = startTime;
-            }
-
-            SD59x18 elapsedTime = (blockTimestamp - previousTimestamp).intoSD59x18();
-            SD59x18 segmentDuration = (currentSegmentTimestamp - previousTimestamp).intoSD59x18();
-
-            SD59x18 elapsedTimePercentage = elapsedTime.div(segmentDuration);
-            SD59x18 multiplier = elapsedTimePercentage.pow(currentSegmentExponent);
-            SD59x18 segmentStreamedAmount = multiplier.mul(currentSegmentAmount);
-            return previousSegmentAmounts + uint128(segmentStreamedAmount.intoUint256());
         }
+
+        SD59x18 currentSegmentAmount = segments[index].amount.intoSD59x18();
+        SD59x18 currentSegmentExponent = segments[index].exponent.intoSD59x18();
+        currentSegmentTimestamp = segments[index].timestamp;
+
+        uint40 previousTimestamp;
+        if (index > 0) {
+            previousTimestamp = segments[index - 1].timestamp;
+        } else {
+            previousTimestamp = startTime;
+        }
+
+        SD59x18 elapsedTime = (blockTimestamp - previousTimestamp).intoSD59x18();
+        SD59x18 segmentDuration = (currentSegmentTimestamp - previousTimestamp).intoSD59x18();
+
+        SD59x18 elapsedTimePercentage = elapsedTime.div(segmentDuration);
+        SD59x18 multiplier = elapsedTimePercentage.pow(currentSegmentExponent);
+        SD59x18 segmentStreamedAmount = multiplier.mul(currentSegmentAmount);
+        return previousSegmentAmounts + uint128(segmentStreamedAmount.intoUint256());
     }
 
     /// @dev Replicates the logic of {LockupMath._calculateStreamedAmountLL}.
@@ -72,7 +70,7 @@ abstract contract Calculations is BaseUtils {
         uint40 endTime,
         uint128 depositAmount,
         LockupLinear.UnlockAmounts memory unlockAmounts,
-        uint40 granularity
+        uint256 granularity
     )
         internal
         view
@@ -95,29 +93,28 @@ abstract contract Calculations is BaseUtils {
             return depositAmount;
         }
 
-        unchecked {
-            uint128 unlockAmountsSum = unlockAmounts.start + unlockAmounts.cliff;
-            if (unlockAmountsSum >= depositAmount) {
-                return depositAmount;
-            }
-
-            // Determine the reference time (cliff or start).
-            uint40 referenceTime = cliffTime > 0 ? cliffTime : startTime;
-
-            // Calculate elapsed granularity units (floored).
-            uint256 elapsedTimeInGranularityUnits = (blockTimestamp - referenceTime) / granularity;
-
-            // Calculate the streamable period scaled. Cast to uint256 to avoid overflow.
-            uint256 streamableTotalDurationScaled = uint256(endTime - referenceTime) * 1e18;
-
-            // Calculate the streamable amount.
-            uint256 streamableAmount = depositAmount - unlockAmountsSum;
-
-            // Formula: streamedPortion = floor(elapsed/g) * streamableAmount * g / totalDuration
-            uint256 streamedPortionScaled = elapsedTimeInGranularityUnits * streamableAmount * granularity * 1e18;
-
-            return unlockAmountsSum + uint128(streamedPortionScaled / streamableTotalDurationScaled);
+        uint128 unlockAmountsSum = unlockAmounts.start + unlockAmounts.cliff;
+        if (unlockAmountsSum >= depositAmount) {
+            return depositAmount;
         }
+
+        // Determine the reference time (cliff or start).
+        uint40 referenceTime = cliffTime > 0 ? cliffTime : startTime;
+
+        // Calculate elapsed granularity units (floored).
+        uint256 elapsedTimeInGranularityUnits = (blockTimestamp - referenceTime) / granularity;
+
+        // Calculate the streamable period scaled. Cast to uint256 to avoid overflow.
+        uint256 streamableTotalDuration = uint256(endTime - referenceTime);
+
+        // Calculate the streamable amount.
+        uint256 streamableAmount = depositAmount - unlockAmountsSum;
+
+        // Formula: streamedPortion = floor(elapsed/g) * streamableAmount * g / totalDuration
+        uint256 streamedPortionScaled =
+            (elapsedTimeInGranularityUnits * streamableAmount * granularity) / streamableTotalDuration;
+
+        return unlockAmountsSum + uint128(streamedPortionScaled);
     }
 
     /// @dev Replicates the logic of {LockupMath._calculateStreamedAmountLT}.
@@ -144,12 +141,10 @@ abstract contract Calculations is BaseUtils {
         uint256 index = 1;
 
         // Using unchecked arithmetic is safe because the tranches amounts sum equal to total amount at this point.
-        unchecked {
-            while (currentTrancheTimestamp <= blockTimestamp) {
-                streamedAmount += tranches[index].amount;
-                index += 1;
-                currentTrancheTimestamp = tranches[index].timestamp;
-            }
+        while (currentTrancheTimestamp <= blockTimestamp) {
+            streamedAmount += tranches[index].amount;
+            index += 1;
+            currentTrancheTimestamp = tranches[index].timestamp;
         }
 
         return streamedAmount;


### PR DESCRIPTION
as a consequence of the invariant failing: https://github.com/sablier-labs/lockup/actions/runs/21181095875/job/60923599405?pr=1370

the prb math alternative (may be it can be simplified) i managed to make work is:

<details><summary>click to see it</summary>
<p>


```solidity
// Determine the reference time (cliff or start).
uint40 referenceTime = cliffTime == 0 ? startTime : cliffTime;

// Calculate elapsed granularity units (floored) and scale to UD60x18.
UD60x18 elapsedGranularityUnits = convert((blockTimestamp - referenceTime) / granularity);

UD60x18 streamableAmount = ud(depositedAmount - unlockAmountsSum);
UD60x18 scaledGranularity = convert(granularity);
UD60x18 scaledTotalDuration = convert(endTime - referenceTime);

UD60x18 streamedPortion =
    elapsedGranularityUnits.mul(streamableAmount).mul(scaledGranularity).div(scaledTotalDuration);

// The streamed amount is the sum of the unlock amounts plus the streamed portion.
uint128 streamedAmount = unlockAmountsSum + streamedPortion.intoUint128();

```

</p>
</details> 

which has significantly more math operations. i’d now be in favor of keeping native types in ll, though there would be no consistency between models