### PR TITLE
feat: claim-type

### DIFF
--- a/airdrops/scripts/solidity/CreateMerkleInstant.s.sol
+++ b/airdrops/scripts/solidity/CreateMerkleInstant.s.sol
@@ -6,21 +6,23 @@ import { BaseScript as EvmUtilsBaseScript } from "@sablier/evm-utils/src/tests/B
 
 import { ISablierMerkleInstant } from "../../src/interfaces/ISablierMerkleInstant.sol";
 import { SablierFactoryMerkleInstant } from "../../src/SablierFactoryMerkleInstant.sol";
-import { MerkleInstant } from "../../src/types/DataTypes.sol";
+import { ClaimType, MerkleInstant } from "../../src/types/DataTypes.sol";
 
 /// @dev Creates a dummy MerkleInstant campaign.
 contract CreateMerkleInstant is EvmUtilsBaseScript {
     /// @dev Deploy via Forge.
     function run(SablierFactoryMerkleInstant factory) public broadcast returns (ISablierMerkleInstant merkleInstant) {
         // Prepare the constructor parameters.
-        MerkleInstant.ConstructorParams memory campaignParams;
-        campaignParams.campaignName = "The Boys Instant";
-        campaignParams.campaignStartTime = uint40(block.timestamp);
-        campaignParams.expiration = uint40(block.timestamp + 30 days);
-        campaignParams.initialAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
-        campaignParams.ipfsCID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
-        campaignParams.merkleRoot = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        campaignParams.token = IERC20(0xf983A617DA60e88c112D52F00f9Fab17851D2feF);
+        MerkleInstant.ConstructorParams memory campaignParams = MerkleInstant.ConstructorParams({
+            campaignName: "The Boys Instant",
+            campaignStartTime: uint40(block.timestamp),
+            claimType: ClaimType.DEFAULT,
+            expiration: uint40(block.timestamp + 30 days),
+            initialAdmin: 0x79Fb3e81aAc012c08501f41296CCC145a1E15844,
+            ipfsCID: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+            merkleRoot: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            token: IERC20(0xf983A617DA60e88c112D52F00f9Fab17851D2feF)
+        });
 
         // The total amount to airdrop through the campaign.
         uint256 aggregateAmount = 10_000e18;

--- a/airdrops/scripts/solidity/CreateMerkleLL.s.sol
+++ b/airdrops/scripts/solidity/CreateMerkleLL.s.sol
@@ -8,7 +8,7 @@ import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.so
 
 import { ISablierMerkleLL } from "../../src/interfaces/ISablierMerkleLL.sol";
 import { SablierFactoryMerkleLL } from "../../src/SablierFactoryMerkleLL.sol";
-import { MerkleLL } from "../../src/types/DataTypes.sol";
+import { ClaimType, MerkleLL } from "../../src/types/DataTypes.sol";
 
 /// @dev Creates a dummy campaign to airdrop tokens through Lockup Linear.
 contract CreateMerkleLL is EvmUtilsBaseScript {
@@ -23,23 +23,26 @@ contract CreateMerkleLL is EvmUtilsBaseScript {
         returns (ISablierMerkleLL merkleLL)
     {
         // Prepare the constructor parameters.
-        MerkleLL.ConstructorParams memory campaignParams;
-        campaignParams.campaignName = "The Boys LL";
-        campaignParams.campaignStartTime = uint40(block.timestamp);
-        campaignParams.cancelable = true;
-        campaignParams.cliffDuration = 30 days;
-        campaignParams.cliffUnlockPercentage = ud60x18(0.01e18);
-        campaignParams.expiration = uint40(block.timestamp + 30 days);
-        campaignParams.initialAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
-        campaignParams.ipfsCID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
-        campaignParams.lockup = lockup;
-        campaignParams.merkleRoot = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        campaignParams.shape = "LL";
-        campaignParams.startUnlockPercentage = ud60x18(0.01e18);
-        campaignParams.vestingStartTime = 0; // i.e. block.timestamp
-        campaignParams.token = token;
-        campaignParams.totalDuration = 90 days;
-        campaignParams.transferable = true;
+        MerkleLL.ConstructorParams memory campaignParams = MerkleLL.ConstructorParams({
+            campaignName: "The Boys LL",
+            campaignStartTime: uint40(block.timestamp),
+            cancelable: true,
+            claimType: ClaimType.DEFAULT,
+            cliffDuration: 30 days,
+            cliffUnlockPercentage: ud60x18(0.01e18),
+            expiration: uint40(block.timestamp + 30 days),
+            granularity: 0, // i.e. 1 second
+            initialAdmin: 0x79Fb3e81aAc012c08501f41296CCC145a1E15844,
+            ipfsCID: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+            lockup: lockup,
+            merkleRoot: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            shape: "LL",
+            startUnlockPercentage: ud60x18(0.01e18),
+            token: token,
+            totalDuration: 90 days,
+            transferable: true,
+            vestingStartTime: 0 // i.e. block.timestamp
+        });
 
         uint256 aggregateAmount = 10_000e18;
         uint256 recipientCount = 100;

--- a/airdrops/scripts/solidity/CreateMerkleLT.s.sol
+++ b/airdrops/scripts/solidity/CreateMerkleLT.s.sol
@@ -8,7 +8,7 @@ import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.so
 import { ISablierMerkleLT } from "../../src/interfaces/ISablierMerkleLT.sol";
 import { SablierFactoryMerkleLT } from "../../src/SablierFactoryMerkleLT.sol";
 
-import { MerkleLT } from "../../src/types/DataTypes.sol";
+import { ClaimType, MerkleLT } from "../../src/types/DataTypes.sol";
 
 /// @dev Creates a dummy campaign to airdrop tokens through Lockup Tranched.
 contract CreateMerkleLT is EvmUtilsBaseScript {
@@ -22,27 +22,29 @@ contract CreateMerkleLT is EvmUtilsBaseScript {
         broadcast
         returns (ISablierMerkleLT merkleLT)
     {
-        // Prepare the constructor parameters.
-        MerkleLT.ConstructorParams memory campaignParams;
-        campaignParams.campaignName = "The Boys LT";
-        campaignParams.campaignStartTime = uint40(block.timestamp);
-        campaignParams.cancelable = true;
-        campaignParams.expiration = uint40(block.timestamp + 30 days);
-        campaignParams.lockup = lockup;
-        campaignParams.initialAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
-        campaignParams.ipfsCID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
-        campaignParams.merkleRoot = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        campaignParams.token = token;
-        campaignParams.transferable = true;
-
         // The tranches with their unlock percentages and durations.
-        campaignParams.tranchesWithPercentages = new MerkleLT.TrancheWithPercentage[](2);
-        campaignParams.tranchesWithPercentages[0] =
-            MerkleLT.TrancheWithPercentage({ unlockPercentage: ud2x18(0.5e18), duration: 3600 });
-        campaignParams.tranchesWithPercentages[1] =
-            MerkleLT.TrancheWithPercentage({ unlockPercentage: ud2x18(0.5e18), duration: 7200 });
+        MerkleLT.TrancheWithPercentage[] memory tranches = new MerkleLT.TrancheWithPercentage[](2);
+        tranches[0] = MerkleLT.TrancheWithPercentage({ unlockPercentage: ud2x18(0.5e18), duration: 3600 });
+        tranches[1] = MerkleLT.TrancheWithPercentage({ unlockPercentage: ud2x18(0.5e18), duration: 7200 });
 
-        campaignParams.vestingStartTime = 0; // i.e. block.timestamp
+        // Prepare the constructor parameters.
+        MerkleLT.ConstructorParams memory campaignParams = MerkleLT.ConstructorParams({
+            campaignName: "The Boys LT",
+            campaignStartTime: uint40(block.timestamp),
+            cancelable: true,
+            claimType: ClaimType.DEFAULT,
+            expiration: uint40(block.timestamp + 30 days),
+            initialAdmin: 0x79Fb3e81aAc012c08501f41296CCC145a1E15844,
+            ipfsCID: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+            lockup: lockup,
+            merkleRoot: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            shape: "LT",
+            token: token,
+            tranchesWithPercentages: tranches,
+            transferable: true,
+            vestingStartTime: 0 // i.e. block.timestamp
+        });
+
         uint256 aggregateAmount = 10_000e18;
         uint256 recipientCount = 100;
 

--- a/airdrops/scripts/solidity/CreateMerkleVCA.s.sol
+++ b/airdrops/scripts/solidity/CreateMerkleVCA.s.sol
@@ -2,28 +2,33 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ud } from "@prb/math/src/UD60x18.sol";
 import { BaseScript as EvmUtilsBaseScript } from "@sablier/evm-utils/src/tests/BaseScript.sol";
 
 import { ISablierMerkleVCA } from "../../src/interfaces/ISablierMerkleVCA.sol";
 import { SablierFactoryMerkleVCA } from "../../src/SablierFactoryMerkleVCA.sol";
-import { MerkleVCA } from "../../src/types/DataTypes.sol";
+import { ClaimType, MerkleVCA } from "../../src/types/DataTypes.sol";
 
 /// @dev Creates a dummy MerkleVCA campaign.
 contract CreateMerkleVCA is EvmUtilsBaseScript {
     /// @dev Deploy via Forge.
     function run(SablierFactoryMerkleVCA factory) public broadcast returns (ISablierMerkleVCA merkleVCA) {
         // Prepare the constructor parameters.
-        MerkleVCA.ConstructorParams memory campaignParams;
-        campaignParams.aggregateAmount = 10_000e18;
-        campaignParams.campaignName = "The Boys VCA";
-        campaignParams.campaignStartTime = uint40(block.timestamp);
-        campaignParams.expiration = uint40(block.timestamp + 400 days);
-        campaignParams.initialAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
-        campaignParams.ipfsCID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
-        campaignParams.merkleRoot = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        campaignParams.token = IERC20(0xf983A617DA60e88c112D52F00f9Fab17851D2feF);
-        campaignParams.vestingEndTime = uint40(block.timestamp + 365 days);
-        campaignParams.vestingStartTime = uint40(block.timestamp);
+        MerkleVCA.ConstructorParams memory campaignParams = MerkleVCA.ConstructorParams({
+            aggregateAmount: 10_000e18,
+            campaignName: "The Boys VCA",
+            campaignStartTime: uint40(block.timestamp),
+            claimType: ClaimType.DEFAULT,
+            enableRedistribution: false,
+            expiration: uint40(block.timestamp + 400 days),
+            initialAdmin: 0x79Fb3e81aAc012c08501f41296CCC145a1E15844,
+            ipfsCID: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+            merkleRoot: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            token: IERC20(0xf983A617DA60e88c112D52F00f9Fab17851D2feF),
+            unlockPercentage: ud(0.1e18),
+            vestingEndTime: uint40(block.timestamp + 365 days),
+            vestingStartTime: uint40(block.timestamp)
+        });
 
         // The number of eligible users for the airdrop.
         uint256 recipientCount = 100;

--- a/airdrops/src/SablierMerkleExecute.sol
+++ b/airdrops/src/SablierMerkleExecute.sol
@@ -88,7 +88,6 @@ contract SablierMerkleExecute is
         external
         payable
         override
-        revertIfNot(ClaimType.EXECUTE)
         nonReentrant
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.

--- a/airdrops/src/SablierMerkleExecute.sol
+++ b/airdrops/src/SablierMerkleExecute.sol
@@ -7,7 +7,7 @@ import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.s
 
 import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { ISablierMerkleExecute } from "./interfaces/ISablierMerkleExecute.sol";
-import { MerkleBase, MerkleExecute } from "./types/DataTypes.sol";
+import { ClaimType, MerkleBase, MerkleExecute } from "./types/DataTypes.sol";
 
 /*
 
@@ -60,6 +60,7 @@ contract SablierMerkleExecute is
                 campaignCreator: campaignCreator,
                 campaignName: campaignParams.campaignName,
                 campaignStartTime: campaignParams.campaignStartTime,
+                claimType: ClaimType.EXECUTE,
                 comptroller: comptroller,
                 expiration: campaignParams.expiration,
                 initialAdmin: campaignParams.initialAdmin,
@@ -87,6 +88,7 @@ contract SablierMerkleExecute is
         external
         payable
         override
+        revertIfNot(ClaimType.EXECUTE)
         nonReentrant
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.

--- a/airdrops/src/SablierMerkleInstant.sol
+++ b/airdrops/src/SablierMerkleInstant.sol
@@ -49,6 +49,7 @@ contract SablierMerkleInstant is
                 campaignCreator: campaignCreator,
                 campaignName: campaignParams.campaignName,
                 campaignStartTime: campaignParams.campaignStartTime,
+                claimType: campaignParams.claimType,
                 comptroller: comptroller,
                 expiration: campaignParams.expiration,
                 initialAdmin: campaignParams.initialAdmin,

--- a/airdrops/src/SablierMerkleInstant.sol
+++ b/airdrops/src/SablierMerkleInstant.sol
@@ -72,7 +72,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);
@@ -91,7 +91,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -112,7 +112,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
-        checkClaimType(ClaimType.ATTEST)
+        revertIfNot(ClaimType.ATTEST)
         notZeroAddress(to)
     {
         // Check: the attestation signature is valid and the recovered signer matches the attestor.
@@ -138,7 +138,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/SablierMerkleInstant.sol
+++ b/airdrops/src/SablierMerkleInstant.sol
@@ -7,7 +7,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { SablierMerkleSignature } from "./abstracts/SablierMerkleSignature.sol";
 import { ISablierMerkleInstant } from "./interfaces/ISablierMerkleInstant.sol";
-import { MerkleBase, MerkleInstant } from "./types/DataTypes.sol";
+import { ClaimType, MerkleBase, MerkleInstant } from "./types/DataTypes.sol";
 
 /*
 
@@ -72,6 +72,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);
@@ -90,6 +91,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -110,6 +112,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
+        checkClaimType(ClaimType.ATTEST)
         notZeroAddress(to)
     {
         // Check: the attestation signature is valid and the recovered signer matches the attestor.
@@ -135,6 +138,7 @@ contract SablierMerkleInstant is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/SablierMerkleLL.sol
+++ b/airdrops/src/SablierMerkleLL.sol
@@ -10,7 +10,7 @@ import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { SablierMerkleLockup } from "./abstracts/SablierMerkleLockup.sol";
 import { SablierMerkleSignature } from "./abstracts/SablierMerkleSignature.sol";
 import { ISablierMerkleLL } from "./interfaces/ISablierMerkleLL.sol";
-import { MerkleBase, MerkleLL, MerkleLockup } from "./types/DataTypes.sol";
+import { ClaimType, MerkleBase, MerkleLL, MerkleLockup } from "./types/DataTypes.sol";
 
 /*
 
@@ -113,6 +113,7 @@ contract SablierMerkleLL is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);
@@ -131,6 +132,7 @@ contract SablierMerkleLL is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -151,6 +153,7 @@ contract SablierMerkleLL is
         external
         payable
         override
+        checkClaimType(ClaimType.ATTEST)
         notZeroAddress(to)
     {
         // Check: the attestation signature is valid and the recovered signer matches the attestor.
@@ -176,6 +179,7 @@ contract SablierMerkleLL is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/SablierMerkleLL.sol
+++ b/airdrops/src/SablierMerkleLL.sol
@@ -76,6 +76,7 @@ contract SablierMerkleLL is
                 campaignCreator: campaignCreator,
                 campaignName: campaignParams.campaignName,
                 campaignStartTime: campaignParams.campaignStartTime,
+                claimType: campaignParams.claimType,
                 comptroller: comptroller,
                 expiration: campaignParams.expiration,
                 initialAdmin: campaignParams.initialAdmin,

--- a/airdrops/src/SablierMerkleLL.sol
+++ b/airdrops/src/SablierMerkleLL.sol
@@ -113,7 +113,7 @@ contract SablierMerkleLL is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);
@@ -132,7 +132,7 @@ contract SablierMerkleLL is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -153,7 +153,7 @@ contract SablierMerkleLL is
         external
         payable
         override
-        checkClaimType(ClaimType.ATTEST)
+        revertIfNot(ClaimType.ATTEST)
         notZeroAddress(to)
     {
         // Check: the attestation signature is valid and the recovered signer matches the attestor.
@@ -179,7 +179,7 @@ contract SablierMerkleLL is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/SablierMerkleLT.sol
+++ b/airdrops/src/SablierMerkleLT.sol
@@ -64,6 +64,7 @@ contract SablierMerkleLT is
                 campaignCreator: campaignCreator,
                 campaignName: campaignParams.campaignName,
                 campaignStartTime: campaignParams.campaignStartTime,
+                claimType: campaignParams.claimType,
                 comptroller: comptroller,
                 expiration: campaignParams.expiration,
                 initialAdmin: campaignParams.initialAdmin,

--- a/airdrops/src/SablierMerkleLT.sol
+++ b/airdrops/src/SablierMerkleLT.sol
@@ -10,7 +10,7 @@ import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { SablierMerkleLockup } from "./abstracts/SablierMerkleLockup.sol";
 import { SablierMerkleSignature } from "./abstracts/SablierMerkleSignature.sol";
 import { ISablierMerkleLT } from "./interfaces/ISablierMerkleLT.sol";
-import { MerkleBase, MerkleLockup, MerkleLT } from "./types/DataTypes.sol";
+import { ClaimType, MerkleBase, MerkleLockup, MerkleLT } from "./types/DataTypes.sol";
 
 /*
 
@@ -110,6 +110,7 @@ contract SablierMerkleLT is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);
@@ -128,6 +129,7 @@ contract SablierMerkleLT is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -148,6 +150,7 @@ contract SablierMerkleLT is
         external
         payable
         override
+        checkClaimType(ClaimType.ATTEST)
         notZeroAddress(to)
     {
         // Check: the attestation signature is valid and the recovered signer matches the attestor.
@@ -173,6 +176,7 @@ contract SablierMerkleLT is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/SablierMerkleLT.sol
+++ b/airdrops/src/SablierMerkleLT.sol
@@ -110,7 +110,7 @@ contract SablierMerkleLT is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of the recipient.
         _preProcessClaim(index, recipient, amount, merkleProof);
@@ -129,7 +129,7 @@ contract SablierMerkleLT is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -150,7 +150,7 @@ contract SablierMerkleLT is
         external
         payable
         override
-        checkClaimType(ClaimType.ATTEST)
+        revertIfNot(ClaimType.ATTEST)
         notZeroAddress(to)
     {
         // Check: the attestation signature is valid and the recovered signer matches the attestor.
@@ -176,7 +176,7 @@ contract SablierMerkleLT is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/SablierMerkleVCA.sol
+++ b/airdrops/src/SablierMerkleVCA.sol
@@ -154,7 +154,7 @@ contract SablierMerkleVCA is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -200,7 +200,7 @@ contract SablierMerkleVCA is
         external
         payable
         override
-        checkClaimType(ClaimType.DEFAULT)
+        revertIfNot(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/SablierMerkleVCA.sol
+++ b/airdrops/src/SablierMerkleVCA.sol
@@ -176,6 +176,7 @@ contract SablierMerkleVCA is
         external
         payable
         override
+        revertIfNot(ClaimType.ATTEST)
         notZeroAddress(to)
     {
         // Check: the attestation signature is valid and the recovered signer matches the attestor.

--- a/airdrops/src/SablierMerkleVCA.sol
+++ b/airdrops/src/SablierMerkleVCA.sol
@@ -78,6 +78,7 @@ contract SablierMerkleVCA is
                 campaignCreator: campaignCreator,
                 campaignName: campaignParams.campaignName,
                 campaignStartTime: campaignParams.campaignStartTime,
+                claimType: campaignParams.claimType,
                 comptroller: comptroller,
                 expiration: campaignParams.expiration,
                 initialAdmin: campaignParams.initialAdmin,

--- a/airdrops/src/SablierMerkleVCA.sol
+++ b/airdrops/src/SablierMerkleVCA.sol
@@ -10,7 +10,7 @@ import { SablierMerkleBase } from "./abstracts/SablierMerkleBase.sol";
 import { SablierMerkleSignature } from "./abstracts/SablierMerkleSignature.sol";
 import { ISablierMerkleVCA } from "./interfaces/ISablierMerkleVCA.sol";
 import { Errors } from "./libraries/Errors.sol";
-import { MerkleBase, MerkleVCA } from "./types/DataTypes.sol";
+import { ClaimType, MerkleBase, MerkleVCA } from "./types/DataTypes.sol";
 
 /*
 
@@ -154,6 +154,7 @@ contract SablierMerkleVCA is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check, Effect and Interaction: Pre-process the claim parameters on behalf of `msg.sender`.
@@ -199,6 +200,7 @@ contract SablierMerkleVCA is
         external
         payable
         override
+        checkClaimType(ClaimType.DEFAULT)
         notZeroAddress(to)
     {
         // Check: the signature is valid and the recovered signer matches the recipient.

--- a/airdrops/src/abstracts/SablierMerkleBase.sol
+++ b/airdrops/src/abstracts/SablierMerkleBase.sol
@@ -29,6 +29,9 @@ abstract contract SablierMerkleBase is
     uint40 public immutable override CAMPAIGN_START_TIME;
 
     /// @inheritdoc ISablierMerkleBase
+    ClaimType public immutable override CLAIM_TYPE;
+
+    /// @inheritdoc ISablierMerkleBase
     address public immutable override COMPTROLLER;
 
     /// @inheritdoc ISablierMerkleBase
@@ -45,9 +48,6 @@ abstract contract SablierMerkleBase is
 
     /// @inheritdoc ISablierMerkleBase
     string public override campaignName;
-
-    /// @inheritdoc ISablierMerkleBase
-    ClaimType public override claimType;
 
     /// @inheritdoc ISablierMerkleBase
     uint40 public override firstClaimTime;
@@ -75,10 +75,10 @@ abstract contract SablierMerkleBase is
 
     /// @dev Modifier to revert if `claimType_` value does not match the campaign's claim type.
     modifier revertIfNot(ClaimType claimType_) {
-        if (claimType != claimType_) {
+        if (CLAIM_TYPE != claimType_) {
             revert Errors.SablierMerkleBase_InvalidClaimType({
                 claimTypeCalled: claimType_,
-                claimTypeSupported: claimType
+                claimTypeSupported: CLAIM_TYPE
             });
         }
         _;
@@ -91,13 +91,13 @@ abstract contract SablierMerkleBase is
     /// @notice Constructs the contract by initializing the immutable state variables.
     constructor(MerkleBase.ConstructorParams memory baseParams) Adminable(baseParams.initialAdmin) {
         CAMPAIGN_START_TIME = baseParams.campaignStartTime;
+        CLAIM_TYPE = baseParams.claimType;
         COMPTROLLER = baseParams.comptroller;
         EXPIRATION = baseParams.expiration;
         MERKLE_ROOT = baseParams.merkleRoot;
         TOKEN = baseParams.token;
 
         campaignName = baseParams.campaignName;
-        claimType = baseParams.claimType;
         ipfsCID = baseParams.ipfsCID;
         minFeeUSD = ISablierComptroller(baseParams.comptroller)
             .getMinFeeUSDFor({ protocol: ISablierComptroller.Protocol.Airdrops, user: baseParams.campaignCreator });

--- a/airdrops/src/abstracts/SablierMerkleBase.sol
+++ b/airdrops/src/abstracts/SablierMerkleBase.sol
@@ -73,11 +73,11 @@ abstract contract SablierMerkleBase is
         _;
     }
 
-    /// @dev Modifier to revert if `claimType_` value does not match the campaign's claim type.
-    modifier revertIfNot(ClaimType claimType_) {
-        if (CLAIM_TYPE != claimType_) {
-            revert Errors.SablierMerkleBase_InvalidClaimType({
-                claimTypeCalled: claimType_,
+    /// @dev Modifier to revert if `claimType` value does not match the campaign's claim type.
+    modifier revertIfNot(ClaimType claimType) {
+        if (CLAIM_TYPE != claimType) {
+            revert Errors.SablierMerkleBase_UnsupportedClaimType({
+                claimTypeRequired: claimType,
                 claimTypeSupported: CLAIM_TYPE
             });
         }

--- a/airdrops/src/abstracts/SablierMerkleBase.sol
+++ b/airdrops/src/abstracts/SablierMerkleBase.sol
@@ -65,7 +65,6 @@ abstract contract SablierMerkleBase is
     /// @dev Modifier to check that `to` is not zero address.
     modifier notZeroAddress(address to) {
         _revertIfToZeroAddress(to);
-
         _;
     }
 

--- a/airdrops/src/abstracts/SablierMerkleBase.sol
+++ b/airdrops/src/abstracts/SablierMerkleBase.sol
@@ -10,7 +10,7 @@ import { ISablierComptroller } from "@sablier/evm-utils/src/interfaces/ISablierC
 
 import { ISablierMerkleBase } from "./../interfaces/ISablierMerkleBase.sol";
 import { Errors } from "./../libraries/Errors.sol";
-import { MerkleBase } from "./../types/DataTypes.sol";
+import { ClaimType, MerkleBase } from "./../types/DataTypes.sol";
 
 /// @title SablierMerkleBase
 /// @notice See the documentation in {ISablierMerkleBase}.
@@ -47,6 +47,9 @@ abstract contract SablierMerkleBase is
     string public override campaignName;
 
     /// @inheritdoc ISablierMerkleBase
+    ClaimType public override claimType;
+
+    /// @inheritdoc ISablierMerkleBase
     uint40 public override firstClaimTime;
 
     /// @inheritdoc ISablierMerkleBase
@@ -68,6 +71,17 @@ abstract contract SablierMerkleBase is
         _;
     }
 
+    /// @dev Modifier to revert if `claimType_` value does not match the campaign's claim type.
+    modifier revertIfNot(ClaimType claimType_) {
+        if (claimType != claimType_) {
+            revert Errors.SablierMerkleBase_InvalidClaimType({
+                claimTypeCalled: claimType_,
+                claimTypeSupported: claimType
+            });
+        }
+        _;
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                                     CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
@@ -81,6 +95,7 @@ abstract contract SablierMerkleBase is
         TOKEN = baseParams.token;
 
         campaignName = baseParams.campaignName;
+        claimType = baseParams.claimType;
         ipfsCID = baseParams.ipfsCID;
         minFeeUSD = ISablierComptroller(baseParams.comptroller)
             .getMinFeeUSDFor({ protocol: ISablierComptroller.Protocol.Airdrops, user: baseParams.campaignCreator });

--- a/airdrops/src/abstracts/SablierMerkleBase.sol
+++ b/airdrops/src/abstracts/SablierMerkleBase.sol
@@ -67,7 +67,9 @@ abstract contract SablierMerkleBase is
 
     /// @dev Modifier to check that `to` is not zero address.
     modifier notZeroAddress(address to) {
-        _revertIfToZeroAddress(to);
+        if (to == address(0)) {
+            revert Errors.SablierMerkleBase_ToZeroAddress();
+        }
         _;
     }
 
@@ -175,13 +177,6 @@ abstract contract SablierMerkleBase is
     /// @dev The grace period is 7 days after the first claim.
     function _hasGracePeriodPassed() private view returns (bool) {
         return firstClaimTime > 0 && block.timestamp > firstClaimTime + 7 days;
-    }
-
-    /// @dev This function checks if `to` is zero address.
-    function _revertIfToZeroAddress(address to) private pure {
-        if (to == address(0)) {
-            revert Errors.SablierMerkleBase_ToZeroAddress();
-        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/airdrops/src/abstracts/SablierMerkleLockup.sol
+++ b/airdrops/src/abstracts/SablierMerkleLockup.sol
@@ -6,7 +6,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 
 import { ISablierMerkleLockup } from "../interfaces/ISablierMerkleLockup.sol";
-import { ClaimType, MerkleLockup } from "../types/DataTypes.sol";
+import { MerkleLockup } from "../types/DataTypes.sol";
 import { SablierMerkleBase } from "./SablierMerkleBase.sol";
 
 /// @title SablierMerkleLockup

--- a/airdrops/src/abstracts/SablierMerkleLockup.sol
+++ b/airdrops/src/abstracts/SablierMerkleLockup.sol
@@ -6,7 +6,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 
 import { ISablierMerkleLockup } from "../interfaces/ISablierMerkleLockup.sol";
-import { MerkleLockup } from "../types/DataTypes.sol";
+import { ClaimType, MerkleLockup } from "../types/DataTypes.sol";
 import { SablierMerkleBase } from "./SablierMerkleBase.sol";
 
 /// @title SablierMerkleLockup

--- a/airdrops/src/abstracts/SablierMerkleSignature.sol
+++ b/airdrops/src/abstracts/SablierMerkleSignature.sol
@@ -8,6 +8,7 @@ import { ISablierComptroller } from "@sablier/evm-utils/src/interfaces/ISablierC
 import { ISablierMerkleSignature } from "./../interfaces/ISablierMerkleSignature.sol";
 import { Errors } from "./../libraries/Errors.sol";
 import { SignatureHash } from "./../libraries/SignatureHash.sol";
+import { ClaimType } from "./../types/DataTypes.sol";
 import { SablierMerkleBase } from "./SablierMerkleBase.sol";
 
 /// @title SablierMerkleSignature
@@ -32,12 +33,25 @@ abstract contract SablierMerkleSignature is
     /// attestor is queried from the comptroller.
     address private _attestor;
 
+    /// @inheritdoc ISablierMerkleSignature
+    ClaimType public override claimType;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     MODIFIERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Modifier to check that the provided claim type matches the campaign's claim type.
+    modifier checkClaimType(ClaimType claimType_) {
+        _checkClaimType(claimType_);
+        _;
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                                     CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Constructs the contract by initializing the immutable state variables.
-    constructor() {
+    constructor(ClaimType claimType_) {
         // Cache the chain ID.
         _CACHED_CHAIN_ID = block.chainid;
 
@@ -45,6 +59,9 @@ abstract contract SablierMerkleSignature is
         _CACHED_DOMAIN_SEPARATOR = keccak256(
             abi.encode(SignatureHash.DOMAIN_TYPEHASH, SignatureHash.PROTOCOL_NAME, block.chainid, address(this))
         );
+
+        // Effect: set the claim type.
+        claimType = claimType_;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -136,6 +153,16 @@ abstract contract SablierMerkleSignature is
     /*//////////////////////////////////////////////////////////////////////////
                             PRIVATE READ-ONLY FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Checks that the provided claim type matches the campaign's claim type.
+    function _checkClaimType(ClaimType claimType_) private view {
+        if (claimType != claimType_) {
+            revert Errors.SablierMerkleSignature_InvalidClaimType({
+                claimTypeCalled: claimType_,
+                claimTypeSupported: claimType
+            });
+        }
+    }
 
     /// @dev Returns the domain separator for the current chain.
     function _domainSeparator() private view returns (bytes32) {

--- a/airdrops/src/abstracts/SablierMerkleSignature.sol
+++ b/airdrops/src/abstracts/SablierMerkleSignature.sol
@@ -40,9 +40,14 @@ abstract contract SablierMerkleSignature is
                                      MODIFIERS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Modifier to check that the provided claim type matches the campaign's claim type.
-    modifier checkClaimType(ClaimType claimType_) {
-        _checkClaimType(claimType_);
+    /// @dev Modifier to revert if `claimType_` value does not match the campaign's claim type.
+    modifier revertIfNot(ClaimType claimType_) {
+        if (claimType != claimType_) {
+            revert Errors.SablierMerkleSignature_InvalidClaimType({
+                claimTypeCalled: claimType_,
+                claimTypeSupported: claimType
+            });
+        }
         _;
     }
 
@@ -153,16 +158,6 @@ abstract contract SablierMerkleSignature is
     /*//////////////////////////////////////////////////////////////////////////
                             PRIVATE READ-ONLY FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
-
-    /// @dev Checks that the provided claim type matches the campaign's claim type.
-    function _checkClaimType(ClaimType claimType_) private view {
-        if (claimType != claimType_) {
-            revert Errors.SablierMerkleSignature_InvalidClaimType({
-                claimTypeCalled: claimType_,
-                claimTypeSupported: claimType
-            });
-        }
-    }
 
     /// @dev Returns the domain separator for the current chain.
     function _domainSeparator() private view returns (bytes32) {

--- a/airdrops/src/abstracts/SablierMerkleSignature.sol
+++ b/airdrops/src/abstracts/SablierMerkleSignature.sol
@@ -8,7 +8,6 @@ import { ISablierComptroller } from "@sablier/evm-utils/src/interfaces/ISablierC
 import { ISablierMerkleSignature } from "./../interfaces/ISablierMerkleSignature.sol";
 import { Errors } from "./../libraries/Errors.sol";
 import { SignatureHash } from "./../libraries/SignatureHash.sol";
-import { ClaimType } from "./../types/DataTypes.sol";
 import { SablierMerkleBase } from "./SablierMerkleBase.sol";
 
 /// @title SablierMerkleSignature
@@ -33,30 +32,12 @@ abstract contract SablierMerkleSignature is
     /// attestor is queried from the comptroller.
     address private _attestor;
 
-    /// @inheritdoc ISablierMerkleSignature
-    ClaimType public override claimType;
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                     MODIFIERS
-    //////////////////////////////////////////////////////////////////////////*/
-
-    /// @dev Modifier to revert if `claimType_` value does not match the campaign's claim type.
-    modifier revertIfNot(ClaimType claimType_) {
-        if (claimType != claimType_) {
-            revert Errors.SablierMerkleSignature_InvalidClaimType({
-                claimTypeCalled: claimType_,
-                claimTypeSupported: claimType
-            });
-        }
-        _;
-    }
-
     /*//////////////////////////////////////////////////////////////////////////
                                     CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @notice Constructs the contract by initializing the immutable state variables.
-    constructor(ClaimType claimType_) {
+    constructor() {
         // Cache the chain ID.
         _CACHED_CHAIN_ID = block.chainid;
 
@@ -64,9 +45,6 @@ abstract contract SablierMerkleSignature is
         _CACHED_DOMAIN_SEPARATOR = keccak256(
             abi.encode(SignatureHash.DOMAIN_TYPEHASH, SignatureHash.PROTOCOL_NAME, block.chainid, address(this))
         );
-
-        // Effect: set the claim type.
-        claimType = claimType_;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/airdrops/src/interfaces/ISablierMerkleBase.sol
+++ b/airdrops/src/interfaces/ISablierMerkleBase.sol
@@ -4,6 +4,8 @@ pragma solidity >=0.8.22;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IAdminable } from "@sablier/evm-utils/src/interfaces/IAdminable.sol";
 
+import { ClaimType } from "../types/DataTypes.sol";
+
 /// @title ISablierMerkleBase
 /// @dev Common interface between campaign contracts.
 interface ISablierMerkleBase is IAdminable {
@@ -24,6 +26,9 @@ interface ISablierMerkleBase is IAdminable {
     /// @notice The timestamp at which campaign starts and claim begins.
     /// @dev This is an immutable state variable.
     function CAMPAIGN_START_TIME() external view returns (uint40);
+
+    /// @notice Retrieves the claim type available in the campaign.
+    function claimType() external view returns (ClaimType);
 
     /// @notice Retrieves the address of the comptroller contract.
     function COMPTROLLER() external view returns (address);

--- a/airdrops/src/interfaces/ISablierMerkleBase.sol
+++ b/airdrops/src/interfaces/ISablierMerkleBase.sol
@@ -28,7 +28,8 @@ interface ISablierMerkleBase is IAdminable {
     function CAMPAIGN_START_TIME() external view returns (uint40);
 
     /// @notice Retrieves the claim type available in the campaign.
-    function claimType() external view returns (ClaimType);
+    /// @dev This is an immutable state variable.
+    function CLAIM_TYPE() external view returns (ClaimType);
 
     /// @notice Retrieves the address of the comptroller contract.
     function COMPTROLLER() external view returns (address);

--- a/airdrops/src/interfaces/ISablierMerkleBase.sol
+++ b/airdrops/src/interfaces/ISablierMerkleBase.sol
@@ -27,7 +27,7 @@ interface ISablierMerkleBase is IAdminable {
     /// @dev This is an immutable state variable.
     function CAMPAIGN_START_TIME() external view returns (uint40);
 
-    /// @notice Retrieves the claim type available in the campaign.
+    /// @notice Retrieves the claim type supported by the campaign.
     /// @dev This is an immutable state variable.
     function CLAIM_TYPE() external view returns (ClaimType);
 

--- a/airdrops/src/interfaces/ISablierMerkleInstant.sol
+++ b/airdrops/src/interfaces/ISablierMerkleInstant.sol
@@ -22,7 +22,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     /// @dev It emits a {ClaimInstant} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -40,7 +40,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     /// @dev It emits a {ClaimInstant} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - `msg.sender` must be the airdrop recipient.
     /// - The `to` must not be the zero address.
     /// - Refer to the requirements in {claim}.
@@ -62,7 +62,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     ///
     /// Requirements:
     /// - `msg.sender` must be the airdrop recipient.
-    /// - `claimType` must be `ATTEST`.
+    /// - `CLAIM_TYPE` must be `ATTEST`.
     /// - The `to` must not be the zero address.
     /// - The attestor must not be the zero address.
     /// - The attestation signature must be valid.
@@ -89,7 +89,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     /// @dev It emits a {ClaimInstant} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/interfaces/ISablierMerkleInstant.sol
+++ b/airdrops/src/interfaces/ISablierMerkleInstant.sol
@@ -22,6 +22,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     /// @dev It emits a {ClaimInstant} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -39,6 +40,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     /// @dev It emits a {ClaimInstant} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - `msg.sender` must be the airdrop recipient.
     /// - The `to` must not be the zero address.
     /// - Refer to the requirements in {claim}.
@@ -60,6 +62,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     ///
     /// Requirements:
     /// - `msg.sender` must be the airdrop recipient.
+    /// - `claimType` must be `ATTEST`.
     /// - The `to` must not be the zero address.
     /// - The attestor must not be the zero address.
     /// - The attestation signature must be valid.
@@ -86,6 +89,7 @@ interface ISablierMerkleInstant is ISablierMerkleSignature {
     /// @dev It emits a {ClaimInstant} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/interfaces/ISablierMerkleLL.sol
+++ b/airdrops/src/interfaces/ISablierMerkleLL.sol
@@ -62,6 +62,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     /// @dev It emits either {ClaimLLWithTransfer} or {ClaimLLWithVesting} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -81,6 +82,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     /// @dev It emits either {ClaimLLWithTransfer} or {ClaimLLWithVesting} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - `msg.sender` must be the airdrop recipient.
     /// - The `to` must not be the zero address.
     /// - Refer to the requirements in {claim}.
@@ -104,6 +106,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     ///
     /// Requirements:
     /// - `msg.sender` must be the airdrop recipient.
+    /// - `claimType` must be `ATTEST`.
     /// - The `to` must not be the zero address.
     /// - The attestor must not be the zero address.
     /// - The attestation signature must be valid.
@@ -131,6 +134,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     /// @dev It emits either {ClaimLLWithTransfer} or {ClaimLLWithVesting} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/interfaces/ISablierMerkleLL.sol
+++ b/airdrops/src/interfaces/ISablierMerkleLL.sol
@@ -62,7 +62,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     /// @dev It emits either {ClaimLLWithTransfer} or {ClaimLLWithVesting} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -82,7 +82,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     /// @dev It emits either {ClaimLLWithTransfer} or {ClaimLLWithVesting} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - `msg.sender` must be the airdrop recipient.
     /// - The `to` must not be the zero address.
     /// - Refer to the requirements in {claim}.
@@ -106,7 +106,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     ///
     /// Requirements:
     /// - `msg.sender` must be the airdrop recipient.
-    /// - `claimType` must be `ATTEST`.
+    /// - `CLAIM_TYPE` must be `ATTEST`.
     /// - The `to` must not be the zero address.
     /// - The attestor must not be the zero address.
     /// - The attestation signature must be valid.
@@ -134,7 +134,7 @@ interface ISablierMerkleLL is ISablierMerkleSignature, ISablierMerkleLockup {
     /// @dev It emits either {ClaimLLWithTransfer} or {ClaimLLWithVesting} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/interfaces/ISablierMerkleLT.sol
+++ b/airdrops/src/interfaces/ISablierMerkleLT.sol
@@ -46,6 +46,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     /// @dev It emits either {ClaimLTWithTransfer} or {ClaimLTWithVesting} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -65,6 +66,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     /// @dev It emits either {ClaimLTWithTransfer} or {ClaimLTWithVesting} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - `msg.sender` must be the airdrop recipient.
     /// - The `to` must not be the zero address.
     /// - Refer to the requirements in {claim}.
@@ -88,6 +90,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     ///
     /// Requirements:
     /// - `msg.sender` must be the airdrop recipient.
+    /// - `claimType` must be `ATTEST`.
     /// - The `to` must not be the zero address.
     /// - The attestor must not be the zero address.
     /// - The attestation signature must be valid.
@@ -115,6 +118,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     /// @dev It emits either {ClaimLTWithTransfer} or {ClaimLTWithVesting} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/interfaces/ISablierMerkleLT.sol
+++ b/airdrops/src/interfaces/ISablierMerkleLT.sol
@@ -46,7 +46,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     /// @dev It emits either {ClaimLTWithTransfer} or {ClaimLTWithVesting} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -66,7 +66,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     /// @dev It emits either {ClaimLTWithTransfer} or {ClaimLTWithVesting} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - `msg.sender` must be the airdrop recipient.
     /// - The `to` must not be the zero address.
     /// - Refer to the requirements in {claim}.
@@ -90,7 +90,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     ///
     /// Requirements:
     /// - `msg.sender` must be the airdrop recipient.
-    /// - `claimType` must be `ATTEST`.
+    /// - `CLAIM_TYPE` must be `ATTEST`.
     /// - The `to` must not be the zero address.
     /// - The attestor must not be the zero address.
     /// - The attestation signature must be valid.
@@ -118,7 +118,7 @@ interface ISablierMerkleLT is ISablierMerkleLockup, ISablierMerkleSignature {
     /// @dev It emits either {ClaimLTWithTransfer} or {ClaimLTWithVesting} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/interfaces/ISablierMerkleSignature.sol
+++ b/airdrops/src/interfaces/ISablierMerkleSignature.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
-import { ClaimType } from "../types/DataTypes.sol";
 import { ISablierMerkleBase } from "./ISablierMerkleBase.sol";
 
 /// @title ISablierMerkleSignature
@@ -21,9 +20,6 @@ interface ISablierMerkleSignature is ISablierMerkleBase {
 
     /// @notice Retrieves the attestor address used for creating attestation signatures.
     function attestor() external view returns (address);
-
-    /// @notice Retrieves the claim type available in the campaign.
-    function claimType() external view returns (ClaimType);
 
     /// @notice The domain separator, as required by EIP-712 and EIP-1271, used for signing claims to prevent replay
     /// attacks across different campaigns.

--- a/airdrops/src/interfaces/ISablierMerkleSignature.sol
+++ b/airdrops/src/interfaces/ISablierMerkleSignature.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22;
 
+import { ClaimType } from "../types/DataTypes.sol";
 import { ISablierMerkleBase } from "./ISablierMerkleBase.sol";
 
 /// @title ISablierMerkleSignature
@@ -20,6 +21,9 @@ interface ISablierMerkleSignature is ISablierMerkleBase {
 
     /// @notice Retrieves the attestor address used for creating attestation signatures.
     function attestor() external view returns (address);
+
+    /// @notice Retrieves the claim type available in the campaign.
+    function claimType() external view returns (ClaimType);
 
     /// @notice The domain separator, as required by EIP-712 and EIP-1271, used for signing claims to prevent replay
     /// attacks across different campaigns.

--- a/airdrops/src/interfaces/ISablierMerkleVCA.sol
+++ b/airdrops/src/interfaces/ISablierMerkleVCA.sol
@@ -96,6 +96,7 @@ interface ISablierMerkleVCA is ISablierMerkleSignature {
     /// on the rewards while subsequent recipients would get them.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -151,6 +152,7 @@ interface ISablierMerkleVCA is ISablierMerkleSignature {
     /// @dev It emits a {ClaimVCA} event.
     ///
     /// Requirements:
+    /// - `claimType` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/interfaces/ISablierMerkleVCA.sol
+++ b/airdrops/src/interfaces/ISablierMerkleVCA.sol
@@ -96,7 +96,7 @@ interface ISablierMerkleVCA is ISablierMerkleSignature {
     /// on the rewards while subsequent recipients would get them.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - The current time must be greater than or equal to the campaign start time.
     /// - The campaign must not have expired.
     /// - `msg.value` must not be less than the value returned by {COMPTROLLER.calculateMinFeeWei}.
@@ -125,6 +125,7 @@ interface ISablierMerkleVCA is ISablierMerkleSignature {
     ///
     /// Requirements:
     /// - `msg.sender` must be the airdrop recipient.
+    /// - `CLAIM_TYPE` must be `ATTEST`.
     /// - The `to` must not be the zero address.
     /// - The attestor must not be the zero address.
     /// - The attestation signature must be valid.
@@ -152,7 +153,7 @@ interface ISablierMerkleVCA is ISablierMerkleSignature {
     /// @dev It emits a {ClaimVCA} event.
     ///
     /// Requirements:
-    /// - `claimType` must be `DEFAULT`.
+    /// - `CLAIM_TYPE` must be `DEFAULT`.
     /// - If `recipient` is an EOA, it must match the recovered signer.
     /// - If `recipient` is a contract, it must implement the IERC-1271 interface.
     /// - The `to` must not be the zero address.

--- a/airdrops/src/libraries/Errors.sol
+++ b/airdrops/src/libraries/Errors.sol
@@ -83,9 +83,6 @@ library Errors {
     /// @notice Thrown when trying to claim the same index more than once.
     error SablierMerkleBase_IndexClaimed(uint256 index);
 
-    /// @notice Thrown when trying to call a claim function not supported in the campaign.
-    error SablierMerkleBase_InvalidClaimType(ClaimType claimTypeCalled, ClaimType claimTypeSupported);
-
     /// @notice Thrown when trying to claim without paying the min fee.
     error SablierMerkleBase_InsufficientFeePayment(uint256 feePaid, uint256 minFeeWei);
 
@@ -97,6 +94,9 @@ library Errors {
 
     /// @notice Thrown when trying to claim to the zero address.
     error SablierMerkleBase_ToZeroAddress();
+
+    /// @notice Thrown when trying to call a claim function not supported in the campaign.
+    error SablierMerkleBase_UnsupportedClaimType(ClaimType claimTypeRequired, ClaimType claimTypeSupported);
 
     /*//////////////////////////////////////////////////////////////////////////
                               SABLIER-MERKLE-SIGNATURE

--- a/airdrops/src/libraries/Errors.sol
+++ b/airdrops/src/libraries/Errors.sol
@@ -83,6 +83,9 @@ library Errors {
     /// @notice Thrown when trying to claim the same index more than once.
     error SablierMerkleBase_IndexClaimed(uint256 index);
 
+    /// @notice Thrown when trying to call a claim function not supported in the campaign.
+    error SablierMerkleBase_InvalidClaimType(ClaimType claimTypeCalled, ClaimType claimTypeSupported);
+
     /// @notice Thrown when trying to claim without paying the min fee.
     error SablierMerkleBase_InsufficientFeePayment(uint256 feePaid, uint256 minFeeWei);
 
@@ -104,9 +107,6 @@ library Errors {
 
     /// @notice Thrown when caller is not the comptroller or campaign admin.
     error SablierMerkleSignature_CallerNotAuthorized(address caller, address campaignAdmin, address comptroller);
-
-    /// @notice Thrown when trying to call a claim function not supported in the campaign.
-    error SablierMerkleSignature_InvalidClaimType(ClaimType claimTypeCalled, ClaimType claimTypeSupported);
 
     /// @notice Thrown when claiming with an invalid EIP-712 or EIP-1271 signature.
     error SablierMerkleSignature_InvalidSignature();

--- a/airdrops/src/libraries/Errors.sol
+++ b/airdrops/src/libraries/Errors.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.22;
 
 import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 
+import { ClaimType } from "../types/DataTypes.sol";
+
 /// @title Errors
 /// @notice Library containing all custom errors the protocol may revert with.
 library Errors {
@@ -102,6 +104,9 @@ library Errors {
 
     /// @notice Thrown when caller is not the comptroller or campaign admin.
     error SablierMerkleSignature_CallerNotAuthorized(address caller, address campaignAdmin, address comptroller);
+
+    /// @notice Thrown when trying to call a claim function not supported in the campaign.
+    error SablierMerkleSignature_InvalidClaimType(ClaimType claimTypeCalled, ClaimType claimTypeSupported);
 
     /// @notice Thrown when claiming with an invalid EIP-712 or EIP-1271 signature.
     error SablierMerkleSignature_InvalidSignature();

--- a/airdrops/src/types/DataTypes.sol
+++ b/airdrops/src/types/DataTypes.sol
@@ -7,6 +7,14 @@ import { UD2x18 } from "@prb/math/src/UD2x18.sol";
 import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 
+/// @notice Enum representing the type of claim functions available for a Merkle campaign.
+/// @custom:value DEFAULT Activates `claim`, `claimTo`, and `claimViaSig` functions.
+/// @custom:value ATTEST Activates only the `claimViaAttestation` function.
+enum ClaimType {
+    DEFAULT,
+    ATTEST
+}
+
 library MerkleBase {
     /// @notice Struct encapsulating the constructor parameters of {SablierMerkleBase} contract.
     /// @dev The fields are arranged alphabetically.
@@ -67,6 +75,7 @@ library MerkleInstant {
     /// @dev The fields are arranged alphabetically.
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
+    /// @param claimType The type of claim functions to be enabled in the campaign.
     /// @param expiration The expiration of the campaign, as a Unix timestamp. A value of zero means the campaign does
     /// not expire.
     /// @param initialAdmin The initial admin of the campaign.
@@ -77,6 +86,7 @@ library MerkleInstant {
     struct ConstructorParams {
         string campaignName;
         uint40 campaignStartTime;
+        ClaimType claimType;
         uint40 expiration;
         address initialAdmin;
         string ipfsCID;
@@ -91,6 +101,7 @@ library MerkleLL {
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
     /// @param cancelable Indicates if the Lockup stream will be cancelable after claiming.
+    /// @param claimType The type of claim functions to be enabled in the campaign.
     /// @param cliffDuration The cliff duration of the vesting stream, in seconds.
     /// @param cliffUnlockPercentage The percentage of the claim amount due to be unlocked at the vesting cliff time, as
     /// a fixed-point number where 1e18 is 100%
@@ -115,6 +126,7 @@ library MerkleLL {
         string campaignName;
         uint40 campaignStartTime;
         bool cancelable;
+        ClaimType claimType;
         uint40 cliffDuration;
         UD60x18 cliffUnlockPercentage;
         uint40 expiration;
@@ -153,6 +165,7 @@ library MerkleLT {
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
     /// @param cancelable Indicates if the Lockup stream will be cancelable after claiming.
+    /// @param claimType The type of claim functions to be enabled in the campaign.
     /// @param expiration The expiration of the campaign, as a Unix timestamp. A value of zero means the campaign does
     /// not expire.
     /// @param initialAdmin The initial admin of the campaign.
@@ -171,6 +184,7 @@ library MerkleLT {
         string campaignName;
         uint40 campaignStartTime;
         bool cancelable;
+        ClaimType claimType;
         uint40 expiration;
         address initialAdmin;
         string ipfsCID;
@@ -205,6 +219,7 @@ library MerkleVCA {
     /// the value to the actual total allocations.
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
+    /// @param claimType The type of claim functions to be enabled in the campaign.
     /// @param enableRedistribution Enable redistribution of forgone tokens at deployment.
     /// @param expiration The expiration of the campaign, as a Unix timestamp.
     /// @param initialAdmin The initial admin of the campaign.
@@ -220,6 +235,7 @@ library MerkleVCA {
         uint128 aggregateAmount;
         string campaignName;
         uint40 campaignStartTime;
+        ClaimType claimType;
         bool enableRedistribution;
         uint40 expiration;
         address initialAdmin;

--- a/airdrops/src/types/DataTypes.sol
+++ b/airdrops/src/types/DataTypes.sol
@@ -7,10 +7,10 @@ import { UD2x18 } from "@prb/math/src/UD2x18.sol";
 import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 
-/// @notice Enum representing the type of claim functions available for a Merkle campaign.
+/// @notice Enum representing the type of claim functions supported by a Merkle campaign.
 /// @custom:value0 DEFAULT Activates `claim`, `claimTo`, and `claimViaSig` functions.
-/// @custom:value1 ATTEST Activates only the `claimViaAttestation` function.
-/// @custom:value2 EXECUTE Activates only the `claimAndExecute` function.
+/// @custom:value1 ATTEST Activates `claimViaAttestation` function only.
+/// @custom:value2 EXECUTE Activates `claimAndExecute` function only.
 enum ClaimType {
     DEFAULT,
     ATTEST,
@@ -79,7 +79,7 @@ library MerkleInstant {
     /// @dev The fields are arranged alphabetically.
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
-    /// @param claimType The type of claim functions to be enabled in the campaign.
+    /// @param claimType The type of claim functions supported by the campaign.
     /// @param expiration The expiration of the campaign, as a Unix timestamp. A value of zero means the campaign does
     /// not expire.
     /// @param initialAdmin The initial admin of the campaign.
@@ -105,7 +105,7 @@ library MerkleLL {
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
     /// @param cancelable Indicates if the Lockup stream will be cancelable after claiming.
-    /// @param claimType The type of claim functions to be enabled in the campaign.
+    /// @param claimType The type of claim functions supported by the campaign.
     /// @param cliffDuration The cliff duration of the vesting stream, in seconds.
     /// @param cliffUnlockPercentage The percentage of the claim amount due to be unlocked at the vesting cliff time, as
     /// a fixed-point number where 1e18 is 100%
@@ -169,7 +169,7 @@ library MerkleLT {
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
     /// @param cancelable Indicates if the Lockup stream will be cancelable after claiming.
-    /// @param claimType The type of claim functions to be enabled in the campaign.
+    /// @param claimType The type of claim functions supported by the campaign.
     /// @param expiration The expiration of the campaign, as a Unix timestamp. A value of zero means the campaign does
     /// not expire.
     /// @param initialAdmin The initial admin of the campaign.
@@ -223,7 +223,7 @@ library MerkleVCA {
     /// the value to the actual total allocations.
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
-    /// @param claimType The type of claim functions to be enabled in the campaign.
+    /// @param claimType The type of claim functions supported by the campaign.
     /// @param enableRedistribution Enable redistribution of forgone tokens at deployment.
     /// @param expiration The expiration of the campaign, as a Unix timestamp.
     /// @param initialAdmin The initial admin of the campaign.

--- a/airdrops/src/types/DataTypes.sol
+++ b/airdrops/src/types/DataTypes.sol
@@ -8,11 +8,13 @@ import { UD60x18 } from "@prb/math/src/UD60x18.sol";
 import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
 
 /// @notice Enum representing the type of claim functions available for a Merkle campaign.
-/// @custom:value DEFAULT Activates `claim`, `claimTo`, and `claimViaSig` functions.
-/// @custom:value ATTEST Activates only the `claimViaAttestation` function.
+/// @custom:value0 DEFAULT Activates `claim`, `claimTo`, and `claimViaSig` functions.
+/// @custom:value1 ATTEST Activates only the `claimViaAttestation` function.
+/// @custom:value2 EXECUTE Activates only the `claimAndExecute` function.
 enum ClaimType {
     DEFAULT,
-    ATTEST
+    ATTEST,
+    EXECUTE
 }
 
 library MerkleBase {
@@ -21,6 +23,7 @@ library MerkleBase {
     /// @param campaignCreator The address of campaign creator which should be the same as the `msg.sender`.
     /// @param campaignName The name of the campaign.
     /// @param campaignStartTime The start time of the campaign, as a Unix timestamp.
+    /// @param claimType The type of claim functions to be enabled in the campaign.
     /// @param comptroller The address of the comptroller contract.
     /// @param expiration The expiration of the campaign, as a Unix timestamp. A value of zero means the campaign does
     /// not expire.
@@ -33,6 +36,7 @@ library MerkleBase {
         address campaignCreator;
         string campaignName;
         uint40 campaignStartTime;
+        ClaimType claimType;
         address comptroller;
         uint40 expiration;
         address initialAdmin;

--- a/airdrops/tests/Base.t.sol
+++ b/airdrops/tests/Base.t.sol
@@ -34,7 +34,7 @@ import { SablierMerkleInstant } from "src/SablierMerkleInstant.sol";
 import { SablierMerkleLL } from "src/SablierMerkleLL.sol";
 import { SablierMerkleLT } from "src/SablierMerkleLT.sol";
 import { SablierMerkleVCA } from "src/SablierMerkleVCA.sol";
-import { MerkleExecute, MerkleInstant, MerkleLL, MerkleLT, MerkleVCA } from "src/types/DataTypes.sol";
+import { ClaimType, MerkleExecute, MerkleInstant, MerkleLL, MerkleLT, MerkleVCA } from "src/types/DataTypes.sol";
 import { MockStaking } from "./mocks/MockStaking.sol";
 import { Assertions } from "./utils/Assertions.sol";
 import { DeployOptimized } from "./utils/DeployOptimized.sol";
@@ -489,6 +489,7 @@ abstract contract Base_Test is Assertions, Modifiers, DeployOptimized, Fuzzers, 
         return MerkleInstant.ConstructorParams({
             campaignName: CAMPAIGN_NAME,
             campaignStartTime: campaignStartTime,
+            claimType: ClaimType.DEFAULT,
             expiration: expiration,
             initialAdmin: campaignCreator,
             ipfsCID: IPFS_CID,
@@ -581,6 +582,7 @@ abstract contract Base_Test is Assertions, Modifiers, DeployOptimized, Fuzzers, 
             campaignName: CAMPAIGN_NAME,
             campaignStartTime: campaignStartTime,
             cancelable: STREAM_CANCELABLE,
+            claimType: ClaimType.DEFAULT,
             cliffDuration: VESTING_CLIFF_DURATION,
             cliffUnlockPercentage: VESTING_CLIFF_UNLOCK_PERCENTAGE,
             expiration: expiration,
@@ -698,6 +700,7 @@ abstract contract Base_Test is Assertions, Modifiers, DeployOptimized, Fuzzers, 
         return MerkleLT.ConstructorParams({
             campaignName: CAMPAIGN_NAME,
             campaignStartTime: campaignStartTime,
+            claimType: ClaimType.DEFAULT,
             cancelable: STREAM_CANCELABLE,
             expiration: expiration,
             initialAdmin: campaignCreator,
@@ -836,6 +839,7 @@ abstract contract Base_Test is Assertions, Modifiers, DeployOptimized, Fuzzers, 
             aggregateAmount: aggregateAmount,
             campaignName: CAMPAIGN_NAME,
             campaignStartTime: campaignStartTime,
+            claimType: ClaimType.DEFAULT,
             enableRedistribution: enableRedistribution,
             expiration: expiration,
             initialAdmin: campaignCreator,

--- a/airdrops/tests/integration/Integration.t.sol
+++ b/airdrops/tests/integration/Integration.t.sol
@@ -8,7 +8,7 @@ import { ISablierMerkleInstant } from "src/interfaces/ISablierMerkleInstant.sol"
 import { ISablierMerkleLL } from "src/interfaces/ISablierMerkleLL.sol";
 import { ISablierMerkleLT } from "src/interfaces/ISablierMerkleLT.sol";
 import { ISablierMerkleVCA } from "src/interfaces/ISablierMerkleVCA.sol";
-import { MerkleExecute, MerkleInstant, MerkleLL, MerkleLT, MerkleVCA } from "src/types/DataTypes.sol";
+import { ClaimType, MerkleExecute, MerkleInstant, MerkleLL, MerkleLT, MerkleVCA } from "src/types/DataTypes.sol";
 
 import { Base_Test } from "../Base.t.sol";
 
@@ -19,6 +19,12 @@ abstract contract Integration_Test is Base_Test {
 
     /// @dev Type of the campaign, e.g., "execute", "instant", "ll", "lt", or "vca".
     string internal campaignType;
+
+    /// @dev Campaigns with ClaimType.ATTEST for testing claim type restrictions.
+    ISablierMerkleInstant internal merkleInstantAttest;
+    ISablierMerkleLL internal merkleLLAttest;
+    ISablierMerkleLT internal merkleLTAttest;
+    ISablierMerkleVCA internal merkleVCAAttest;
 
     /*//////////////////////////////////////////////////////////////////////////
                                   SET-UP FUNCTION
@@ -36,6 +42,12 @@ abstract contract Integration_Test is Base_Test {
         merkleLL = createMerkleLL();
         merkleLT = createMerkleLT();
         merkleVCA = createMerkleVCA();
+
+        // Create campaigns with ClaimType.ATTEST.
+        merkleInstantAttest = createMerkleInstantAttest();
+        merkleLLAttest = createMerkleLLAttest();
+        merkleLTAttest = createMerkleLTAttest();
+        merkleVCAAttest = createMerkleVCAAttest();
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -235,6 +247,13 @@ abstract contract Integration_Test is Base_Test {
         fundCampaignWithDai(address(campaignAddress));
     }
 
+    function createMerkleInstantAttest() internal returns (ISablierMerkleInstant) {
+        MerkleInstant.ConstructorParams memory params = merkleInstantConstructorParams();
+        params.campaignName = "attest instant";
+        params.claimType = ClaimType.ATTEST;
+        return createMerkleInstant(params);
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                                     MERKLE-LL
     //////////////////////////////////////////////////////////////////////////*/
@@ -251,6 +270,13 @@ abstract contract Integration_Test is Base_Test {
 
         // Fund the campaign.
         fundCampaignWithDai(address(campaignAddress));
+    }
+
+    function createMerkleLLAttest() internal returns (ISablierMerkleLL) {
+        MerkleLL.ConstructorParams memory params = merkleLLConstructorParams();
+        params.campaignName = "attest ll";
+        params.claimType = ClaimType.ATTEST;
+        return createMerkleLL(params);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -271,6 +297,13 @@ abstract contract Integration_Test is Base_Test {
         fundCampaignWithDai(address(campaignAddress));
     }
 
+    function createMerkleLTAttest() internal returns (ISablierMerkleLT) {
+        MerkleLT.ConstructorParams memory params = merkleLTConstructorParams();
+        params.campaignName = "attest lt";
+        params.claimType = ClaimType.ATTEST;
+        return createMerkleLT(params);
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                                     MERKLE-VCA
     //////////////////////////////////////////////////////////////////////////*/
@@ -287,5 +320,12 @@ abstract contract Integration_Test is Base_Test {
 
         // Fund the campaign.
         fundCampaignWithDai(address(campaignAddress));
+    }
+
+    function createMerkleVCAAttest() internal returns (ISablierMerkleVCA) {
+        MerkleVCA.ConstructorParams memory params = merkleVCAConstructorParams();
+        params.campaignName = "attest vca";
+        params.claimType = ClaimType.ATTEST;
+        return createMerkleVCA(params);
     }
 }

--- a/airdrops/tests/integration/concrete/campaign/execute/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/execute/constructor.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { SablierMerkleExecute } from "src/SablierMerkleExecute.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { MockStaking } from "../../../../mocks/MockStaking.sol";
 import { Integration_Test } from "./../../../Integration.t.sol";
@@ -19,6 +20,7 @@ contract Constructor_MerkleExecute_Integration_Test is Integration_Test {
         assertEq(constructedExecute.admin(), users.campaignCreator, "admin");
         assertEq(constructedExecute.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedExecute.CAMPAIGN_START_TIME(), CAMPAIGN_START_TIME, "campaign start time");
+        assertEq(uint8(constructedExecute.CLAIM_TYPE()), uint8(ClaimType.EXECUTE), "claim type");
         assertEq(constructedExecute.COMPTROLLER(), address(comptroller), "comptroller");
         assertEq(constructedExecute.EXPIRATION(), EXPIRATION, "expiration");
         assertEq(constructedExecute.ipfsCID(), IPFS_CID, "IPFS CID");

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-to/claimTo.t.sol
@@ -18,7 +18,7 @@ contract ClaimTo_MerkleInstant_Integration_Test is ClaimTo_Integration_Test, Mer
         merkleBase = merkleInstantAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-to/claimTo.t.sol
@@ -18,7 +18,7 @@ contract ClaimTo_MerkleInstant_Integration_Test is ClaimTo_Integration_Test, Mer
         merkleBase = merkleInstantAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-to/claimTo.t.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierMerkleInstant } from "src/interfaces/ISablierMerkleInstant.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { ClaimTo_Integration_Test } from "./../../shared/claim-to/claimTo.t.sol";
 import { MerkleInstant_Integration_Shared_Test } from "./../MerkleInstant.t.sol";
@@ -12,9 +14,20 @@ contract ClaimTo_MerkleInstant_Integration_Test is ClaimTo_Integration_Test, Mer
         ClaimTo_Integration_Test.setUp();
     }
 
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleInstantAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claimTo();
+    }
+
     function test_WhenMerkleProofValid()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenCallerNotClaimed
         whenCallerEligible

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
@@ -5,6 +5,8 @@ import { ERC1271WalletMock } from "@sablier/evm-utils/src/mocks/ERC1271WalletMoc
 
 import { ISablierMerkleInstant } from "src/interfaces/ISablierMerkleInstant.sol";
 import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { ClaimViaAttestation_Integration_Test } from "./../../shared/claim-via-attestation/claimViaAttestation.t.sol";
 import { MerkleInstant_Integration_Shared_Test } from "./../MerkleInstant.t.sol";
@@ -20,11 +22,25 @@ contract ClaimViaAttestation_MerkleInstant_Integration_Test is
     {
         MerkleInstant_Integration_Shared_Test.setUp();
         ClaimViaAttestation_Integration_Test.setUp();
+
+        // Use the pre-created MerkleInstant campaign with ClaimType.ATTEST.
+        merkleBase = merkleInstantAttest;
+    }
+
+    function test_RevertGiven_ClaimTypeDEFAULT() external {
+        merkleBase = merkleInstant;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+            )
+        );
+        claimViaAttestation();
     }
 
     function test_WhenAttestationValid()
         external
         override
+        givenClaimTypeNotDefault
         whenToAddressNotZero
         givenAttestorNotZero
         givenAttestorIsEOA
@@ -35,6 +51,7 @@ contract ClaimViaAttestation_MerkleInstant_Integration_Test is
     function test_WhenAttestorImplementsIERC1271Interface()
         external
         override
+        givenClaimTypeNotDefault
         whenToAddressNotZero
         givenAttestorNotZero
         givenAttestorIsContract
@@ -54,13 +71,13 @@ contract ClaimViaAttestation_MerkleInstant_Integration_Test is
         uint256 previousFeeAccrued = address(comptroller).balance;
         uint256 index = getIndexInMerkleTree();
 
-        vm.expectEmit({ emitter: address(merkleInstant) });
+        vm.expectEmit({ emitter: address(merkleBase) });
         emit ISablierMerkleInstant.ClaimInstant(index, users.recipient, CLAIM_AMOUNT, users.eve, false);
 
         expectCallToTransfer({ to: users.eve, value: CLAIM_AMOUNT });
         claimViaAttestation();
 
-        assertTrue(merkleInstant.hasClaimed(index), "not claimed");
+        assertTrue(ISablierMerkleInstant(address(merkleBase)).hasClaimed(index), "not claimed");
         assertEq(address(comptroller).balance, previousFeeAccrued + AIRDROP_MIN_FEE_WEI, "fee collected");
     }
 }

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
@@ -31,7 +31,7 @@ contract ClaimViaAttestation_MerkleInstant_Integration_Test is
         merkleBase = merkleInstant;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
             )
         );
         claimViaAttestation();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-via-attestation/claimViaAttestation.t.sol
@@ -31,7 +31,7 @@ contract ClaimViaAttestation_MerkleInstant_Integration_Test is
         merkleBase = merkleInstant;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
             )
         );
         claimViaAttestation();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
@@ -2,7 +2,8 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierMerkleInstant } from "src/interfaces/ISablierMerkleInstant.sol";
-
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 import { ClaimViaSig_Integration_Test } from "./../../shared/claim-via-sig/claimViaSig.t.sol";
 import { MerkleInstant_Integration_Shared_Test } from "./../MerkleInstant.t.sol";
 
@@ -15,9 +16,20 @@ contract ClaimViaSig_MerkleInstant_Integration_Test is
         ClaimViaSig_Integration_Test.setUp();
     }
 
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleInstantAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claimViaSig();
+    }
+
     function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
@@ -43,6 +55,7 @@ contract ClaimViaSig_MerkleInstant_Integration_Test is
     function test_WhenRecipientImplementsIERC1271Interface()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsContract
     {

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
@@ -20,7 +20,7 @@ contract ClaimViaSig_MerkleInstant_Integration_Test is
         merkleBase = merkleInstantAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim-via-sign/claimViaSig.t.sol
@@ -20,7 +20,7 @@ contract ClaimViaSig_MerkleInstant_Integration_Test is
         merkleBase = merkleInstantAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim/claim.t.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierMerkleInstant } from "src/interfaces/ISablierMerkleInstant.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { Claim_Integration_Test } from "./../../shared/claim/claim.t.sol";
 import { MerkleInstant_Integration_Shared_Test, Integration_Test } from "./../MerkleInstant.t.sol";
@@ -11,9 +13,20 @@ contract Claim_MerkleInstant_Integration_Test is Claim_Integration_Test, MerkleI
         MerkleInstant_Integration_Shared_Test.setUp();
     }
 
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleInstantAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claim();
+    }
+
     function test_WhenMerkleProofValid()
         external
         override
+        givenClaimTypeNotAttest
         givenCampaignStartTimeNotInFuture
         givenCampaignNotExpired
         givenMsgValueNotLessThanFee

--- a/airdrops/tests/integration/concrete/campaign/instant/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim/claim.t.sol
@@ -17,7 +17,7 @@ contract Claim_MerkleInstant_Integration_Test is Claim_Integration_Test, MerkleI
         merkleBase = merkleInstantAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claim();

--- a/airdrops/tests/integration/concrete/campaign/instant/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/claim/claim.t.sol
@@ -17,7 +17,7 @@ contract Claim_MerkleInstant_Integration_Test is Claim_Integration_Test, MerkleI
         merkleBase = merkleInstantAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claim();

--- a/airdrops/tests/integration/concrete/campaign/instant/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/instant/constructor.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { SablierMerkleInstant } from "src/SablierMerkleInstant.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { Integration_Test } from "./../../../Integration.t.sol";
 
@@ -21,6 +22,7 @@ contract Constructor_MerkleInstant_Integration_Test is Integration_Test {
         assertEq(constructedInstant.admin(), users.campaignCreator, "admin");
         assertEq(constructedInstant.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedInstant.CAMPAIGN_START_TIME(), CAMPAIGN_START_TIME, "campaign start time");
+        assertEq(uint8(constructedInstant.CLAIM_TYPE()), uint8(ClaimType.DEFAULT), "claim type");
         assertEq(constructedInstant.COMPTROLLER(), address(comptroller), "comptroller");
         assertEq(constructedInstant.EXPIRATION(), EXPIRATION, "expiration");
         assertEq(constructedInstant.ipfsCID(), IPFS_CID, "IPFS CID");

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.t.sol
@@ -20,7 +20,7 @@ contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL
         merkleBase = merkleLLAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.t.sol
@@ -20,7 +20,7 @@ contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL
         merkleBase = merkleLLAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.t.sol
@@ -4,12 +4,11 @@ pragma solidity >=0.8.22 <0.9.0;
 import { ud, ZERO } from "@prb/math/src/UD60x18.sol";
 import { Errors as LockupErrors } from "@sablier/lockup/src/libraries/Errors.sol";
 import { Lockup } from "@sablier/lockup/src/types/DataTypes.sol";
-
 import { ISablierMerkleLL } from "src/interfaces/ISablierMerkleLL.sol";
-import { MerkleLL } from "src/types/DataTypes.sol";
-
-import { ClaimTo_Integration_Test } from "../../shared/claim-to/claimTo.t.sol";
-import { MerkleLL_Integration_Shared_Test } from "../MerkleLL.t.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType, MerkleLL } from "src/types/DataTypes.sol";
+import { ClaimTo_Integration_Test } from "./../../shared/claim-to/claimTo.t.sol";
+import { MerkleLL_Integration_Shared_Test } from "./../MerkleLL.t.sol";
 
 contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL_Integration_Shared_Test {
     function setUp() public virtual override(MerkleLL_Integration_Shared_Test, ClaimTo_Integration_Test) {
@@ -17,7 +16,17 @@ contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL
         ClaimTo_Integration_Test.setUp();
     }
 
-    function test_WhenVestingEndTimeNotExceedClaimTime() external whenMerkleProofValid {
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleLLAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claimTo();
+    }
+
+    function test_WhenVestingEndTimeNotExceedClaimTime() external whenMerkleProofValid givenClaimTypeNotAttest {
         // Forward in time to the end of the vesting period.
         vm.warp({ newTimestamp: VESTING_END_TIME });
 
@@ -45,6 +54,7 @@ contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL
     function test_RevertWhen_TotalPercentageGreaterThan100()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
     {
         MerkleLL.ConstructorParams memory params = merkleLLConstructorParams();
@@ -76,6 +86,7 @@ contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL
     function test_WhenVestingStartTimeZero()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
         whenTotalPercentageNotGreaterThan100
     {
@@ -94,6 +105,7 @@ contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL
     function test_WhenCliffDurationZero()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
         whenTotalPercentageNotGreaterThan100
         whenVestingStartTimeNotZero
@@ -115,6 +127,7 @@ contract ClaimTo_MerkleLL_Integration_Test is ClaimTo_Integration_Test, MerkleLL
     function test_WhenCliffDurationNotZero()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
         whenTotalPercentageNotGreaterThan100
         whenVestingStartTimeNotZero

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.tree
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-to/claimTo.tree
@@ -1,24 +1,27 @@
 ClaimTo_MerkleLL_Integration_Test
 └── when merkle proof valid
-   ├── when vesting end time not exceed claim time
-   │  ├── it should transfer the tokens to Eve
-   │  └── it should emit a {ClaimLLWithTransfer} event
-   └── when vesting end time exceeds claim time
-      ├── when total percentage greater than 100
-      │  └── it should revert
-      └── when total percentage not greater than 100
-         ├── when vesting start time zero
-         │  ├── it should create a stream with block timestamp as vesting start time
-         │  ├── it should create a stream with Eve as recipient
-         │  └── it should emit a {ClaimLLWithVesting} event
-         └── when vesting start time not zero
-            ├── when cliff duration zero
-            │  ├── it should create a stream with start time as vesting start time
-            │  ├── it should create a stream with cliff as zero
+   ├── given claim type ATTEST
+   │  └── it should revert
+   └── given claim type not ATTEST
+      ├── when vesting end time not exceed claim time
+      │  ├── it should transfer the tokens to Eve
+      │  └── it should emit a {ClaimLLWithTransfer} event
+      └── when vesting end time exceeds claim time
+         ├── when total percentage greater than 100
+         │  └── it should revert
+         └── when total percentage not greater than 100
+            ├── when vesting start time zero
+            │  ├── it should create a stream with block timestamp as vesting start time
             │  ├── it should create a stream with Eve as recipient
             │  └── it should emit a {ClaimLLWithVesting} event
-            └── when cliff duration not zero
-               ├── it should create a stream with start time as vesting start time
-               ├── it should create a stream with cliff as vesting start time + cliff duration
-               ├── it should create a stream with Eve as recipient
-               └── it should emit a {ClaimLLWithVesting} event
+            └── when vesting start time not zero
+               ├── when cliff duration zero
+               │  ├── it should create a stream with start time as vesting start time
+               │  ├── it should create a stream with cliff as zero
+               │  ├── it should create a stream with Eve as recipient
+               │  └── it should emit a {ClaimLLWithVesting} event
+               └── when cliff duration not zero
+                  ├── it should create a stream with start time as vesting start time
+                  ├── it should create a stream with cliff as vesting start time + cliff duration
+                  ├── it should create a stream with Eve as recipient
+                  └── it should emit a {ClaimLLWithVesting} event

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-via-attestation/claimViaAttestation.t.sol
@@ -25,7 +25,7 @@ contract ClaimViaAttestation_MerkleLL_Integration_Test is
         merkleBase = merkleLL;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
             )
         );
         claimViaAttestation();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-via-attestation/claimViaAttestation.t.sol
@@ -25,7 +25,7 @@ contract ClaimViaAttestation_MerkleLL_Integration_Test is
         merkleBase = merkleLL;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
             )
         );
         claimViaAttestation();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
@@ -17,7 +17,7 @@ contract ClaimViaSig_MerkleLL_Integration_Test is ClaimViaSig_Integration_Test, 
         merkleBase = merkleLLAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
@@ -17,7 +17,7 @@ contract ClaimViaSig_MerkleLL_Integration_Test is ClaimViaSig_Integration_Test, 
         merkleBase = merkleLLAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim-via-sign/claimViaSig.t.sol
@@ -2,7 +2,8 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierMerkleLL } from "src/interfaces/ISablierMerkleLL.sol";
-
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 import { ClaimViaSig_Integration_Test } from "./../../shared/claim-via-sig/claimViaSig.t.sol";
 import { MerkleLL_Integration_Shared_Test } from "./../MerkleLL.t.sol";
 
@@ -12,9 +13,20 @@ contract ClaimViaSig_MerkleLL_Integration_Test is ClaimViaSig_Integration_Test, 
         ClaimViaSig_Integration_Test.setUp();
     }
 
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleLLAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claimViaSig();
+    }
+
     function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
@@ -50,6 +62,7 @@ contract ClaimViaSig_MerkleLL_Integration_Test is ClaimViaSig_Integration_Test, 
     function test_WhenRecipientImplementsIERC1271Interface()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsContract
     {

--- a/airdrops/tests/integration/concrete/campaign/ll/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim/claim.t.sol
@@ -19,7 +19,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
         merkleBase = merkleLLAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claim();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim/claim.t.sol
@@ -19,7 +19,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
         merkleBase = merkleLLAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claim();

--- a/airdrops/tests/integration/concrete/campaign/ll/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim/claim.t.sol
@@ -4,19 +4,28 @@ pragma solidity >=0.8.22 <0.9.0;
 import { ud, ZERO } from "@prb/math/src/UD60x18.sol";
 import { Errors as LockupErrors } from "@sablier/lockup/src/libraries/Errors.sol";
 import { Lockup } from "@sablier/lockup/src/types/DataTypes.sol";
-
 import { ISablierMerkleLL } from "src/interfaces/ISablierMerkleLL.sol";
-import { MerkleLL } from "src/types/DataTypes.sol";
-
-import { Claim_Integration_Test } from "../../shared/claim/claim.t.sol";
-import { MerkleLL_Integration_Shared_Test, Integration_Test } from "../MerkleLL.t.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType, MerkleLL } from "src/types/DataTypes.sol";
+import { Claim_Integration_Test } from "./../../shared/claim/claim.t.sol";
+import { MerkleLL_Integration_Shared_Test, Integration_Test } from "./../MerkleLL.t.sol";
 
 contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Integration_Shared_Test {
     function setUp() public virtual override(MerkleLL_Integration_Shared_Test, Integration_Test) {
         MerkleLL_Integration_Shared_Test.setUp();
     }
 
-    function test_WhenVestingEndTimeNotExceedClaimTime() external whenMerkleProofValid {
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleLLAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claim();
+    }
+
+    function test_WhenVestingEndTimeNotExceedClaimTime() external whenMerkleProofValid givenClaimTypeNotAttest {
         // Forward in time to the end of the vesting period.
         vm.warp({ newTimestamp: VESTING_END_TIME });
 
@@ -44,6 +53,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
     function test_RevertWhen_TotalPercentageGreaterThan100()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
     {
         MerkleLL.ConstructorParams memory params = merkleLLConstructorParams();
@@ -76,6 +86,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
     function test_WhenVestingStartTimeZero()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
         whenTotalPercentageNotGreaterThan100
     {
@@ -91,6 +102,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
     function test_WhenCliffDurationZero()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
         whenTotalPercentageNotGreaterThan100
         whenVestingStartTimeNotZero
@@ -109,6 +121,7 @@ contract Claim_MerkleLL_Integration_Test is Claim_Integration_Test, MerkleLL_Int
     function test_WhenCliffDurationNotZero()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingEndTimeExceedsClaimTime
         whenTotalPercentageNotGreaterThan100
         whenVestingStartTimeNotZero

--- a/airdrops/tests/integration/concrete/campaign/ll/claim/claim.tree
+++ b/airdrops/tests/integration/concrete/campaign/ll/claim/claim.tree
@@ -1,21 +1,24 @@
 Claim_MerkleLL_Integration_Test
 └── when merkle proof valid
-   ├── when vesting end time not exceed claim time
-   │  ├── it should transfer the tokens to the recipient
-   │  └── it should emit a {ClaimLLWithTransfer} event
-   └── when vesting end time exceeds claim time
-      ├── when total percentage greater than 100
-      │  └── it should revert
-      └── when total percentage not greater than 100
-         ├── when vesting start time zero
-         │  ├── it should create a stream with block timestamp as vesting start time
-         │  └── it should emit a {ClaimLLWithVesting} event
-         └── when vesting start time not zero
-            ├── when cliff duration zero
-            │  ├── it should create a stream with start time as vesting start time
-            │  ├── it should create a stream with cliff as zero
+   ├── given claim type ATTEST
+   │  └── it should revert
+   └── given claim type not ATTEST
+      ├── when vesting end time not exceed claim time
+      │  ├── it should transfer the tokens to the recipient
+      │  └── it should emit a {ClaimLLWithTransfer} event
+      └── when vesting end time exceeds claim time
+         ├── when total percentage greater than 100
+         │  └── it should revert
+         └── when total percentage not greater than 100
+            ├── when vesting start time zero
+            │  ├── it should create a stream with block timestamp as vesting start time
             │  └── it should emit a {ClaimLLWithVesting} event
-            └── when cliff duration not zero
-               ├── it should create a stream with start time as vesting start time
-               ├── it should create a stream with cliff as vesting start time + cliff duration
-               └── it should emit a {ClaimLLWithVesting} event
+            └── when vesting start time not zero
+               ├── when cliff duration zero
+               │  ├── it should create a stream with start time as vesting start time
+               │  ├── it should create a stream with cliff as zero
+               │  └── it should emit a {ClaimLLWithVesting} event
+               └── when cliff duration not zero
+                  ├── it should create a stream with start time as vesting start time
+                  ├── it should create a stream with cliff as vesting start time + cliff duration
+                  └── it should emit a {ClaimLLWithVesting} event

--- a/airdrops/tests/integration/concrete/campaign/ll/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/ll/constructor.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { SablierMerkleLL } from "src/SablierMerkleLL.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { Integration_Test } from "./../../../Integration.t.sol";
 
@@ -24,6 +25,7 @@ contract Constructor_MerkleLL_Integration_Test is Integration_Test {
         // SablierMerkleBase
         assertEq(constructedLL.admin(), users.campaignCreator, "admin");
         assertEq(constructedLL.CAMPAIGN_START_TIME(), CAMPAIGN_START_TIME, "campaign start time");
+        assertEq(uint8(constructedLL.CLAIM_TYPE()), uint8(ClaimType.DEFAULT), "claim type");
         assertEq(constructedLL.COMPTROLLER(), address(comptroller), "comptroller");
         assertEq(constructedLL.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedLL.EXPIRATION(), EXPIRATION, "expiration");

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-to/claimTo.t.sol
@@ -18,7 +18,7 @@ contract ClaimTo_MerkleLT_Integration_Test is ClaimTo_Integration_Test, MerkleLT
         merkleBase = merkleLTAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-to/claimTo.t.sol
@@ -18,7 +18,7 @@ contract ClaimTo_MerkleLT_Integration_Test is ClaimTo_Integration_Test, MerkleLT
         merkleBase = merkleLTAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-to/claimTo.tree
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-to/claimTo.tree
@@ -1,14 +1,17 @@
 ClaimTo_MerkleLT_Integration_Test
 └── when merkle proof valid
-   ├── when vesting end time not exceed claim time
-   │  ├── it should transfer the tokens to Eve
-   │  └── it should emit a {ClaimLTWithTransfer} event
-   └── when vesting end time exceeds claim time
-      ├── when vesting start time zero
-      │  ├── it should create a stream with block timestamp as vesting start time
-      │  ├── it should create a stream with Eve as recipient
-      │  └── it should emit a {ClaimLTWithVesting} event
-      └── when vesting start time not zero
-         ├── it should create a ranged stream with provided start time
-         ├── it should create a stream with Eve as recipient
-         └── it should emit a {ClaimLTWithVesting} event
+   ├── given claim type ATTEST
+   │  └── it should revert
+   └── given claim type not ATTEST
+      ├── when vesting end time not exceed claim time
+      │  ├── it should transfer the tokens to Eve
+      │  └── it should emit a {ClaimLTWithTransfer} event
+      └── when vesting end time exceeds claim time
+         ├── when vesting start time zero
+         │  ├── it should create a stream with block timestamp as vesting start time
+         │  ├── it should create a stream with Eve as recipient
+         │  └── it should emit a {ClaimLTWithVesting} event
+         └── when vesting start time not zero
+            ├── it should create a ranged stream with provided start time
+            ├── it should create a stream with Eve as recipient
+            └── it should emit a {ClaimLTWithVesting} event

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
@@ -5,6 +5,8 @@ import { ERC1271WalletMock } from "@sablier/evm-utils/src/mocks/ERC1271WalletMoc
 
 import { ISablierMerkleLT } from "src/interfaces/ISablierMerkleLT.sol";
 import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { ClaimViaAttestation_Integration_Test } from "./../../shared/claim-via-attestation/claimViaAttestation.t.sol";
 import { MerkleLT_Integration_Shared_Test } from "./../MerkleLT.t.sol";
@@ -16,6 +18,19 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
     function setUp() public virtual override(MerkleLT_Integration_Shared_Test, ClaimViaAttestation_Integration_Test) {
         MerkleLT_Integration_Shared_Test.setUp();
         ClaimViaAttestation_Integration_Test.setUp();
+
+        // Use the pre-created MerkleLT campaign with ClaimType.ATTEST.
+        merkleBase = merkleLTAttest;
+    }
+
+    function test_RevertGiven_ClaimTypeDEFAULT() external {
+        merkleBase = merkleLT;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+            )
+        );
+        claimViaAttestation();
     }
 
     function test_WhenAttestationValid()
@@ -23,6 +38,7 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
         override
         whenToAddressNotZero
         givenAttestorNotZero
+        givenAttestorSet
         givenAttestorIsEOA
     {
         _test_ClaimViaAttestation();
@@ -33,6 +49,7 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
         override
         whenToAddressNotZero
         givenAttestorNotZero
+        givenAttestorSet
         givenAttestorIsContract
     {
         // Deploy an ERC1271 wallet with the EOA attestor as the admin.
@@ -40,7 +57,7 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
 
         // Set the attestor to the smart contract.
         setMsgSender(users.campaignCreator);
-        ISablierMerkleSignature(address(merkleLT)).setAttestor(smartAttestor);
+        ISablierMerkleSignature(address(merkleBase)).setAttestor(smartAttestor);
         setMsgSender(users.recipient);
 
         _test_ClaimViaAttestation();
@@ -51,7 +68,7 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
         uint256 previousFeeAccrued = address(comptroller).balance;
         uint256 index = getIndexInMerkleTree();
 
-        vm.expectEmit({ emitter: address(merkleLT) });
+        vm.expectEmit({ emitter: address(merkleBase) });
         emit ISablierMerkleLT.ClaimLTWithVesting(
             index,
             users.recipient,
@@ -61,10 +78,10 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
             false
         );
 
-        expectCallToTransferFrom({ from: address(merkleLT), to: address(lockup), value: CLAIM_AMOUNT });
+        expectCallToTransferFrom({ from: address(merkleBase), to: address(lockup), value: CLAIM_AMOUNT });
         claimViaAttestation();
 
-        assertTrue(merkleLT.hasClaimed(index), "not claimed");
+        assertTrue(ISablierMerkleLT(address(merkleBase)).hasClaimed(index), "not claimed");
         assertEq(address(comptroller).balance, previousFeeAccrued + AIRDROP_MIN_FEE_WEI, "fee collected");
     }
 }

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
@@ -27,7 +27,7 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
         merkleBase = merkleLT;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
             )
         );
         claimViaAttestation();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-via-attestation/claimViaAttestation.t.sol
@@ -27,7 +27,7 @@ contract ClaimViaAttestation_MerkleLT_Integration_Test is
         merkleBase = merkleLT;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
             )
         );
         claimViaAttestation();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
@@ -17,7 +17,7 @@ contract ClaimViaSig_MerkleLT_Integration_Test is ClaimViaSig_Integration_Test, 
         merkleBase = merkleLTAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
@@ -2,7 +2,8 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierMerkleLT } from "src/interfaces/ISablierMerkleLT.sol";
-
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 import { ClaimViaSig_Integration_Test } from "./../../shared/claim-via-sig/claimViaSig.t.sol";
 import { MerkleLT_Integration_Shared_Test } from "./../MerkleLT.t.sol";
 
@@ -12,9 +13,20 @@ contract ClaimViaSig_MerkleLT_Integration_Test is ClaimViaSig_Integration_Test, 
         ClaimViaSig_Integration_Test.setUp();
     }
 
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleLTAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claimViaSig();
+    }
+
     function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
@@ -50,6 +62,7 @@ contract ClaimViaSig_MerkleLT_Integration_Test is ClaimViaSig_Integration_Test, 
     function test_WhenRecipientImplementsIERC1271Interface()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsContract
     {

--- a/airdrops/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim-via-sign/claimViaSig.t.sol
@@ -17,7 +17,7 @@ contract ClaimViaSig_MerkleLT_Integration_Test is ClaimViaSig_Integration_Test, 
         merkleBase = merkleLTAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim/claim.t.sol
@@ -17,7 +17,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
         merkleBase = merkleLTAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claim();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim/claim.t.sol
@@ -2,19 +2,28 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { Lockup } from "@sablier/lockup/src/types/DataTypes.sol";
-
 import { ISablierMerkleLT } from "src/interfaces/ISablierMerkleLT.sol";
-import { MerkleLT } from "src/types/DataTypes.sol";
-
-import { Claim_Integration_Test } from "../../shared/claim/claim.t.sol";
-import { MerkleLT_Integration_Shared_Test, Integration_Test } from "../MerkleLT.t.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType, MerkleLT } from "src/types/DataTypes.sol";
+import { Claim_Integration_Test } from "./../../shared/claim/claim.t.sol";
+import { MerkleLT_Integration_Shared_Test, Integration_Test } from "./../MerkleLT.t.sol";
 
 contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Integration_Shared_Test {
     function setUp() public virtual override(MerkleLT_Integration_Shared_Test, Integration_Test) {
         MerkleLT_Integration_Shared_Test.setUp();
     }
 
-    function test_WhenVestingEndTimeNotExceedClaimTime() external whenMerkleProofValid {
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleLTAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claim();
+    }
+
+    function test_WhenVestingEndTimeNotExceedClaimTime() external whenMerkleProofValid givenClaimTypeNotAttest {
         // Forward in time to the end of the vesting period.
         vm.warp({ newTimestamp: VESTING_END_TIME });
 
@@ -39,7 +48,12 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
         assertEq(dai.balanceOf(users.recipient), expectedRecipientBalance, "recipient balance");
     }
 
-    function test_WhenVestingStartTimeZero() external whenMerkleProofValid whenVestingEndTimeExceedsClaimTime {
+    function test_WhenVestingStartTimeZero()
+        external
+        whenMerkleProofValid
+        givenClaimTypeNotAttest
+        whenVestingEndTimeExceedsClaimTime
+    {
         MerkleLT.ConstructorParams memory params = merkleLTConstructorParams();
         params.vestingStartTime = 0;
 
@@ -51,7 +65,12 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
         _test_Claim({ streamStartTime: getBlockTimestamp() });
     }
 
-    function test_WhenVestingStartTimeNotZero() external whenMerkleProofValid whenVestingEndTimeExceedsClaimTime {
+    function test_WhenVestingStartTimeNotZero()
+        external
+        whenMerkleProofValid
+        givenClaimTypeNotAttest
+        whenVestingEndTimeExceedsClaimTime
+    {
         // It should create a ranged stream with provided vesting start time.
         _test_Claim({ streamStartTime: VESTING_START_TIME });
     }

--- a/airdrops/tests/integration/concrete/campaign/lt/claim/claim.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim/claim.t.sol
@@ -17,7 +17,7 @@ contract Claim_MerkleLT_Integration_Test is Claim_Integration_Test, MerkleLT_Int
         merkleBase = merkleLTAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claim();

--- a/airdrops/tests/integration/concrete/campaign/lt/claim/claim.tree
+++ b/airdrops/tests/integration/concrete/campaign/lt/claim/claim.tree
@@ -1,12 +1,15 @@
 Claim_MerkleLT_Integration_Test
 └── when merkle proof valid
-   ├── when vesting end time not exceed claim time
-   │  ├── it should transfer the tokens to the recipient
-   │  └── it should emit a {ClaimLTWithTransfer} event
-   └── when vesting end time exceeds claim time
-         ├── when vesting start time zero
-         │  ├── it should create a stream with block timestamp as vesting start time
-         │  └── it should emit a {ClaimLTWithVesting} event
-         └── when vesting start time not zero
-            ├── it should create a ranged stream with provided vesting start time
-            └── it should emit a {ClaimLTWithVesting} event
+   ├── given claim type ATTEST
+   │  └── it should revert
+   └── given claim type not ATTEST
+      ├── when vesting end time not exceed claim time
+      │  ├── it should transfer the tokens to the recipient
+      │  └── it should emit a {ClaimLTWithTransfer} event
+      └── when vesting end time exceeds claim time
+            ├── when vesting start time zero
+            │  ├── it should create a stream with block timestamp as vesting start time
+            │  └── it should emit a {ClaimLTWithVesting} event
+            └── when vesting start time not zero
+               ├── it should create a ranged stream with provided vesting start time
+               └── it should emit a {ClaimLTWithVesting} event

--- a/airdrops/tests/integration/concrete/campaign/lt/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/lt/constructor.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { SablierMerkleLT } from "src/SablierMerkleLT.sol";
-import { MerkleLT } from "src/types/DataTypes.sol";
+import { ClaimType, MerkleLT } from "src/types/DataTypes.sol";
 
 import { Integration_Test } from "./../../../Integration.t.sol";
 
@@ -27,6 +27,7 @@ contract Constructor_MerkleLT_Integration_Test is Integration_Test {
         assertEq(constructedLT.admin(), users.campaignCreator, "admin");
         assertEq(constructedLT.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedLT.CAMPAIGN_START_TIME(), CAMPAIGN_START_TIME, "campaign start time");
+        assertEq(uint8(constructedLT.CLAIM_TYPE()), uint8(ClaimType.DEFAULT), "claim type");
         assertEq(constructedLT.COMPTROLLER(), address(comptroller), "comptroller");
 
         assertEq(constructedLT.EXPIRATION(), EXPIRATION, "expiration");

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierMerkleVCA } from "src/interfaces/ISablierMerkleVCA.sol";
 import { Errors } from "src/libraries/Errors.sol";
-import { MerkleVCA } from "src/types/DataTypes.sol";
+import { ClaimType, MerkleVCA } from "src/types/DataTypes.sol";
 
 import { Integration_Test } from "../../../../Integration.t.sol";
 import { ClaimTo_Integration_Test } from "../../shared/claim-to/claimTo.t.sol";
@@ -39,7 +39,17 @@ contract ClaimTo_MerkleVCA_Integration_Test is
         setMsgSender(users.recipient);
     }
 
-    function test_RevertWhen_VestingStartTimeInFuture() external whenMerkleProofValid {
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleVCAAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claimTo();
+    }
+
+    function test_RevertWhen_VestingStartTimeInFuture() external whenMerkleProofValid givenClaimTypeNotAttest {
         // Create a new campaign with vesting start time in the future.
         MerkleVCA.ConstructorParams memory params = merkleVCAConstructorParams();
         params.vestingStartTime = getBlockTimestamp() + 1 seconds;
@@ -58,7 +68,7 @@ contract ClaimTo_MerkleVCA_Integration_Test is
         });
     }
 
-    function test_WhenVestingStartTimeInPresent() external whenMerkleProofValid {
+    function test_WhenVestingStartTimeInPresent() external whenMerkleProofValid givenClaimTypeNotAttest {
         // Create a new campaign with vesting start time in the present.
         MerkleVCA.ConstructorParams memory params = merkleVCAConstructorParams();
         params.vestingStartTime = getBlockTimestamp();
@@ -72,7 +82,12 @@ contract ClaimTo_MerkleVCA_Integration_Test is
         });
     }
 
-    function test_WhenVestingEndTimeInFuture() external whenMerkleProofValid whenVestingStartTimeInPast {
+    function test_WhenVestingEndTimeInFuture()
+        external
+        whenMerkleProofValid
+        givenClaimTypeNotAttest
+        whenVestingStartTimeInPast
+    {
         _test_ClaimTo({
             expectedTransferAmount: VCA_CLAIM_AMOUNT,
             forgoneAmount: VCA_FULL_AMOUNT - VCA_CLAIM_AMOUNT,
@@ -83,6 +98,7 @@ contract ClaimTo_MerkleVCA_Integration_Test is
     function test_GivenRedistributionNotEnabled()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingStartTimeInPast
         whenVestingEndTimeNotInFuture
     {
@@ -95,6 +111,7 @@ contract ClaimTo_MerkleVCA_Integration_Test is
     function test_GivenRedistributionEnabled()
         external
         whenMerkleProofValid
+        givenClaimTypeNotAttest
         whenVestingStartTimeInPast
         whenVestingEndTimeNotInFuture
     {

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
@@ -43,7 +43,7 @@ contract ClaimTo_MerkleVCA_Integration_Test is
         merkleBase = merkleVCAAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
@@ -43,7 +43,7 @@ contract ClaimTo_MerkleVCA_Integration_Test is
         merkleBase = merkleVCAAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimTo();

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.tree
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.tree
@@ -1,27 +1,30 @@
 ClaimTo_MerkleVCA_Integration_Test
 └── when merkle proof valid
-   ├── when vesting start time in future
+   ├── given claim type ATTEST
    │  └── it should revert
-   ├── when vesting start time in present
-   │  ├── it should transfer the unlock amount to Eve
-   │  ├── it should mark the index as Claimed
-   │  ├── it should update total forgone amount
-   │  └── it should emit a {ClaimVCA} event
-   └── when vesting start time in past
-      ├── when vesting end time in future
-      │  ├── it should transfer a portion of the amount to Eve
+   └── given claim type not ATTEST
+      ├── when vesting start time in future
+      │  └── it should revert
+      ├── when vesting start time in present
+      │  ├── it should transfer the unlock amount to Eve
       │  ├── it should mark the index as Claimed
       │  ├── it should update total forgone amount
       │  └── it should emit a {ClaimVCA} event
-      └── when vesting end time not in future
-         ├── given redistribution not enabled
-         │  ├── it should transfer the full amount to Eve
+      └── when vesting start time in past
+         ├── when vesting end time in future
+         │  ├── it should transfer a portion of the amount to Eve
          │  ├── it should mark the index as Claimed
-         │  ├── it should not update total forgone amount
+         │  ├── it should update total forgone amount
          │  └── it should emit a {ClaimVCA} event
-         └── given redistribution enabled
-            ├── it should transfer the full amount to Eve
-            ├── it should transfer the reward amount to Eve
-            ├── it should mark the index as Claimed
-            ├── it should not update total forgone amount
-            └── it should emit a {ClaimVCA} event
+         └── when vesting end time not in future
+            ├── given redistribution not enabled
+            │  ├── it should transfer the full amount to Eve
+            │  ├── it should mark the index as Claimed
+            │  ├── it should not update total forgone amount
+            │  └── it should emit a {ClaimVCA} event
+            └── given redistribution enabled
+               ├── it should transfer the full amount to Eve
+               ├── it should transfer the reward amount to Eve
+               ├── it should mark the index as Claimed
+               ├── it should not update total forgone amount
+               └── it should emit a {ClaimVCA} event

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-via-attestation/claimViaAttestation.t.sol
@@ -5,6 +5,8 @@ import { ERC1271WalletMock } from "@sablier/evm-utils/src/mocks/ERC1271WalletMoc
 
 import { ISablierMerkleSignature } from "src/interfaces/ISablierMerkleSignature.sol";
 import { ISablierMerkleVCA } from "src/interfaces/ISablierMerkleVCA.sol";
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 
 import { ClaimViaAttestation_Integration_Test } from "./../../shared/claim-via-attestation/claimViaAttestation.t.sol";
 import { MerkleVCA_Integration_Shared_Test } from "./../MerkleVCA.t.sol";
@@ -16,11 +18,27 @@ contract ClaimViaAttestation_MerkleVCA_Integration_Test is
     function setUp() public virtual override(MerkleVCA_Integration_Shared_Test, ClaimViaAttestation_Integration_Test) {
         MerkleVCA_Integration_Shared_Test.setUp();
         ClaimViaAttestation_Integration_Test.setUp();
+
+        // Use the pre-created MerkleVCA campaign with ClaimType.ATTEST.
+        merkleVCA = merkleVCAAttest;
+        merkleBase = merkleVCAAttest;
+    }
+
+    function test_RevertGiven_ClaimTypeDEFAULT() external {
+        merkleVCA = ISablierMerkleVCA(address(createMerkleVCA()));
+        merkleBase = merkleVCA;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+            )
+        );
+        claimViaAttestation();
     }
 
     function test_WhenAttestationValid()
         external
         override
+        givenClaimTypeNotDefault
         whenToAddressNotZero
         givenAttestorNotZero
         givenAttestorIsEOA
@@ -50,6 +68,7 @@ contract ClaimViaAttestation_MerkleVCA_Integration_Test is
     function test_WhenAttestorImplementsIERC1271Interface()
         external
         override
+        givenClaimTypeNotDefault
         whenToAddressNotZero
         givenAttestorNotZero
         givenAttestorIsContract

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-via-attestation/claimViaAttestation.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-via-attestation/claimViaAttestation.t.sol
@@ -29,7 +29,7 @@ contract ClaimViaAttestation_MerkleVCA_Integration_Test is
         merkleBase = merkleVCA;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.ATTEST, ClaimType.DEFAULT
             )
         );
         claimViaAttestation();

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
@@ -17,7 +17,7 @@ contract ClaimViaSig_MerkleVCA_Integration_Test is ClaimViaSig_Integration_Test,
         merkleBase = merkleVCAAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_UnsupportedClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
@@ -2,7 +2,8 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { ISablierMerkleVCA } from "src/interfaces/ISablierMerkleVCA.sol";
-
+import { Errors } from "src/libraries/Errors.sol";
+import { ClaimType } from "src/types/DataTypes.sol";
 import { ClaimViaSig_Integration_Test } from "./../../shared/claim-via-sig/claimViaSig.t.sol";
 import { MerkleVCA_Integration_Shared_Test } from "./../MerkleVCA.t.sol";
 
@@ -12,9 +13,20 @@ contract ClaimViaSig_MerkleVCA_Integration_Test is ClaimViaSig_Integration_Test,
         ClaimViaSig_Integration_Test.setUp();
     }
 
+    function test_RevertGiven_ClaimTypeATTEST() external {
+        merkleBase = merkleVCAAttest;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+            )
+        );
+        claimViaSig();
+    }
+
     function test_WhenSignatureValidityTimestampNotInFuture()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsEOA
         whenSignatureCompatible
@@ -49,6 +61,7 @@ contract ClaimViaSig_MerkleVCA_Integration_Test is ClaimViaSig_Integration_Test,
     function test_WhenRecipientImplementsIERC1271Interface()
         external
         override
+        givenClaimTypeNotAttest
         whenToAddressNotZero
         givenRecipientIsContract
     {

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-via-sign/claimViaSig.t.sol
@@ -17,7 +17,7 @@ contract ClaimViaSig_MerkleVCA_Integration_Test is ClaimViaSig_Integration_Test,
         merkleBase = merkleVCAAttest;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SablierMerkleSignature_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
+                Errors.SablierMerkleBase_InvalidClaimType.selector, ClaimType.DEFAULT, ClaimType.ATTEST
             )
         );
         claimViaSig();

--- a/airdrops/tests/integration/concrete/campaign/vca/constructor.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/constructor.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { SablierMerkleVCA } from "src/SablierMerkleVCA.sol";
-import { MerkleVCA } from "src/types/DataTypes.sol";
+import { ClaimType, MerkleVCA } from "src/types/DataTypes.sol";
 
 import { Integration_Test } from "./../../../Integration.t.sol";
 
@@ -33,6 +33,7 @@ contract Constructor_MerkleVCA_Integration_Test is Integration_Test {
         assertEq(constructedVCA.admin(), users.campaignCreator, "admin");
         assertEq(constructedVCA.campaignName(), CAMPAIGN_NAME, "campaign name");
         assertEq(constructedVCA.CAMPAIGN_START_TIME(), CAMPAIGN_START_TIME, "campaign start time");
+        assertEq(uint8(constructedVCA.CLAIM_TYPE()), uint8(ClaimType.DEFAULT), "claim type");
         assertEq(constructedVCA.COMPTROLLER(), address(comptroller), "comptroller");
         assertEq(constructedVCA.EXPIRATION(), EXPIRATION, "expiration");
         assertEq(constructedVCA.ipfsCID(), IPFS_CID, "IPFS CID");

--- a/airdrops/tests/utils/Modifiers.sol
+++ b/airdrops/tests/utils/Modifiers.sol
@@ -32,6 +32,18 @@ abstract contract Modifiers is EvmUtilsBase {
         _;
     }
 
+    modifier givenAttestorSet() {
+        _;
+    }
+
+    modifier givenClaimTypeNotAttest() {
+        _;
+    }
+
+    modifier givenClaimTypeNotDefault() {
+        _;
+    }
+
     modifier givenCallerNotClaimed() {
         _;
     }


### PR DESCRIPTION
Closes https://github.com/sablier-labs/lockup/issues/1359

Note: since we have implemented the `MerkleExecute` as a separate campaign the claim type enum include just `DEFAULT` and `ATTEST`