### PR TITLE
feat(airdrops): claim via attestation

### DIFF
--- a/airdrops/src/SablierMerkleExecute.sol
+++ b/airdrops/src/SablierMerkleExecute.sol
@@ -7,7 +7,7 @@ import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.s
 
 import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { ISablierMerkleExecute } from "./interfaces/ISablierMerkleExecute.sol";
-import { MerkleExecute } from "./types/DataTypes.sol";
+import { MerkleBase, MerkleExecute } from "./types/DataTypes.sol";
 
 /*
 
@@ -56,17 +56,17 @@ contract SablierMerkleExecute is
         address campaignCreator,
         address comptroller
     )
-        SablierMerkleBase(
-            campaignCreator,
-            campaignParams.campaignName,
-            campaignParams.campaignStartTime,
-            comptroller,
-            campaignParams.expiration,
-            campaignParams.initialAdmin,
-            campaignParams.ipfsCID,
-            campaignParams.merkleRoot,
-            campaignParams.token
-        )
+        SablierMerkleBase(MerkleBase.ConstructorParams({
+                campaignCreator: campaignCreator,
+                campaignName: campaignParams.campaignName,
+                campaignStartTime: campaignParams.campaignStartTime,
+                comptroller: comptroller,
+                expiration: campaignParams.expiration,
+                initialAdmin: campaignParams.initialAdmin,
+                ipfsCID: campaignParams.ipfsCID,
+                merkleRoot: campaignParams.merkleRoot,
+                token: campaignParams.token
+            }))
     {
         // Effect: set the immutable state variables.
         SELECTOR = campaignParams.selector;

--- a/airdrops/src/SablierMerkleInstant.sol
+++ b/airdrops/src/SablierMerkleInstant.sol
@@ -56,7 +56,6 @@ contract SablierMerkleInstant is
                 merkleRoot: campaignParams.merkleRoot,
                 token: campaignParams.token
             }))
-        SablierMerkleSignature()
     { }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/airdrops/src/SablierMerkleLL.sol
+++ b/airdrops/src/SablierMerkleLL.sol
@@ -89,7 +89,6 @@ contract SablierMerkleLL is
                 shape: campaignParams.shape,
                 transferable: campaignParams.transferable
             }))
-        SablierMerkleSignature()
     {
         // Effect: set the immutable variables.
         VESTING_CLIFF_DURATION = campaignParams.cliffDuration;

--- a/airdrops/src/SablierMerkleLL.sol
+++ b/airdrops/src/SablierMerkleLL.sol
@@ -6,9 +6,11 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ud60x18, UD60x18 } from "@prb/math/src/UD60x18.sol";
 import { Lockup, LockupLinear } from "@sablier/lockup/src/types/DataTypes.sol";
 
+import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { SablierMerkleLockup } from "./abstracts/SablierMerkleLockup.sol";
+import { SablierMerkleSignature } from "./abstracts/SablierMerkleSignature.sol";
 import { ISablierMerkleLL } from "./interfaces/ISablierMerkleLL.sol";
-import { MerkleLL } from "./types/DataTypes.sol";
+import { MerkleBase, MerkleLL, MerkleLockup } from "./types/DataTypes.sol";
 
 /*
 
@@ -31,7 +33,8 @@ import { MerkleLL } from "./types/DataTypes.sol";
 /// @title SablierMerkleLL
 /// @notice See the documentation in {ISablierMerkleLL}.
 contract SablierMerkleLL is
-    ISablierMerkleLL, // 3 inherited components
+    ISablierMerkleLL, // 4 inherited components
+    SablierMerkleSignature, // 5 inherited components
     SablierMerkleLockup // 5 inherited components
 {
     using SafeERC20 for IERC20;
@@ -69,21 +72,24 @@ contract SablierMerkleLL is
         address campaignCreator,
         address comptroller
     )
-        SablierMerkleLockup(
-            campaignCreator,
-            campaignParams.campaignName,
-            campaignParams.campaignStartTime,
-            campaignParams.cancelable,
-            comptroller,
-            campaignParams.lockup,
-            campaignParams.expiration,
-            campaignParams.initialAdmin,
-            campaignParams.ipfsCID,
-            campaignParams.merkleRoot,
-            campaignParams.shape,
-            campaignParams.token,
-            campaignParams.transferable
-        )
+        SablierMerkleBase(MerkleBase.ConstructorParams({
+                campaignCreator: campaignCreator,
+                campaignName: campaignParams.campaignName,
+                campaignStartTime: campaignParams.campaignStartTime,
+                comptroller: comptroller,
+                expiration: campaignParams.expiration,
+                initialAdmin: campaignParams.initialAdmin,
+                ipfsCID: campaignParams.ipfsCID,
+                merkleRoot: campaignParams.merkleRoot,
+                token: campaignParams.token
+            }))
+        SablierMerkleLockup(MerkleLockup.ConstructorParams({
+                cancelable: campaignParams.cancelable,
+                lockup: campaignParams.lockup,
+                shape: campaignParams.shape,
+                transferable: campaignParams.transferable
+            }))
+        SablierMerkleSignature()
     {
         // Effect: set the immutable variables.
         VESTING_CLIFF_DURATION = campaignParams.cliffDuration;
@@ -136,6 +142,29 @@ contract SablierMerkleLL is
     }
 
     /// @inheritdoc ISablierMerkleLL
+    function claimViaAttestation(
+        uint256 index,
+        address to,
+        uint128 amount,
+        bytes32[] calldata merkleProof,
+        bytes calldata attestation
+    )
+        external
+        payable
+        override
+        notZeroAddress(to)
+    {
+        // Check: the attestation signature is valid and the recovered signer matches the attestor.
+        _verifyAttestationSignature(msg.sender, attestation);
+
+        // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
+        _preProcessClaim({ index: index, recipient: msg.sender, amount: amount, merkleProof: merkleProof });
+
+        // Effect and Interaction: Post-process the claim parameters on behalf of `msg.sender`.
+        _postProcessClaim({ index: index, recipient: msg.sender, to: to, amount: amount, viaSig: false });
+    }
+
+    /// @inheritdoc ISablierMerkleLL
     function claimViaSig(
         uint256 index,
         address recipient,
@@ -151,7 +180,7 @@ contract SablierMerkleLL is
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.
-        _checkSignature(index, recipient, to, amount, validFrom, signature);
+        _verifyClaimSignature(index, recipient, to, amount, validFrom, signature);
 
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);

--- a/airdrops/src/SablierMerkleLT.sol
+++ b/airdrops/src/SablierMerkleLT.sol
@@ -77,7 +77,6 @@ contract SablierMerkleLT is
                 shape: campaignParams.shape,
                 transferable: campaignParams.transferable
             }))
-        SablierMerkleSignature()
     {
         VESTING_START_TIME = campaignParams.vestingStartTime;
 

--- a/airdrops/src/SablierMerkleVCA.sol
+++ b/airdrops/src/SablierMerkleVCA.sol
@@ -7,9 +7,10 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { ud, UD60x18 } from "@prb/math/src/UD60x18.sol";
 
 import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
+import { SablierMerkleSignature } from "./abstracts/SablierMerkleSignature.sol";
 import { ISablierMerkleVCA } from "./interfaces/ISablierMerkleVCA.sol";
 import { Errors } from "./libraries/Errors.sol";
-import { MerkleVCA } from "./types/DataTypes.sol";
+import { MerkleBase, MerkleVCA } from "./types/DataTypes.sol";
 
 /*
 
@@ -32,8 +33,8 @@ import { MerkleVCA } from "./types/DataTypes.sol";
 /// @title SablierMerkleVCA
 /// @notice See the documentation in {ISablierMerkleVCA}.
 contract SablierMerkleVCA is
-    ISablierMerkleVCA, // 2 inherited components
-    SablierMerkleBase // 3 inherited components
+    ISablierMerkleVCA, // 3 inherited components
+    SablierMerkleSignature // 5 inherited components
 {
     using SafeCast for uint256;
     using SafeERC20 for IERC20;
@@ -73,17 +74,18 @@ contract SablierMerkleVCA is
         address campaignCreator,
         address comptroller
     )
-        SablierMerkleBase(
-            campaignCreator,
-            campaignParams.campaignName,
-            campaignParams.campaignStartTime,
-            comptroller,
-            campaignParams.expiration,
-            campaignParams.initialAdmin,
-            campaignParams.ipfsCID,
-            campaignParams.merkleRoot,
-            campaignParams.token
-        )
+        SablierMerkleBase(MerkleBase.ConstructorParams({
+                campaignCreator: campaignCreator,
+                campaignName: campaignParams.campaignName,
+                campaignStartTime: campaignParams.campaignStartTime,
+                comptroller: comptroller,
+                expiration: campaignParams.expiration,
+                initialAdmin: campaignParams.initialAdmin,
+                ipfsCID: campaignParams.ipfsCID,
+                merkleRoot: campaignParams.merkleRoot,
+                token: campaignParams.token
+            }))
+        SablierMerkleSignature()
     {
         // Effect: set the immutable variables.
         AGGREGATE_AMOUNT = campaignParams.aggregateAmount;
@@ -163,6 +165,29 @@ contract SablierMerkleVCA is
     }
 
     /// @inheritdoc ISablierMerkleVCA
+    function claimViaAttestation(
+        uint256 index,
+        address to,
+        uint128 fullAmount,
+        bytes32[] calldata merkleProof,
+        bytes calldata attestation
+    )
+        external
+        payable
+        override
+        notZeroAddress(to)
+    {
+        // Check: the attestation signature is valid and the recovered signer matches the attestor.
+        _verifyAttestationSignature(msg.sender, attestation);
+
+        // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
+        _preProcessClaim({ index: index, recipient: msg.sender, amount: fullAmount, merkleProof: merkleProof });
+
+        // Check, Effect and Interaction: Post-process the claim parameters on behalf of `msg.sender`.
+        _postProcessClaim({ index: index, recipient: msg.sender, to: to, fullAmount: fullAmount, viaSig: false });
+    }
+
+    /// @inheritdoc ISablierMerkleVCA
     function claimViaSig(
         uint256 index,
         address recipient,
@@ -178,7 +203,7 @@ contract SablierMerkleVCA is
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.
-        _checkSignature(index, recipient, to, fullAmount, validFrom, signature);
+        _verifyClaimSignature(index, recipient, to, fullAmount, validFrom, signature);
 
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, fullAmount, merkleProof);

--- a/airdrops/src/SablierMerkleVCA.sol
+++ b/airdrops/src/SablierMerkleVCA.sol
@@ -85,7 +85,6 @@ contract SablierMerkleVCA is
                 merkleRoot: campaignParams.merkleRoot,
                 token: campaignParams.token
             }))
-        SablierMerkleSignature()
     {
         // Effect: set the immutable variables.
         AGGREGATE_AMOUNT = campaignParams.aggregateAmount;

--- a/airdrops/src/abstracts/SablierMerkleBase.sol
+++ b/airdrops/src/abstracts/SablierMerkleBase.sol
@@ -83,7 +83,7 @@ abstract contract SablierMerkleBase is
 
         campaignName = baseParams.campaignName;
         ipfsCID = baseParams.ipfsCID;
-        minFeeUSD = ISablierComptroller(COMPTROLLER)
+        minFeeUSD = ISablierComptroller(baseParams.comptroller)
             .getMinFeeUSDFor({ protocol: ISablierComptroller.Protocol.Airdrops, user: baseParams.campaignCreator });
     }
 

--- a/airdrops/src/abstracts/SablierMerkleLockup.sol
+++ b/airdrops/src/abstracts/SablierMerkleLockup.sol
@@ -5,13 +5,14 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 
-import { ISablierMerkleLockup } from "../interfaces/ISablierMerkleLL.sol";
+import { ISablierMerkleLockup } from "../interfaces/ISablierMerkleLockup.sol";
+import { MerkleLockup } from "../types/DataTypes.sol";
 import { SablierMerkleBase } from "./SablierMerkleBase.sol";
 
 /// @title SablierMerkleLockup
 /// @notice See the documentation in {ISablierMerkleLockup}.
 abstract contract SablierMerkleLockup is
-    ISablierMerkleLockup, // 2 inherited components,
+    ISablierMerkleLockup, // 2 inherited components
     SablierMerkleBase // 3 inherited components
 {
     using SafeERC20 for IERC20;
@@ -40,37 +41,11 @@ abstract contract SablierMerkleLockup is
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @dev Constructs the contract by initializing the immutable state vars, and max approving the Lockup contract.
-    constructor(
-        address campaignCreator,
-        string memory campaignName,
-        uint40 campaignStartTime,
-        bool cancelable,
-        address comptroller,
-        ISablierLockup sablierLockup,
-        uint40 expiration,
-        address initialAdmin,
-        string memory ipfsCID,
-        bytes32 merkleRoot,
-        string memory shape_,
-        IERC20 token,
-        bool transferable
-    )
-        SablierMerkleBase(
-            campaignCreator,
-            campaignName,
-            campaignStartTime,
-            comptroller,
-            expiration,
-            initialAdmin,
-            ipfsCID,
-            merkleRoot,
-            token
-        )
-    {
-        SABLIER_LOCKUP = sablierLockup;
-        streamShape = shape_;
-        STREAM_CANCELABLE = cancelable;
-        STREAM_TRANSFERABLE = transferable;
+    constructor(MerkleLockup.ConstructorParams memory lockupParams) {
+        SABLIER_LOCKUP = lockupParams.lockup;
+        STREAM_CANCELABLE = lockupParams.cancelable;
+        STREAM_TRANSFERABLE = lockupParams.transferable;
+        streamShape = lockupParams.shape;
 
         // Max approve the Lockup contract to spend funds from the Merkle Lockup campaigns.
         TOKEN.forceApprove({ spender: address(SABLIER_LOCKUP), value: type(uint256).max });

--- a/airdrops/src/abstracts/SablierMerkleSignature.sol
+++ b/airdrops/src/abstracts/SablierMerkleSignature.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.8.22;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import { ISablierComptroller } from "@sablier/evm-utils/src/interfaces/ISablierComptroller.sol";
+
+import { ISablierMerkleSignature } from "./../interfaces/ISablierMerkleSignature.sol";
+import { Errors } from "./../libraries/Errors.sol";
+import { SignatureHash } from "./../libraries/SignatureHash.sol";
+import { SablierMerkleBase } from "./SablierMerkleBase.sol";
+
+/// @title SablierMerkleSignature
+/// @notice See the documentation in {ISablierMerkleSignature}.
+abstract contract SablierMerkleSignature is
+    ISablierMerkleSignature, // 2 inherited components
+    SablierMerkleBase // 3 inherited components
+{
+    /*//////////////////////////////////////////////////////////////////////////
+                                  STATE VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Cache the chain ID in order to invalidate the cached domain separator if the chain ID changes in case of a
+    /// chain split.
+    uint256 private immutable _CACHED_CHAIN_ID;
+
+    /// @dev The domain separator, as required by EIP-712 and EIP-1271, used for signing claim to prevent replay attacks
+    /// across different campaigns.
+    bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
+
+    /// @dev A private variable to store the attestor address if set after the contract is deployed. If zero, the
+    /// attestor is queried from the comptroller.
+    address private _attestor;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Constructs the contract by initializing the immutable state variables.
+    constructor() {
+        // Cache the chain ID.
+        _CACHED_CHAIN_ID = block.chainid;
+
+        // Compute and store the domain separator to be used for claiming using an EIP-712 or EIP-1271 signature.
+        _CACHED_DOMAIN_SEPARATOR = keccak256(
+            abi.encode(SignatureHash.DOMAIN_TYPEHASH, SignatureHash.PROTOCOL_NAME, block.chainid, address(this))
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                          USER-FACING READ-ONLY FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc ISablierMerkleSignature
+    function attestor() external view override returns (address) {
+        return _getAttestor();
+    }
+
+    /// @inheritdoc ISablierMerkleSignature
+    function domainSeparator() external view override returns (bytes32) {
+        return _domainSeparator();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                        USER-FACING STATE-CHANGING FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc ISablierMerkleSignature
+    function setAttestor(address newAttestor) external override {
+        // Check: the caller is the comptroller or the campaign admin.
+        if (msg.sender != admin && msg.sender != COMPTROLLER) {
+            revert Errors.SablierMerkleSignature_CallerNotAuthorized({
+                caller: msg.sender,
+                campaignAdmin: admin,
+                comptroller: COMPTROLLER
+            });
+        }
+
+        //  Get the current attestor.
+        address currentAttestor = _getAttestor();
+
+        // Effect: set the new attestor.
+        _attestor = newAttestor;
+
+        // Log the event.
+        emit SetAttestor({ caller: msg.sender, previousAttestor: currentAttestor, newAttestor: newAttestor });
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            INTERNAL READ-ONLY FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Verifies that the attestation signature created for the recipient is signed by the attestor. It supports
+    /// both EIP-712 and EIP-1271 signatures.
+    function _verifyAttestationSignature(address recipient, bytes calldata signature) internal view {
+        // Get the attestor address.
+        address attestor_ = _getAttestor();
+
+        // Check: the attestor is set.
+        if (attestor_ == address(0)) {
+            revert Errors.SablierMerkleSignature_AttestorNotSet();
+        }
+
+        // Create the struct hash for the identity.
+        bytes32 identityHash = keccak256(abi.encode(SignatureHash.IDENTITY_TYPEHASH, recipient));
+
+        // Verify that the signature is signed by the attestor.
+        _verifySignature({ signer: attestor_, structHash: identityHash, signature: signature });
+    }
+
+    /// @dev Verifies that the claim signature is signed by the recipient. It supports both EIP-712 and EIP-1271
+    /// signatures.
+    function _verifyClaimSignature(
+        uint256 index,
+        address recipient,
+        address to,
+        uint128 amount,
+        uint40 validFrom,
+        bytes calldata signature
+    )
+        internal
+        view
+    {
+        // Encode the parameters using claim type hash and hash it.
+        bytes32 claimHash = keccak256(abi.encode(SignatureHash.CLAIM_TYPEHASH, index, recipient, to, amount, validFrom));
+
+        // Verify that the signature is signed by the recipient.
+        _verifySignature({ signer: recipient, structHash: claimHash, signature: signature });
+
+        // Check: the `validFrom` is less than or equal to the current block timestamp.
+        if (validFrom > uint40(block.timestamp)) {
+            revert Errors.SablierMerkleSignature_SignatureNotYetValid(validFrom, uint40(block.timestamp));
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            PRIVATE READ-ONLY FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Returns the domain separator for the current chain.
+    function _domainSeparator() private view returns (bytes32) {
+        // If the current chain ID is the same as the cached chain ID, return the cached domain separator.
+        if (block.chainid == _CACHED_CHAIN_ID) {
+            return _CACHED_DOMAIN_SEPARATOR;
+        }
+        // Otherwise, compute the domain separator for the current chain ID.
+        else {
+            return keccak256(
+                abi.encode(SignatureHash.DOMAIN_TYPEHASH, SignatureHash.PROTOCOL_NAME, block.chainid, address(this))
+            );
+        }
+    }
+
+    /// @dev Returns the attestor address.
+    function _getAttestor() private view returns (address) {
+        // If the attestor is stored in the contract, return it.
+        if (_attestor != address(0)) {
+            return _attestor;
+        }
+
+        // Otherwise, return it from the comptroller.
+        return ISablierComptroller(COMPTROLLER).attestor();
+    }
+
+    /// @dev Verifies that the EIP-712 or EIP-1271 signature is signed by the expected signer.
+    function _verifySignature(address signer, bytes32 structHash, bytes calldata signature) private view {
+        // Create keccak256 digest of the claim parameters using claim hash and the domain separator.
+        bytes32 digest =
+            MessageHashUtils.toTypedDataHash({ domainSeparator: _domainSeparator(), structHash: structHash });
+
+        // If recipient is an EOA, `isValidSignatureNow` recovers the signer using ECDSA from the signature and the
+        // digest. It returns true if the recovered signer matches the recipient. If the recipient is a contract,
+        // `isValidSignatureNow` checks if the recipient implements the `IERC1271` interface and returns the magic value
+        // as per EIP-1271 for the given digest and signature.
+        bool isSignatureValid =
+            SignatureChecker.isValidSignatureNow({ signer: signer, hash: digest, signature: signature });
+
+        // Check: `isSignatureValid` is true.
+        if (!isSignatureValid) {
+            revert Errors.SablierMerkleSignature_InvalidSignature();
+        }
+    }
+}

--- a/airdrops/src/interfaces/ISablierMerkleBase.sol
+++ b/airdrops/src/interfaces/ISablierMerkleBase.sol
@@ -50,10 +50,6 @@ interface ISablierMerkleBase is IAdminable {
     /// @notice Retrieves the name of the campaign.
     function campaignName() external view returns (string memory);
 
-    /// @notice The domain separator, as required by EIP-712 and EIP-1271, used for signing claim to prevent replay
-    /// attacks across different campaigns.
-    function domainSeparator() external view returns (bytes32);
-
     /// @notice Retrieves the timestamp when the first claim is made, and zero if no claim was made yet.
     function firstClaimTime() external view returns (uint40);
 

--- a/airdrops/src/interfaces/ISablierMerkleInstant.sol
+++ b/airdrops/src/interfaces/ISablierMerkleInstant.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ISablierMerkleBase } from "./ISablierMerkleBase.sol";
+import { ISablierMerkleSignature } from "./ISablierMerkleSignature.sol";
 
 /// @title ISablierMerkleInstant
 /// @notice MerkleInstant enables an airdrop model where eligible users receive the tokens as soon as they claim.
-interface ISablierMerkleInstant is ISablierMerkleBase {
+interface ISablierMerkleInstant is ISablierMerkleSignature {
     /*//////////////////////////////////////////////////////////////////////////
                                        EVENTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -48,6 +48,37 @@ interface ISablierMerkleInstant is ISablierMerkleBase {
     /// @param amount The amount of ERC-20 tokens allocated to the `msg.sender`.
     /// @param merkleProof The proof of inclusion in the Merkle tree.
     function claimTo(uint256 index, address to, uint128 amount, bytes32[] calldata merkleProof) external payable;
+
+    /// @notice Claim airdrop using an external attestation from a trusted attestor (e.g., KYC verifier).
+    ///
+    /// @dev It emits a {ClaimInstant} event.
+    ///
+    /// Notes:
+    /// - The attestation must be an EIP-712 signature from the attestor.
+    /// - See the example in the {claimViaSig} function.
+    /// - If the attestor is not set in the campaign, the attestor from the comptroller is used.
+    ///
+    /// Requirements:
+    /// - `msg.sender` must be the airdrop recipient.
+    /// - The `to` must not be the zero address.
+    /// - The attestor must not be the zero address.
+    /// - The attestation signature must be valid.
+    /// - Refer to the requirements in {claim}.
+    ///
+    /// @param index The index of the `msg.sender` in the Merkle tree.
+    /// @param to The address receiving the ERC-20 tokens on behalf of `msg.sender`.
+    /// @param amount The amount of ERC-20 tokens allocated to the `msg.sender`.
+    /// @param merkleProof The proof of inclusion in the Merkle tree.
+    /// @param attestation The EIP-712 signature from the attestor.
+    function claimViaAttestation(
+        uint256 index,
+        address to,
+        uint128 amount,
+        bytes32[] calldata merkleProof,
+        bytes calldata attestation
+    )
+        external
+        payable;
 
     /// @notice Claim airdrop on behalf of eligible recipient using an EIP-712 or EIP-1271 signature, and transfer the
     /// tokens to the `to` address.

--- a/airdrops/src/interfaces/ISablierMerkleLL.sol
+++ b/airdrops/src/interfaces/ISablierMerkleLL.sol
@@ -4,10 +4,11 @@ pragma solidity >=0.8.22;
 import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
 import { ISablierMerkleLockup } from "./ISablierMerkleLockup.sol";
+import { ISablierMerkleSignature } from "./ISablierMerkleSignature.sol";
 
 /// @title ISablierMerkleLL
 /// @notice MerkleLL enables an airdrop model with a vesting period powered by the Lockup Linear model.
-interface ISablierMerkleLL is ISablierMerkleLockup {
+interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     /*//////////////////////////////////////////////////////////////////////////
                                        EVENTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -89,6 +90,39 @@ interface ISablierMerkleLL is ISablierMerkleLockup {
     /// @param amount The amount of ERC-20 tokens allocated to the `msg.sender`.
     /// @param merkleProof The proof of inclusion in the Merkle tree.
     function claimTo(uint256 index, address to, uint128 amount, bytes32[] calldata merkleProof) external payable;
+
+    /// @notice Claim airdrop using an external attestation from a trusted attestor (e.g., KYC verifier). If the vesting
+    /// end time is in the future, it creates a Lockup Linear stream with `to` address as the stream recipient,
+    /// otherwise it transfers the tokens directly to the `to` address.
+    ///
+    /// @dev It emits either {ClaimLLWithTransfer} or {ClaimLLWithVesting} event.
+    ///
+    /// Notes:
+    /// - The attestation must be an EIP-712 signature from the attestor.
+    /// - See the example in the {claimViaSig} function.
+    /// - If the attestor is not set in the campaign, the attestor from the comptroller is used.
+    ///
+    /// Requirements:
+    /// - `msg.sender` must be the airdrop recipient.
+    /// - The `to` must not be the zero address.
+    /// - The attestor must not be the zero address.
+    /// - The attestation signature must be valid.
+    /// - Refer to the requirements in {claim}.
+    ///
+    /// @param index The index of the `msg.sender` in the Merkle tree.
+    /// @param to The address to which Lockup stream or ERC-20 tokens will be sent on behalf of `msg.sender`.
+    /// @param amount The amount of ERC-20 tokens allocated to the `msg.sender`.
+    /// @param merkleProof The proof of inclusion in the Merkle tree.
+    /// @param attestation The EIP-712 signature from the attestor.
+    function claimViaAttestation(
+        uint256 index,
+        address to,
+        uint128 amount,
+        bytes32[] calldata merkleProof,
+        bytes calldata attestation
+    )
+        external
+        payable;
 
     /// @notice Claim airdrop on behalf of eligible recipient using an EIP-712 or EIP-1271 signature. If the vesting end
     /// time is in the future, it creates a Lockup Linear stream with `to` address as the stream recipient, otherwise it

--- a/airdrops/src/interfaces/ISablierMerkleLockup.sol
+++ b/airdrops/src/interfaces/ISablierMerkleLockup.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22;
 
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
+
 import { ISablierMerkleBase } from "./ISablierMerkleBase.sol";
 
 /// @title ISablierMerkleLockup

--- a/airdrops/src/interfaces/ISablierMerkleSignature.sol
+++ b/airdrops/src/interfaces/ISablierMerkleSignature.sol
@@ -34,7 +34,7 @@ interface ISablierMerkleSignature is ISablierMerkleBase {
     /// @dev Emits a {SetAttestor} event.
     ///
     /// Requirements:
-    /// - `msg.sender` must either be the comptroller or the campaign admin.
+    /// - `msg.sender` must be either the comptroller or the campaign admin.
     ///
     /// @param newAttestor The new attestor address. If zero, the attestor from the comptroller will be used.
     function setAttestor(address newAttestor) external;

--- a/airdrops/src/interfaces/ISablierMerkleSignature.sol
+++ b/airdrops/src/interfaces/ISablierMerkleSignature.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.22;
+
+import { ISablierMerkleBase } from "./ISablierMerkleBase.sol";
+
+/// @title ISablierMerkleSignature
+/// @notice Abstract contract providing helper functions for verifying EIP-712 and EIP-1271 signatures for Merkle
+/// campaigns.
+interface ISablierMerkleSignature is ISablierMerkleBase {
+    /*//////////////////////////////////////////////////////////////////////////
+                                       EVENTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when the address of the attestor is set in this contract.
+    event SetAttestor(address indexed caller, address indexed previousAttestor, address indexed newAttestor);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                READ-ONLY FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Retrieves the attestor address used for creating attestation signatures.
+    function attestor() external view returns (address);
+
+    /// @notice The domain separator, as required by EIP-712 and EIP-1271, used for signing claims to prevent replay
+    /// attacks across different campaigns.
+    function domainSeparator() external view returns (bytes32);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              STATE-CHANGING FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Sets the attestor address used for verifying attestation signatures.
+    ///
+    /// @dev Emits a {SetAttestor} event.
+    ///
+    /// Requirements:
+    /// - `msg.sender` must either be the comptroller or the campaign admin.
+    ///
+    /// @param newAttestor The new attestor address. If zero, the attestor from the comptroller will be used.
+    function setAttestor(address newAttestor) external;
+}

--- a/airdrops/src/libraries/Errors.sol
+++ b/airdrops/src/libraries/Errors.sol
@@ -40,23 +40,23 @@ library Errors {
     /// @notice Thrown when trying to create a Merkle VCA campaign with zero aggregate amount.
     error SablierFactoryMerkleVCA_AggregateAmountZero();
 
-    /// @notice Thrown if expiration time is within 1 week from the vesting end time.
-    error SablierFactoryMerkleVCA_ExpirationTooEarly(uint40 vestingEndTime, uint40 expiration);
-
     /// @notice Thrown if expiration time is zero.
     error SablierFactoryMerkleVCA_ExpirationTimeZero();
 
-    /// @notice Thrown if vesting end time is not greater than the vesting start time.
-    error SablierFactoryMerkleVCA_VestingEndTimeNotGreaterThanVestingStartTime(
-        uint40 vestingStartTime,
-        uint40 vestingEndTime
-    );
+    /// @notice Thrown if expiration time is within 1 week from the vesting end time.
+    error SablierFactoryMerkleVCA_ExpirationTooEarly(uint40 vestingEndTime, uint40 expiration);
 
     /// @notice Thrown if the start time is zero.
     error SablierFactoryMerkleVCA_StartTimeZero();
 
     /// @notice Thrown if the unlock percentage is greater than 100%.
     error SablierFactoryMerkleVCA_UnlockPercentageTooHigh(UD60x18 unlockPercentage);
+
+    /// @notice Thrown if vesting end time is not greater than the vesting start time.
+    error SablierFactoryMerkleVCA_VestingEndTimeNotGreaterThanVestingStartTime(
+        uint40 vestingStartTime,
+        uint40 vestingEndTime
+    );
 
     /*//////////////////////////////////////////////////////////////////////////
                                 SABLIER-MERKLE-BASE
@@ -87,17 +87,27 @@ library Errors {
     /// @notice Thrown when trying to claim with an invalid Merkle proof.
     error SablierMerkleBase_InvalidProof();
 
-    /// @notice Thrown when claiming with an invalid EIP-712 or EIP-1271 signature.
-    error SablierMerkleBase_InvalidSignature();
-
     /// @notice Thrown when trying to set a new min USD fee that is higher than the current fee.
     error SablierMerkleBase_NewMinFeeUSDNotLower(uint256 currentMinFeeUSD, uint256 newMinFeeUSD);
 
-    /// @notice Thrown when trying to claim with a signature that is not yet valid.
-    error SablierMerkleBase_SignatureNotYetValid(uint40 validFrom, uint40 blockTimestamp);
-
     /// @notice Thrown when trying to claim to the zero address.
     error SablierMerkleBase_ToZeroAddress();
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              SABLIER-MERKLE-SIGNATURE
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Thrown when the attestor returns the zero address.
+    error SablierMerkleSignature_AttestorNotSet();
+
+    /// @notice Thrown when caller is not the comptroller or campaign admin.
+    error SablierMerkleSignature_CallerNotAuthorized(address caller, address campaignAdmin, address comptroller);
+
+    /// @notice Thrown when claiming with an invalid EIP-712 or EIP-1271 signature.
+    error SablierMerkleSignature_InvalidSignature();
+
+    /// @notice Thrown when trying to claim with a signature that is not yet valid.
+    error SablierMerkleSignature_SignatureNotYetValid(uint40 validFrom, uint40 blockTimestamp);
 
     /*//////////////////////////////////////////////////////////////////////////
                                  SABLIER-MERKLE-VCA

--- a/airdrops/src/libraries/SignatureHash.sol
+++ b/airdrops/src/libraries/SignatureHash.sol
@@ -4,13 +4,16 @@ pragma solidity >=0.8.22;
 /// @title SignatureHash
 /// @notice Library containing the hashes for the EIP-712 and EIP-1271 signatures.
 library SignatureHash {
-    /// @dev The struct type hash for computing the domain separator for EIP-712 and EIP-1271 signatures.
+    /// @dev The struct type hash for the claim signature.
     bytes32 public constant CLAIM_TYPEHASH =
         keccak256("Claim(uint256 index,address recipient,address to,uint128 amount,uint40 validFrom)");
 
     /// @notice The domain type hash for computing the domain separator.
     bytes32 public constant DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    /// @notice The struct type hash for the attestation signature.
+    bytes32 public constant IDENTITY_TYPEHASH = keccak256("Identity(address recipient)");
 
     /// @notice The protocol name for the EIP-712 and EIP-1271 signatures.
     bytes32 public constant PROTOCOL_NAME = keccak256("Sablier Airdrops Protocol");

--- a/airdrops/src/types/DataTypes.sol
+++ b/airdrops/src/types/DataTypes.sol
@@ -7,6 +7,33 @@ import { UD2x18 } from "@prb/math/src/UD2x18.sol";
 import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 
+library MerkleBase {
+    /// @notice Struct encapsulating the constructor parameters of {SablierMerkleBase} contract.
+    /// @dev The fields are arranged alphabetically.
+    /// @param campaignCreator The address of campaign creator which should be the same as the `msg.sender`.
+    /// @param campaignName The name of the campaign.
+    /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
+    /// @param comptroller The address of the comptroller contract.
+    /// @param expiration The expiration of the campaign, as a Unix timestamp. A value of zero means the campaign does
+    /// not expire.
+    /// @param initialAdmin The initial admin of the campaign.
+    /// @param ipfsCID The content identifier for indexing the contract on IPFS. An empty value may break certain UI
+    /// features that depend upon the IPFS CID.
+    /// @param merkleRoot The Merkle root of the claim data.
+    /// @param token The contract address of the ERC-20 token to be distributed.
+    struct ConstructorParams {
+        address campaignCreator;
+        string campaignName;
+        uint40 campaignStartTime;
+        address comptroller;
+        uint40 expiration;
+        address initialAdmin;
+        string ipfsCID;
+        bytes32 merkleRoot;
+        IERC20 token;
+    }
+}
+
 library MerkleExecute {
     /// @notice Struct encapsulating the constructor parameters of Merkle Execute campaigns.
     /// @dev The fields are arranged alphabetically.
@@ -102,6 +129,21 @@ library MerkleLL {
         uint40 totalDuration;
         bool transferable;
         uint40 vestingStartTime;
+    }
+}
+
+library MerkleLockup {
+    /// @notice Struct encapsulating the constructor parameters of {SablierMerkleLockup} contract.
+    /// @dev The fields are arranged alphabetically.
+    /// @param cancelable Whether Lockup stream will be cancelable after claiming.
+    /// @param lockup The address of the {SablierLockup} contract.
+    /// @param shape The shape of the vesting stream, used for differentiating between streams in the UI.
+    /// @param transferable Whether Lockup stream will be transferable after claiming.
+    struct ConstructorParams {
+        bool cancelable;
+        ISablierLockup lockup;
+        string shape;
+        bool transferable;
     }
 }
 

--- a/airdrops/tests/integration/Integration.t.sol
+++ b/airdrops/tests/integration/Integration.t.sol
@@ -109,6 +109,35 @@ abstract contract Integration_Test is Base_Test {
         }
     }
 
+    /// @dev Claim using default values for {claimViaAttestation} function.
+    function claimViaAttestation() internal {
+        claimViaAttestation({
+            msgValue: AIRDROP_MIN_FEE_WEI,
+            index: getIndexInMerkleTree(),
+            to: users.eve,
+            amount: CLAIM_AMOUNT,
+            merkleProof: getMerkleProof(),
+            attestation: generateAttestation()
+        });
+    }
+
+    function claimViaAttestation(
+        uint256 msgValue,
+        uint256 index,
+        address to,
+        uint128 amount,
+        bytes32[] memory merkleProof,
+        bytes memory attestation
+    )
+        internal
+        virtual
+    {
+        address campaignAddr = address(merkleBase);
+        ISablierMerkleInstant(campaignAddr).claimViaAttestation{ value: msgValue }(
+            index, to, amount, merkleProof, attestation
+        );
+    }
+
     /// @dev Claim using default values for {claimViaSig} function.
     function claimViaSig() internal {
         claimViaSig(users.recipient, CLAIM_AMOUNT);
@@ -146,6 +175,15 @@ abstract contract Integration_Test is Base_Test {
         ISablierMerkleInstant(campaignAddr).claimViaSig{ value: msgValue }(
             index, recipient, to, amount, validFrom, merkleProof, signature
         );
+    }
+
+    /// @dev Generate the EIP-712 attestation signature with default parameters.
+    function generateAttestation() internal view returns (bytes memory) {
+        return generateAttestationSignature({
+            signerPrivateKey: attestorPrivateKey,
+            merkleContract: address(merkleBase),
+            recipient: users.recipient
+        });
     }
 
     /// @dev Generate the EIP-712 signature to claim with default parameters.

--- a/airdrops/tests/integration/concrete/campaign/instant/MerkleInstant.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/MerkleInstant.t.sol
@@ -11,6 +11,7 @@ import { DomainSeparator_Integration_Test } from "./../shared/domain-separator/d
 import { HasClaimed_Integration_Test } from "./../shared/has-claimed/hasClaimed.t.sol";
 import { HasExpired_Integration_Test } from "./../shared/has-expired/hasExpired.t.sol";
 import { LowerMinFeeUSD_Integration_Test } from "./../shared/lower-min-fee-usd/lowerMinFeeUSD.t.sol";
+import { SetAttestor_Integration_Test } from "./../shared/set-attestor/setAttestor.t.sol";
 
 /*//////////////////////////////////////////////////////////////////////////
                              NON-SHARED TESTS
@@ -84,6 +85,15 @@ contract HasExpired_MerkleInstant_Integration_Test is
 contract LowerMinFeeUSD_MerkleInstant_Integration_Test is
     MerkleInstant_Integration_Shared_Test,
     LowerMinFeeUSD_Integration_Test
+{
+    function setUp() public override(MerkleInstant_Integration_Shared_Test, Integration_Test) {
+        MerkleInstant_Integration_Shared_Test.setUp();
+    }
+}
+
+contract SetAttestor_MerkleInstant_Integration_Test is
+    MerkleInstant_Integration_Shared_Test,
+    SetAttestor_Integration_Test
 {
     function setUp() public override(MerkleInstant_Integration_Shared_Test, Integration_Test) {
         MerkleInstant_Integration_Shared_Test.setUp();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ERC1271WalletMock } from "@sablier/evm-utils/src/mocks/ERC1271WalletMock.sol";
+
+import { ISablierMerkleInstant } from "src/interfaces/ISablierMerkleInstant.sol";
+import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+
+import { ClaimViaAttestation_Integration_Test } from "./../../shared/claim-via-attestation/claimViaAttestation.t.sol";
+import { MerkleInstant_Integration_Shared_Test } from "./../MerkleInstant.t.sol";
+
+contract ClaimViaAttestation_MerkleInstant_Integration_Test is
+    ClaimViaAttestation_Integration_Test,
+    MerkleInstant_Integration_Shared_Test
+{
+    function setUp()
+        public
+        virtual
+        override(MerkleInstant_Integration_Shared_Test, ClaimViaAttestation_Integration_Test)
+    {
+        MerkleInstant_Integration_Shared_Test.setUp();
+        ClaimViaAttestation_Integration_Test.setUp();
+    }
+
+    function test_WhenAttestationValid()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsEOA
+    {
+        _test_ClaimViaAttestation();
+    }
+
+    function test_WhenAttestorImplementsIERC1271Interface()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsContract
+    {
+        // Deploy an ERC1271 wallet with the EOA attestor as the admin.
+        address smartAttestor = address(new ERC1271WalletMock(attestor));
+
+        // Set the attestor to the smart contract.
+        setMsgSender(users.campaignCreator);
+        ISablierMerkleSignature(address(merkleInstant)).setAttestor(smartAttestor);
+        setMsgSender(users.recipient);
+
+        _test_ClaimViaAttestation();
+    }
+
+    function _test_ClaimViaAttestation() internal {
+        uint256 previousFeeAccrued = address(comptroller).balance;
+        uint256 index = getIndexInMerkleTree();
+
+        vm.expectEmit({ emitter: address(merkleInstant) });
+        emit ISablierMerkleInstant.ClaimInstant(index, users.recipient, CLAIM_AMOUNT, users.eve, false);
+
+        expectCallToTransfer({ to: users.eve, value: CLAIM_AMOUNT });
+        claimViaAttestation();
+
+        assertTrue(merkleInstant.hasClaimed(index), "not claimed");
+        assertEq(address(comptroller).balance, previousFeeAccrued + AIRDROP_MIN_FEE_WEI, "fee collected");
+    }
+}

--- a/airdrops/tests/integration/concrete/campaign/instant/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/constructor.t.sol
@@ -14,6 +14,9 @@ contract Constructor_MerkleInstant_Integration_Test is Integration_Test {
         SablierMerkleInstant constructedInstant =
             new SablierMerkleInstant(merkleInstantConstructorParams(), users.campaignCreator, address(comptroller));
 
+        // SablierMerkleSignature
+        assertEq(constructedInstant.attestor(), attestor, "attestor");
+
         // SablierMerkleBase
         assertEq(constructedInstant.admin(), users.campaignCreator, "admin");
         assertEq(constructedInstant.campaignName(), CAMPAIGN_NAME, "campaign name");

--- a/airdrops/tests/integration/concrete/campaign/ll/MerkleLL.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/MerkleLL.t.sol
@@ -9,6 +9,7 @@ import { DomainSeparator_Integration_Test } from "./../shared/domain-separator/d
 import { HasClaimed_Integration_Test } from "./../shared/has-claimed/hasClaimed.t.sol";
 import { HasExpired_Integration_Test } from "./../shared/has-expired/hasExpired.t.sol";
 import { LowerMinFeeUSD_Integration_Test } from "./../shared/lower-min-fee-usd/lowerMinFeeUSD.t.sol";
+import { SetAttestor_Integration_Test } from "./../shared/set-attestor/setAttestor.t.sol";
 
 /*//////////////////////////////////////////////////////////////////////////
                              NON-SHARED TESTS
@@ -73,6 +74,12 @@ contract HasExpired_MerkleLL_Integration_Test is MerkleLL_Integration_Shared_Tes
 }
 
 contract LowerMinFeeUSD_MerkleLL_Integration_Test is MerkleLL_Integration_Shared_Test, LowerMinFeeUSD_Integration_Test {
+    function setUp() public override(MerkleLL_Integration_Shared_Test, Integration_Test) {
+        MerkleLL_Integration_Shared_Test.setUp();
+    }
+}
+
+contract SetAttestor_MerkleLL_Integration_Test is MerkleLL_Integration_Shared_Test, SetAttestor_Integration_Test {
     function setUp() public override(MerkleLL_Integration_Shared_Test, Integration_Test) {
         MerkleLL_Integration_Shared_Test.setUp();
     }

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-via-attestation/claimViaAttestation.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ERC1271WalletMock } from "@sablier/evm-utils/src/mocks/ERC1271WalletMock.sol";
+
+import { ISablierMerkleLL } from "src/interfaces/ISablierMerkleLL.sol";
+import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+
+import { ClaimViaAttestation_Integration_Test } from "./../../shared/claim-via-attestation/claimViaAttestation.t.sol";
+import { MerkleLL_Integration_Shared_Test } from "./../MerkleLL.t.sol";
+
+contract ClaimViaAttestation_MerkleLL_Integration_Test is
+    ClaimViaAttestation_Integration_Test,
+    MerkleLL_Integration_Shared_Test
+{
+    function setUp() public virtual override(MerkleLL_Integration_Shared_Test, ClaimViaAttestation_Integration_Test) {
+        MerkleLL_Integration_Shared_Test.setUp();
+        ClaimViaAttestation_Integration_Test.setUp();
+    }
+
+    function test_WhenAttestationValid()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsEOA
+    {
+        _test_ClaimViaAttestation();
+    }
+
+    function test_WhenAttestorImplementsIERC1271Interface()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsContract
+    {
+        // Deploy an ERC1271 wallet with the EOA attestor as the admin.
+        address smartAttestor = address(new ERC1271WalletMock(attestor));
+
+        // Set the attestor to the smart contract.
+        setMsgSender(users.campaignCreator);
+        ISablierMerkleSignature(address(merkleLL)).setAttestor(smartAttestor);
+        setMsgSender(users.recipient);
+
+        _test_ClaimViaAttestation();
+    }
+
+    function _test_ClaimViaAttestation() internal {
+        uint256 expectedStreamId = lockup.nextStreamId();
+        uint256 previousFeeAccrued = address(comptroller).balance;
+        uint256 index = getIndexInMerkleTree();
+
+        vm.expectEmit({ emitter: address(merkleLL) });
+        emit ISablierMerkleLL.ClaimLLWithVesting(
+            index,
+            users.recipient,
+            CLAIM_AMOUNT,
+            expectedStreamId,
+            users.eve,
+            false
+        );
+
+        expectCallToTransferFrom({ from: address(merkleLL), to: address(lockup), value: CLAIM_AMOUNT });
+        claimViaAttestation();
+
+        assertTrue(merkleLL.hasClaimed(index), "not claimed");
+        assertEq(address(comptroller).balance, previousFeeAccrued + AIRDROP_MIN_FEE_WEI, "fee collected");
+    }
+}

--- a/airdrops/tests/integration/concrete/campaign/ll/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/constructor.t.sol
@@ -18,6 +18,9 @@ contract Constructor_MerkleLL_Integration_Test is Integration_Test {
         uint256 actualAllowance = dai.allowance(address(constructedLL), address(lockup));
         assertEq(actualAllowance, MAX_UINT256, "allowance");
 
+        // SablierMerkleSignature
+        assertEq(constructedLL.attestor(), attestor, "attestor");
+
         // SablierMerkleBase
         assertEq(constructedLL.admin(), users.campaignCreator, "admin");
         assertEq(constructedLL.CAMPAIGN_START_TIME(), CAMPAIGN_START_TIME, "campaign start time");

--- a/airdrops/tests/integration/concrete/campaign/lt/MerkleLT.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/MerkleLT.t.sol
@@ -9,6 +9,7 @@ import { DomainSeparator_Integration_Test } from "./../shared/domain-separator/d
 import { HasClaimed_Integration_Test } from "./../shared/has-claimed/hasClaimed.t.sol";
 import { HasExpired_Integration_Test } from "./../shared/has-expired/hasExpired.t.sol";
 import { LowerMinFeeUSD_Integration_Test } from "./../shared/lower-min-fee-usd/lowerMinFeeUSD.t.sol";
+import { SetAttestor_Integration_Test } from "./../shared/set-attestor/setAttestor.t.sol";
 /*//////////////////////////////////////////////////////////////////////////
                              NON-SHARED TESTS
 //////////////////////////////////////////////////////////////////////////*/
@@ -72,6 +73,12 @@ contract HasExpired_MerkleLT_Integration_Test is MerkleLT_Integration_Shared_Tes
 }
 
 contract LowerMinFeeUSD_MerkleLT_Integration_Test is MerkleLT_Integration_Shared_Test, LowerMinFeeUSD_Integration_Test {
+    function setUp() public override(MerkleLT_Integration_Shared_Test, Integration_Test) {
+        MerkleLT_Integration_Shared_Test.setUp();
+    }
+}
+
+contract SetAttestor_MerkleLT_Integration_Test is MerkleLT_Integration_Shared_Test, SetAttestor_Integration_Test {
     function setUp() public override(MerkleLT_Integration_Shared_Test, Integration_Test) {
         MerkleLT_Integration_Shared_Test.setUp();
     }

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ERC1271WalletMock } from "@sablier/evm-utils/src/mocks/ERC1271WalletMock.sol";
+
+import { ISablierMerkleLT } from "src/interfaces/ISablierMerkleLT.sol";
+import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+
+import { ClaimViaAttestation_Integration_Test } from "./../../shared/claim-via-attestation/claimViaAttestation.t.sol";
+import { MerkleLT_Integration_Shared_Test } from "./../MerkleLT.t.sol";
+
+contract ClaimViaAttestation_MerkleLT_Integration_Test is
+    ClaimViaAttestation_Integration_Test,
+    MerkleLT_Integration_Shared_Test
+{
+    function setUp() public virtual override(MerkleLT_Integration_Shared_Test, ClaimViaAttestation_Integration_Test) {
+        MerkleLT_Integration_Shared_Test.setUp();
+        ClaimViaAttestation_Integration_Test.setUp();
+    }
+
+    function test_WhenAttestationValid()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsEOA
+    {
+        _test_ClaimViaAttestation();
+    }
+
+    function test_WhenAttestorImplementsIERC1271Interface()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsContract
+    {
+        // Deploy an ERC1271 wallet with the EOA attestor as the admin.
+        address smartAttestor = address(new ERC1271WalletMock(attestor));
+
+        // Set the attestor to the smart contract.
+        setMsgSender(users.campaignCreator);
+        ISablierMerkleSignature(address(merkleLT)).setAttestor(smartAttestor);
+        setMsgSender(users.recipient);
+
+        _test_ClaimViaAttestation();
+    }
+
+    function _test_ClaimViaAttestation() internal {
+        uint256 expectedStreamId = lockup.nextStreamId();
+        uint256 previousFeeAccrued = address(comptroller).balance;
+        uint256 index = getIndexInMerkleTree();
+
+        vm.expectEmit({ emitter: address(merkleLT) });
+        emit ISablierMerkleLT.ClaimLTWithVesting(
+            index,
+            users.recipient,
+            CLAIM_AMOUNT,
+            expectedStreamId,
+            users.eve,
+            false
+        );
+
+        expectCallToTransferFrom({ from: address(merkleLT), to: address(lockup), value: CLAIM_AMOUNT });
+        claimViaAttestation();
+
+        assertTrue(merkleLT.hasClaimed(index), "not claimed");
+        assertEq(address(comptroller).balance, previousFeeAccrued + AIRDROP_MIN_FEE_WEI, "fee collected");
+    }
+}

--- a/airdrops/tests/integration/concrete/campaign/lt/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/constructor.t.sol
@@ -20,6 +20,9 @@ contract Constructor_MerkleLT_Integration_Test is Integration_Test {
         uint256 actualAllowance = dai.allowance(address(constructedLT), address(lockup));
         assertEq(actualAllowance, MAX_UINT256, "allowance");
 
+        // SablierMerkleSignature
+        assertEq(constructedLT.attestor(), attestor, "attestor");
+
         // SablierMerkleBase
         assertEq(constructedLT.admin(), users.campaignCreator, "admin");
         assertEq(constructedLT.campaignName(), CAMPAIGN_NAME, "campaign name");

--- a/airdrops/tests/integration/concrete/campaign/shared/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/shared/claim-via-attestation/claimViaAttestation.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { Noop } from "@sablier/evm-utils/src/mocks/Noop.sol";
+
+import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+import { Errors } from "src/libraries/Errors.sol";
+
+import { Integration_Test } from "../../../../Integration.t.sol";
+
+abstract contract ClaimViaAttestation_Integration_Test is Integration_Test {
+    function setUp() public virtual override {
+        // Make `users.recipient` the caller for this test since `claimViaAttestation` uses `msg.sender` as the
+        // recipient.
+        setMsgSender(users.recipient);
+    }
+
+    function test_RevertWhen_ToAddressZero() external {
+        // It should revert.
+        vm.expectRevert(Errors.SablierMerkleBase_ToZeroAddress.selector);
+        claimViaAttestation({
+            msgValue: AIRDROP_MIN_FEE_WEI,
+            index: getIndexInMerkleTree(),
+            to: address(0),
+            amount: CLAIM_AMOUNT,
+            merkleProof: getMerkleProof(),
+            attestation: generateAttestation()
+        });
+    }
+
+    function test_RevertGiven_AttestorZero() external whenToAddressNotZero {
+        // Set the default attestor to the zero address.
+        setMsgSender(admin);
+        comptroller.setAttestor(address(0));
+
+        // Change caller back to the recipient.
+        setMsgSender(users.recipient);
+
+        // It should revert.
+        vm.expectRevert(Errors.SablierMerkleSignature_AttestorNotSet.selector);
+        claimViaAttestation({
+            msgValue: AIRDROP_MIN_FEE_WEI,
+            index: getIndexInMerkleTree(),
+            to: users.eve,
+            amount: CLAIM_AMOUNT,
+            merkleProof: getMerkleProof(),
+            attestation: generateAttestation()
+        });
+    }
+
+    function test_RevertWhen_AttestationInvalid()
+        external
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsEOA
+    {
+        // Change caller to eve and use the default attestation generated for the recipient.
+        setMsgSender(users.eve);
+
+        // It should revert.
+        vm.expectRevert(Errors.SablierMerkleSignature_InvalidSignature.selector);
+        claimViaAttestation({
+            msgValue: AIRDROP_MIN_FEE_WEI,
+            index: getIndexInMerkleTree(),
+            to: users.eve,
+            amount: CLAIM_AMOUNT,
+            merkleProof: getMerkleProof(),
+            attestation: generateAttestation()
+        });
+    }
+
+    /// @dev Since the implementation of `claimViaAttestation()` differs in each Merkle campaign, we declare this
+    /// virtual dummy test. The child contracts implement it.
+    function test_WhenAttestationValid() external virtual whenToAddressNotZero givenAttestorNotZero givenAttestorIsEOA {
+        // The child contract must check that the claim event is emitted.
+        // It should mark the index as claimed.
+        // It should transfer the fee from the caller address to the comptroller.
+    }
+
+    function test_RevertWhen_AttestorNotImplementIERC1271Interface()
+        external
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsContract
+    {
+        // Deploy a contract that does not implement IERC1271.
+        address smartAttestorWithoutIERC1271 = address(new Noop());
+
+        // Set the attestor to the contract without IERC1271.
+        setMsgSender(users.campaignCreator);
+        ISablierMerkleSignature(address(merkleBase)).setAttestor(smartAttestorWithoutIERC1271);
+
+        // Change caller back to the recipient.
+        setMsgSender(users.recipient);
+
+        vm.expectRevert(Errors.SablierMerkleSignature_InvalidSignature.selector);
+        claimViaAttestation({
+            msgValue: AIRDROP_MIN_FEE_WEI,
+            index: getIndexInMerkleTree(),
+            to: users.eve,
+            amount: CLAIM_AMOUNT,
+            merkleProof: getMerkleProof(),
+            attestation: generateAttestation()
+        });
+    }
+
+    /// @dev Since the implementation of `claimViaAttestation()` differs in each Merkle campaign, we declare this
+    /// virtual dummy test. The child contracts implement it.
+    function test_WhenAttestorImplementsIERC1271Interface()
+        external
+        virtual
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsContract
+    {
+        // The child contract must check that the claim event is emitted.
+        // It should mark the index as claimed.
+        // It should transfer the fee from the caller address to the comptroller.
+    }
+}

--- a/airdrops/tests/integration/concrete/campaign/shared/claim-via-attestation/claimViaAttestation.tree
+++ b/airdrops/tests/integration/concrete/campaign/shared/claim-via-attestation/claimViaAttestation.tree
@@ -1,0 +1,21 @@
+ClaimViaAttestation_Integration_Test
+├── when to address zero
+│  └── it should revert
+└── when to address not zero
+   ├── given attestor zero
+   │  └── it should revert
+   └── given attestor not zero
+      ├── given attestor is EOA
+      │  ├── when attestation invalid
+      │  │  └── it should revert
+      │  └── when attestation valid
+      │     ├── it should mark the index as claimed
+      │     ├── it should transfer the ETH to the comptroller
+      │     └── it should emit claim event
+      └── given attestor is contract
+         ├── when attestor not implement IERC1271 interface
+         │  └── it should revert
+         └── when attestor implements IERC1271 interface
+            ├── it should mark the index as claimed
+            ├── it should transfer the ETH to the comptroller
+            └── it should emit claim event

--- a/airdrops/tests/integration/concrete/campaign/shared/claim-via-sig/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/shared/claim-via-sig/claimViaSig.t.sol
@@ -32,7 +32,7 @@ abstract contract ClaimViaSig_Integration_Test is Integration_Test {
         bytes memory incompatibleSignature = vm.randomBytes(65);
 
         // Expect revert.
-        vm.expectRevert(Errors.SablierMerkleBase_InvalidSignature.selector);
+        vm.expectRevert(Errors.SablierMerkleSignature_InvalidSignature.selector);
         claimViaSig({
             msgValue: AIRDROP_MIN_FEE_WEI,
             index: index,
@@ -70,7 +70,7 @@ abstract contract ClaimViaSig_Integration_Test is Integration_Test {
         });
 
         // Expect revert.
-        vm.expectRevert(Errors.SablierMerkleBase_InvalidSignature.selector);
+        vm.expectRevert(Errors.SablierMerkleSignature_InvalidSignature.selector);
         claimViaSig({
             msgValue: AIRDROP_MIN_FEE_WEI,
             index: index,
@@ -108,7 +108,9 @@ abstract contract ClaimViaSig_Integration_Test is Integration_Test {
 
         // Expect revert.
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.SablierMerkleBase_SignatureNotYetValid.selector, VALID_FROM, VALID_FROM - 1)
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_SignatureNotYetValid.selector, VALID_FROM, VALID_FROM - 1
+            )
         );
         claimViaSig({
             msgValue: AIRDROP_MIN_FEE_WEI,
@@ -142,7 +144,7 @@ abstract contract ClaimViaSig_Integration_Test is Integration_Test {
         whenToAddressNotZero
         givenRecipientIsContract
     {
-        vm.expectRevert(Errors.SablierMerkleBase_InvalidSignature.selector);
+        vm.expectRevert(Errors.SablierMerkleSignature_InvalidSignature.selector);
         claimViaSig({
             msgValue: AIRDROP_MIN_FEE_WEI,
             index: getIndexInMerkleTree(users.smartWalletWithoutIERC1271),

--- a/airdrops/tests/integration/concrete/campaign/shared/domain-separator/domainSeparator.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/shared/domain-separator/domainSeparator.t.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22 <0.9.0;
 
+import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+
 import { Integration_Test } from "../../../../Integration.t.sol";
 
 abstract contract DomainSeparator_Integration_Test is Integration_Test {
     function test_WhenChainIDMatchesCachedChainID() external view {
         // It should return the cached domain separator.
-        bytes32 actualDomainSeparator = merkleBase.domainSeparator();
+        bytes32 actualDomainSeparator = ISablierMerkleSignature(address(merkleBase)).domainSeparator();
         bytes32 expectedDomainSeparator = computeEIP712DomainSeparator(address(merkleBase));
         assertEq(actualDomainSeparator, expectedDomainSeparator, "domain separator");
     }
@@ -16,7 +18,7 @@ abstract contract DomainSeparator_Integration_Test is Integration_Test {
         vm.chainId(1000);
 
         // It should return the computed domain separator.
-        bytes32 actualDomainSeparator = merkleBase.domainSeparator();
+        bytes32 actualDomainSeparator = ISablierMerkleSignature(address(merkleBase)).domainSeparator();
         bytes32 expectedDomainSeparator = computeEIP712DomainSeparator(address(merkleBase));
         assertEq(actualDomainSeparator, expectedDomainSeparator, "domain separator");
     }

--- a/airdrops/tests/integration/concrete/campaign/shared/set-attestor/setAttestor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/shared/set-attestor/setAttestor.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+import { Errors } from "src/libraries/Errors.sol";
+
+import { Integration_Test } from "../../../../Integration.t.sol";
+
+abstract contract SetAttestor_Integration_Test is Integration_Test {
+    address internal newAttestor = makeAddr("newAttestor");
+
+    function test_RevertWhen_CallerNotComptroller() external whenCallerNotCampaignCreator {
+        setMsgSender(users.eve);
+
+        // It should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_CallerNotAuthorized.selector,
+                users.eve,
+                users.campaignCreator,
+                address(comptroller)
+            )
+        );
+        ISablierMerkleSignature(address(merkleBase)).setAttestor(newAttestor);
+    }
+
+    function test_WhenCallerComptroller() external whenCallerNotCampaignCreator {
+        setMsgSender(address(comptroller));
+
+        // It should emit a {SetAttestor} event.
+        vm.expectEmit({ emitter: address(merkleBase) });
+        emit ISablierMerkleSignature.SetAttestor({
+            caller: address(comptroller),
+            previousAttestor: attestor,
+            newAttestor: newAttestor
+        });
+
+        ISablierMerkleSignature(address(merkleBase)).setAttestor(newAttestor);
+
+        // It should set the attestor.
+        assertEq(ISablierMerkleSignature(address(merkleBase)).attestor(), newAttestor, "attestor");
+    }
+
+    function test_WhenCallerCampaignCreator() external {
+        // It should emit a {SetAttestor} event.
+        vm.expectEmit({ emitter: address(merkleBase) });
+        emit ISablierMerkleSignature.SetAttestor({
+            caller: users.campaignCreator,
+            previousAttestor: attestor,
+            newAttestor: newAttestor
+        });
+
+        ISablierMerkleSignature(address(merkleBase)).setAttestor(newAttestor);
+
+        // It should set the attestor.
+        assertEq(ISablierMerkleSignature(address(merkleBase)).attestor(), newAttestor, "attestor");
+    }
+}

--- a/airdrops/tests/integration/concrete/campaign/shared/set-attestor/setAttestor.tree
+++ b/airdrops/tests/integration/concrete/campaign/shared/set-attestor/setAttestor.tree
@@ -1,0 +1,10 @@
+SetAttestor_Integration_Test
+├── when caller not campaign creator
+│  ├── when caller not comptroller
+│  │  └── it should revert
+│  └── when caller comptroller
+│     ├── it should set the attestor
+│     └── it should emit a {SetAttestor} event
+└── when caller campaign creator
+   ├── it should set the attestor
+   └── it should emit a {SetAttestor} event

--- a/airdrops/tests/integration/concrete/campaign/vca/MerkleVCA.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/MerkleVCA.t.sol
@@ -9,6 +9,7 @@ import { DomainSeparator_Integration_Test } from "./../shared/domain-separator/d
 import { HasClaimed_Integration_Test } from "./../shared/has-claimed/hasClaimed.t.sol";
 import { HasExpired_Integration_Test } from "./../shared/has-expired/hasExpired.t.sol";
 import { LowerMinFeeUSD_Integration_Test } from "./../shared/lower-min-fee-usd/lowerMinFeeUSD.t.sol";
+import { SetAttestor_Integration_Test } from "./../shared/set-attestor/setAttestor.t.sol";
 
 /*//////////////////////////////////////////////////////////////////////////
                              NON-SHARED TESTS
@@ -73,6 +74,12 @@ contract LowerMinFeeUSD_MerkleVCA_Integration_Test is
     MerkleVCA_Integration_Shared_Test,
     LowerMinFeeUSD_Integration_Test
 {
+    function setUp() public override(MerkleVCA_Integration_Shared_Test, Integration_Test) {
+        MerkleVCA_Integration_Shared_Test.setUp();
+    }
+}
+
+contract SetAttestor_MerkleVCA_Integration_Test is MerkleVCA_Integration_Shared_Test, SetAttestor_Integration_Test {
     function setUp() public override(MerkleVCA_Integration_Shared_Test, Integration_Test) {
         MerkleVCA_Integration_Shared_Test.setUp();
     }

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-via-attestation/claimViaAttestation.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ERC1271WalletMock } from "@sablier/evm-utils/src/mocks/ERC1271WalletMock.sol";
+
+import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+import { ISablierMerkleVCA } from "src/interfaces/ISablierMerkleVCA.sol";
+
+import { ClaimViaAttestation_Integration_Test } from "./../../shared/claim-via-attestation/claimViaAttestation.t.sol";
+import { MerkleVCA_Integration_Shared_Test } from "./../MerkleVCA.t.sol";
+
+contract ClaimViaAttestation_MerkleVCA_Integration_Test is
+    ClaimViaAttestation_Integration_Test,
+    MerkleVCA_Integration_Shared_Test
+{
+    function setUp() public virtual override(MerkleVCA_Integration_Shared_Test, ClaimViaAttestation_Integration_Test) {
+        MerkleVCA_Integration_Shared_Test.setUp();
+        ClaimViaAttestation_Integration_Test.setUp();
+    }
+
+    function test_WhenAttestationValid()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsEOA
+    {
+        uint128 forgoneAmount = VCA_FULL_AMOUNT - VCA_CLAIM_AMOUNT;
+        uint256 previousFeeAccrued = address(comptroller).balance;
+        uint256 index = getIndexInMerkleTree();
+
+        vm.expectEmit({ emitter: address(merkleVCA) });
+        emit ISablierMerkleVCA.ClaimVCA({
+            index: index,
+            recipient: users.recipient,
+            claimAmount: VCA_CLAIM_AMOUNT,
+            forgoneAmount: forgoneAmount,
+            to: users.eve,
+            viaSig: false
+        });
+
+        expectCallToTransfer({ to: users.eve, value: VCA_CLAIM_AMOUNT });
+        claimViaAttestation();
+
+        assertTrue(merkleVCA.hasClaimed(index), "not claimed");
+        assertEq(merkleVCA.totalForgoneAmount(), forgoneAmount, "total forgone amount");
+        assertEq(address(comptroller).balance, previousFeeAccrued + AIRDROP_MIN_FEE_WEI, "fee collected");
+    }
+
+    function test_WhenAttestorImplementsIERC1271Interface()
+        external
+        override
+        whenToAddressNotZero
+        givenAttestorNotZero
+        givenAttestorIsContract
+    {
+        // Deploy an ERC1271 wallet with the EOA attestor as the admin.
+        address smartAttestor = address(new ERC1271WalletMock(attestor));
+
+        // Set the attestor to the smart contract.
+        setMsgSender(users.campaignCreator);
+        ISablierMerkleSignature(address(merkleVCA)).setAttestor(smartAttestor);
+        setMsgSender(users.recipient);
+
+        uint128 forgoneAmount = VCA_FULL_AMOUNT - VCA_CLAIM_AMOUNT;
+        uint256 previousFeeAccrued = address(comptroller).balance;
+        uint256 index = getIndexInMerkleTree();
+
+        vm.expectEmit({ emitter: address(merkleVCA) });
+        emit ISablierMerkleVCA.ClaimVCA({
+            index: index,
+            recipient: users.recipient,
+            claimAmount: VCA_CLAIM_AMOUNT,
+            forgoneAmount: forgoneAmount,
+            to: users.eve,
+            viaSig: false
+        });
+
+        expectCallToTransfer({ to: users.eve, value: VCA_CLAIM_AMOUNT });
+        claimViaAttestation();
+
+        assertTrue(merkleVCA.hasClaimed(index), "not claimed");
+        assertEq(merkleVCA.totalForgoneAmount(), forgoneAmount, "total forgone amount");
+        assertEq(address(comptroller).balance, previousFeeAccrued + AIRDROP_MIN_FEE_WEI, "fee collected");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                OVERRIDDEN-FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Overrides the {claimViaAttestation} function defined in {Integration_Test} to use VCA's function.
+    function claimViaAttestation(
+        uint256 msgValue,
+        uint256 index,
+        address to,
+        uint128 amount,
+        bytes32[] memory merkleProof,
+        bytes memory attestation
+    )
+        internal
+        override
+    {
+        ISablierMerkleVCA(address(merkleVCA)).claimViaAttestation{ value: msgValue }(
+            index, to, amount, merkleProof, attestation
+        );
+    }
+}

--- a/airdrops/tests/integration/concrete/campaign/vca/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/constructor.t.sol
@@ -26,6 +26,9 @@ contract Constructor_MerkleVCA_Integration_Test is Integration_Test {
         SablierMerkleVCA constructedVCA =
             new SablierMerkleVCA(constructorParams, users.campaignCreator, address(comptroller));
 
+        // SablierMerkleSignature
+        assertEq(constructedVCA.attestor(), attestor, "attestor");
+
         // SablierMerkleBase
         assertEq(constructedVCA.admin(), users.campaignCreator, "admin");
         assertEq(constructedVCA.campaignName(), CAMPAIGN_NAME, "campaign name");

--- a/airdrops/tests/integration/concrete/factory/execute/FactoryMerkleExecute.t.sol
+++ b/airdrops/tests/integration/concrete/factory/execute/FactoryMerkleExecute.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { ISablierFactoryMerkleBase } from "src/interfaces/ISablierFactoryMerkleBase.sol";
+import { ISablierMerkleBase } from "src/interfaces/ISablierMerkleBase.sol";
+import { Integration_Test } from "./../../../Integration.t.sol";
+
+import { SetNativeToken_Integration_Test } from "../shared/set-native-token/setNativeToken.t.sol";
+
+/*//////////////////////////////////////////////////////////////////////////
+                             NON-SHARED TESTS
+//////////////////////////////////////////////////////////////////////////*/
+
+abstract contract FactoryMerkleExecute_Integration_Shared_Test is Integration_Test {
+    function setUp() public virtual override {
+        Integration_Test.setUp();
+
+        // Cast the {FactoryMerkleExecute} contract as {ISablierFactoryMerkleBase}
+        factoryMerkleBase = ISablierFactoryMerkleBase(factoryMerkleExecute);
+
+        // Assert that the comptroller is set correctly.
+        assertEq(address(factoryMerkleBase.comptroller()), address(comptroller), "Comptroller mismatch");
+
+        // Set the `merkleBase` to the merkleExecute contract to use it in the tests.
+        merkleBase = ISablierMerkleBase(merkleExecute);
+
+        // Set the campaign type.
+        campaignType = "execute";
+
+        // Claim to collect some fees.
+        setMsgSender(users.recipient);
+        claim();
+    }
+}
+
+/*//////////////////////////////////////////////////////////////////////////
+                                SHARED TESTS
+//////////////////////////////////////////////////////////////////////////*/
+
+contract SetNativeToken_FactoryMerkleExecute_Integration_Test is
+    FactoryMerkleExecute_Integration_Shared_Test,
+    SetNativeToken_Integration_Test
+{
+    function setUp() public override(FactoryMerkleExecute_Integration_Shared_Test, Integration_Test) {
+        FactoryMerkleExecute_Integration_Shared_Test.setUp();
+    }
+}

--- a/airdrops/tests/utils/Constants.sol
+++ b/airdrops/tests/utils/Constants.sol
@@ -53,6 +53,7 @@ abstract contract Constants {
     string public constant SCHEMA_CLAIM =
         "Claim(uint256 index,address recipient,address to,uint128 amount,uint40 validFrom)";
     string public constant SCHEMA_EIP712_DOMAIN = "EIP712Domain(string name,uint256 chainId,address verifyingContract)";
+    string public constant SCHEMA_IDENTITY = "Identity(address recipient)";
 
     /*//////////////////////////////////////////////////////////////////////////
                                      IMMUTABLES

--- a/airdrops/tests/utils/Modifiers.sol
+++ b/airdrops/tests/utils/Modifiers.sol
@@ -20,6 +20,18 @@ abstract contract Modifiers is EvmUtilsBase {
                                        GIVEN
     //////////////////////////////////////////////////////////////////////////*/
 
+    modifier givenAttestorIsContract() {
+        _;
+    }
+
+    modifier givenAttestorIsEOA() {
+        _;
+    }
+
+    modifier givenAttestorNotZero() {
+        _;
+    }
+
     modifier givenCallerNotClaimed() {
         _;
     }
@@ -99,6 +111,10 @@ abstract contract Modifiers is EvmUtilsBase {
         _;
     }
 
+    modifier whenCallerNotCampaignCreator() {
+        _;
+    }
+
     modifier whenClaimTimeGreaterThanVestingStartTime() {
         _;
     }
@@ -148,6 +164,10 @@ abstract contract Modifiers is EvmUtilsBase {
     }
 
     modifier whenProvidedAddressNotZero() {
+        _;
+    }
+
+    modifier whenRecipientAddressNotZero() {
         _;
     }
 

--- a/airdrops/tests/utils/Types.sol
+++ b/airdrops/tests/utils/Types.sol
@@ -19,6 +19,11 @@ struct EIP712Domain {
     address verifyingContract;
 }
 
+/// @dev Struct to hold the Identity message parameters during ERC-712 attestation tests.
+struct Identity {
+    address recipient;
+}
+
 /// @dev Struct to hold the common parameters needed for fuzz tests.
 struct Params {
     uint128 clawbackAmount;

--- a/utils/src/interfaces/ISablierComptroller.sol
+++ b/utils/src/interfaces/ISablierComptroller.sol
@@ -45,6 +45,9 @@ interface ISablierComptroller is IERC165, IERC1822Proxiable, IRoleAdminable {
     /// @notice Emitted when a target contract is called.
     event Execute(address indexed target, bytes targetCallData, bytes result);
 
+    /// @notice Emitted when the attestor is set.
+    event SetAttestor(address indexed caller, address indexed previousAttestor, address indexed newAttestor);
+
     /// @notice Emitted when the admin or the fee manager sets a new minimum USD fee.
     event SetMinFeeUSD(Protocol indexed protocol, address caller, uint256 previousMinFeeUSD, uint256 newMinFeeUSD);
 
@@ -82,6 +85,10 @@ interface ISablierComptroller is IERC165, IERC1822Proxiable, IRoleAdminable {
     /// @notice The version of the comptroller contract.
     /// @dev This follows the format "v{Major}.{Minor}" (e.g., "v1.1").
     function VERSION() external view returns (string memory);
+
+    /// @notice Retrieves the attestor address used for verifying attestation signatures in merkle campaigns.
+    /// @dev A zero address indicates that the attestor is not set.
+    function attestor() external view returns (address);
 
     /// @notice Calculates the minimum fee in wei for the given protocol.
     /// @dev See the documentation for {convertUSDFeeToWei} for more details.
@@ -165,6 +172,35 @@ interface ISablierComptroller is IERC165, IERC1822Proxiable, IRoleAdminable {
     /// @param campaign The address of an existing campaign.
     /// @param newMinFeeUSD The new min USD fee to set, denominated in 8 decimals.
     function lowerMinFeeUSDForCampaign(address campaign, uint256 newMinFeeUSD) external;
+
+    /// @notice Sets the attestor address used for verifying attestation signatures in airdrop campaigns.
+    ///
+    /// @dev Emits a {SetAttestor} event.
+    ///
+    /// Notes:
+    /// - The default attestor to be used in merkle campaigns. It can be overridden by setting a different attestor in
+    /// the campaign contract.
+    /// - Setting it to zero address would disable attestation-based claims globally.
+    ///
+    /// Requirements:
+    /// - `msg.sender` must be either the admin or have the {IRoleAdminable.FEE_MANAGEMENT_ROLE} role.
+    ///
+    /// @param newAttestor The new attestor address. It can be the zero address.
+    function setAttestor(address newAttestor) external;
+
+    /// @notice Calls `setAttestor` function on an existing campaign contract.
+    ///
+    /// @dev Notes:
+    /// - This function is a pass-through to the campaign's `setAttestor` function.
+    /// - All validations are expected to be performed in the campaign's `setAttestor` function.
+    ///
+    /// Requirements:
+    /// - `msg.sender` must be either the admin or have the {IRoleAdminable.FEE_MANAGEMENT_ROLE} role.
+    /// - Setting it to zero address would allow merkle campaigns to use the default attestor.
+    ///
+    /// @param campaign The address of an existing campaign contract.
+    /// @param newAttestor The new attestor address.
+    function setAttestorForCampaign(address campaign, address newAttestor) external;
 
     /// @notice Sets the custom USD fee for the provided user for the given protocol.
     /// @dev Emits an {UpdateCustomFeeUSD} event.

--- a/utils/src/tests/BaseTest.sol
+++ b/utils/src/tests/BaseTest.sol
@@ -22,6 +22,8 @@ abstract contract BaseTest is BaseConstants, BaseUtils, StdCheats {
     //////////////////////////////////////////////////////////////////////////*/
 
     address internal admin;
+    address internal attestor;
+    uint256 internal attestorPrivateKey;
     ISablierComptroller internal comptroller;
     ContractWithoutReceive internal contractWithoutReceive;
     ContractWithReceive internal contractWithReceive;
@@ -51,9 +53,17 @@ abstract contract BaseTest is BaseConstants, BaseUtils, StdCheats {
             )
         );
 
+        // Create the attestor address and store the private key for signing purposes.
+        (attestor, attestorPrivateKey) = makeAddrAndKey({ name: "Attestor" });
+
+        // Set the default attestor in the comptroller.
+        vm.prank(admin);
+        comptroller.setAttestor(attestor);
+
         // Label the contracts.
-        vm.label(address(oracle), "Oracle");
+        vm.label(attestor, "Attestor");
         vm.label(address(comptroller), "Comptroller");
+        vm.label(address(oracle), "Oracle");
 
         // Deploy the tokens.
         dai = new ERC20Mock("Dai stablecoin", "DAI", 18);

--- a/utils/tests/Base.t.sol
+++ b/utils/tests/Base.t.sol
@@ -12,6 +12,7 @@ import { NoDelegateCallMock } from "src/mocks/NoDelegateCallMock.sol";
 import { RoleAdminableMock } from "src/mocks/RoleAdminableMock.sol";
 import { BaseTest } from "src/tests/BaseTest.sol";
 
+import { MerkleMock } from "./mocks/MerkleMock.sol";
 import { Modifiers } from "./utils/Modifiers.sol";
 import { Users } from "./utils/Types.sol";
 import { Utils } from "./utils/Utils.sol";
@@ -37,6 +38,7 @@ abstract contract Base_Test is BaseTest, Modifiers, StdAssertions, Utils {
     AdminableMock internal adminableMock;
     BatchMock internal batchMock;
     ComptrollerableMock internal comptrollerableMock;
+    MerkleMock internal merkleMock;
     NoDelegateCallMock internal noDelegateCallMock;
     RoleAdminableMock internal roleAdminableMock;
 
@@ -59,6 +61,7 @@ abstract contract Base_Test is BaseTest, Modifiers, StdAssertions, Utils {
         adminableMock = new AdminableMock(admin);
         batchMock = new BatchMock();
         comptrollerableMock = new ComptrollerableMock(address(comptroller));
+        merkleMock = new MerkleMock();
         noDelegateCallMock = new NoDelegateCallMock();
         roleAdminableMock = new RoleAdminableMock(admin);
 

--- a/utils/tests/integration/concrete/comptroller/constructor.t.sol
+++ b/utils/tests/integration/concrete/comptroller/constructor.t.sol
@@ -8,6 +8,7 @@ import { Base_Test } from "tests/Base.t.sol";
 contract Constructor_Comptroller_Concrete_Test is Base_Test {
     function test_Constructor() public view {
         assertEq(comptroller.admin(), admin, "admin");
+        assertEq(comptroller.attestor(), attestor, "attestor");
         assertEq(comptroller.MAX_FEE_USD(), MAX_FEE_USD, "max fee USD");
         bytes4 expectedMinimalInterfaceId = ISablierComptroller.calculateMinFeeWeiFor.selector
             ^ ISablierComptroller.convertUSDFeeToWei.selector ^ ISablierComptroller.execute.selector

--- a/utils/tests/integration/concrete/comptroller/lower-min-fee-usd-for-campaign/lowerMinFeeUSDForCampaign.t.sol
+++ b/utils/tests/integration/concrete/comptroller/lower-min-fee-usd-for-campaign/lowerMinFeeUSDForCampaign.t.sol
@@ -4,29 +4,10 @@ pragma solidity >=0.8.22;
 import { Errors } from "src/libraries/Errors.sol";
 
 import { Base_Test } from "tests/Base.t.sol";
-import {
-    MerkleMock,
-    MerkleMockReverting,
-    MerkleMockWithFalseIsSablierMerkle,
-    MerkleMockWithMissingIsSablierMerkle
-} from "tests/mocks/MerkleMock.sol";
+import { MerkleMockReverting } from "tests/mocks/MerkleMock.sol";
 
 contract LowerMinFeeUSDForCampaign_Comptroller_Concrete_Test is Base_Test {
-    MerkleMock internal merkleMock;
-    MerkleMockReverting internal merkleMockReverting;
-    MerkleMockWithFalseIsSablierMerkle internal merkleMockWithFalseIsSablierMerkle;
-    MerkleMockWithMissingIsSablierMerkle internal merkleMockWithMissingIsSablierMerkle;
     uint256 internal newMinFeeUSD = AIRDROP_MIN_FEE_USD - 1;
-
-    function setUp() public override {
-        Base_Test.setUp();
-
-        // Deploy mock contracts.
-        merkleMock = new MerkleMock();
-        merkleMockReverting = new MerkleMockReverting();
-        merkleMockWithFalseIsSablierMerkle = new MerkleMockWithFalseIsSablierMerkle();
-        merkleMockWithMissingIsSablierMerkle = new MerkleMockWithMissingIsSablierMerkle();
-    }
 
     function test_RevertWhen_CallerWithoutFeeManagementRole() external whenCallerNotAdmin {
         setMsgSender(users.eve);
@@ -49,6 +30,8 @@ contract LowerMinFeeUSDForCampaign_Comptroller_Concrete_Test is Base_Test {
         whenCampaignImplementsSablierMerkle
         whenCampaignReturnsTrueForSablierMerkle
     {
+        MerkleMockReverting merkleMockReverting = new MerkleMockReverting();
+
         // It should revert.
         vm.expectRevert("Not gonna happen");
         comptroller.lowerMinFeeUSDForCampaign(address(merkleMockReverting), newMinFeeUSD);

--- a/utils/tests/integration/concrete/comptroller/set-attestor-for-campaign/setAttestorForCampaign.t.sol
+++ b/utils/tests/integration/concrete/comptroller/set-attestor-for-campaign/setAttestorForCampaign.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { Errors } from "src/libraries/Errors.sol";
+
+import { Base_Test } from "tests/Base.t.sol";
+import { MerkleMockReverting } from "tests/mocks/MerkleMock.sol";
+
+contract SetAttestorForCampaign_Comptroller_Concrete_Test is Base_Test {
+    address internal newAttestor = makeAddr("newAttestor");
+
+    function test_RevertWhen_CallerWithoutFeeManagementRole() external whenCallerNotAdmin {
+        setMsgSender(users.eve);
+
+        // It should revert.
+        vm.expectRevert(abi.encodeWithSelector(Errors.UnauthorizedAccess.selector, users.eve, FEE_MANAGEMENT_ROLE));
+        comptroller.setAttestorForCampaign(address(merkleMock), newAttestor);
+    }
+
+    function test_WhenCallerWithFeeManagementRole() external whenCallerNotAdmin {
+        setMsgSender(users.accountant);
+
+        // It should succeed.
+        comptroller.setAttestorForCampaign(address(merkleMock), newAttestor);
+    }
+
+    function test_RevertWhen_CallReverts() external whenCallerAdmin {
+        MerkleMockReverting merkleMockReverting = new MerkleMockReverting();
+
+        // It should revert.
+        vm.expectRevert("Not gonna happen");
+        comptroller.setAttestorForCampaign(address(merkleMockReverting), newAttestor);
+    }
+
+    function test_WhenCallDoesNotRevert() external whenCallerAdmin {
+        // It should succeed.
+        comptroller.setAttestorForCampaign(address(merkleMock), newAttestor);
+    }
+}

--- a/utils/tests/integration/concrete/comptroller/set-attestor-for-campaign/setAttestorForCampaign.tree
+++ b/utils/tests/integration/concrete/comptroller/set-attestor-for-campaign/setAttestorForCampaign.tree
@@ -1,0 +1,11 @@
+SetAttestorForCampaign_Comptroller_Concrete_Test
+├── when caller not admin
+│  ├── when caller without fee management role
+│  │  └── it should revert
+│  └── when caller with fee management role
+│     └── it should succeed
+└── when caller admin
+   ├── when call reverts
+   │  └── it should revert
+   └── when call does not revert
+      └── it should succeed

--- a/utils/tests/integration/concrete/comptroller/set-attestor/setAttestor.t.sol
+++ b/utils/tests/integration/concrete/comptroller/set-attestor/setAttestor.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
+import { Errors } from "src/libraries/Errors.sol";
+
+import { Base_Test } from "tests/Base.t.sol";
+
+contract SetAttestor_Comptroller_Concrete_Test is Base_Test {
+    address internal newAttestor = makeAddr("newAttestor");
+
+    function test_RevertWhen_CallerWithoutFeeManagementRole() external whenCallerNotAdmin {
+        setMsgSender(users.eve);
+
+        // It should revert.
+        vm.expectRevert(abi.encodeWithSelector(Errors.UnauthorizedAccess.selector, users.eve, FEE_MANAGEMENT_ROLE));
+        comptroller.setAttestor(newAttestor);
+    }
+
+    function test_WhenCallerWithFeeManagementRole() external whenCallerNotAdmin {
+        setMsgSender(users.accountant);
+
+        address currentAttestor = comptroller.attestor();
+
+        // It should emit a {SetAttestor} event.
+        vm.expectEmit({ emitter: address(comptroller) });
+        emit ISablierComptroller.SetAttestor(users.accountant, currentAttestor, newAttestor);
+
+        // Set the new attestor.
+        comptroller.setAttestor(newAttestor);
+
+        // It should set the attestor.
+        assertEq(comptroller.attestor(), newAttestor, "attestor");
+    }
+
+    function test_WhenCallerAdmin() external whenCallerAdmin {
+        address currentAttestor = comptroller.attestor();
+
+        // It should emit a {SetAttestor} event.
+        vm.expectEmit({ emitter: address(comptroller) });
+        emit ISablierComptroller.SetAttestor(admin, currentAttestor, newAttestor);
+
+        // Set the new attestor.
+        comptroller.setAttestor(newAttestor);
+
+        // It should set the attestor.
+        assertEq(comptroller.attestor(), newAttestor, "attestor");
+    }
+}

--- a/utils/tests/integration/concrete/comptroller/set-attestor/setAttestor.tree
+++ b/utils/tests/integration/concrete/comptroller/set-attestor/setAttestor.tree
@@ -1,0 +1,10 @@
+SetAttestor_Comptroller_Concrete_Test
+├── when caller not admin
+│  ├── when caller without fee management role
+│  │  └── it should revert
+│  └── when caller with fee management role
+│     ├── it should set the attestor
+│     └── it should emit a {SetAttestor} event
+└── when caller admin
+   ├── it should set the attestor
+   └── it should emit a {SetAttestor} event

--- a/utils/tests/mocks/MerkleMock.sol
+++ b/utils/tests/mocks/MerkleMock.sol
@@ -7,6 +7,8 @@ contract MerkleMock {
     }
 
     function lowerMinFeeUSD(uint256 newMinFeeUSD) external { }
+
+    function setAttestor(address newAttestor) external { }
 }
 
 contract MerkleMockReverting {
@@ -17,14 +19,8 @@ contract MerkleMockReverting {
     function lowerMinFeeUSD(uint256) external pure {
         revert("Not gonna happen");
     }
-}
 
-contract MerkleMockWithFalseIsSablierMerkle {
-    function IS_SABLIER_MERKLE() external pure returns (bool) { }
-
-    function lowerMinFeeUSD(uint256 newMinFeeUSD) external { }
-}
-
-contract MerkleMockWithMissingIsSablierMerkle {
-    function lowerMinFeeUSD(uint256 newMinFeeUSD) external { }
+    function setAttestor(address) external pure {
+        revert("Not gonna happen");
+    }
 }


### PR DESCRIPTION
Closes https://github.com/sablier-labs/lockup/issues/1358

Q: add examples in `claimViaAttestation`, or keep the note about `claimViaSig` only?

---

note: if the attestor is changed, and a signature was created before that, the signature wouldn’t be valid anymore.
note: with the current identity hash, once a recipient has completed kyc, they can claim multiple airdrops (if eligible) with the same signature (intended)

note: due to more params in the merkle constructor, i faced issues with the "stack-too-deep" error - so, i added the new ConstructorParams struct for `MerkleBase` and `MerkleLockup`