### PR TITLE
feat(utils): add version constant to comptroller

### DIFF
--- a/utils/src/SablierComptroller.sol
+++ b/utils/src/SablierComptroller.sol
@@ -52,6 +52,9 @@ contract SablierComptroller is
         ^ this.execute.selector ^ this.getMinFeeUSDFor.selector;
 
     /// @inheritdoc ISablierComptroller
+    string public constant VERSION = "v1.1";
+
+    /// @inheritdoc ISablierComptroller
     address public override oracle;
 
     /// @dev A mapping of protocol fees.

--- a/utils/src/interfaces/ISablierComptroller.sol
+++ b/utils/src/interfaces/ISablierComptroller.sol
@@ -79,6 +79,10 @@ interface ISablierComptroller is IERC165, IERC1822Proxiable, IRoleAdminable {
     /// 4. {getMinFeeUSDFor}       - used by protocols inherited from {IComptrollerable}.
     function MINIMAL_INTERFACE_ID() external view returns (bytes4);
 
+    /// @notice The version of the comptroller contract.
+    /// @dev This follows the format "v{Major}.{Minor}" (e.g., "v1.1").
+    function VERSION() external view returns (string memory);
+
     /// @notice Calculates the minimum fee in wei for the given protocol.
     /// @dev See the documentation for {convertUSDFeeToWei} for more details.
     /// @param protocol The protocol as defined in {Protocol} enum.

--- a/utils/tests/integration/concrete/comptroller/constructor.t.sol
+++ b/utils/tests/integration/concrete/comptroller/constructor.t.sol
@@ -14,5 +14,6 @@ contract Constructor_Comptroller_Concrete_Test is Base_Test {
             ^ ISablierComptroller.getMinFeeUSDFor.selector;
         assertEq(comptroller.MINIMAL_INTERFACE_ID(), expectedMinimalInterfaceId, "minimal interface ID");
         assertEq(comptroller.oracle(), address(oracle), "oracle");
+        assertEq(comptroller.VERSION(), "v1.1", "version");
     }
 }


### PR DESCRIPTION
Closes #1382

Adds `VERSION` constant ("v1.1") to `SablierComptroller`.

Uses `constant` (not `immutable`) so value is inlined at compile time—no storage slot used, proxy-safe.