### PR TITLE
refactor: safe oracle split

### DIFF
--- a/lockup/src/libraries/LockupHelpers.sol
+++ b/lockup/src/libraries/LockupHelpers.sol
@@ -145,7 +145,7 @@ library LockupHelpers {
         }
 
         // Check: validate that the oracle implements {AggregatorV3Interface} interface and returns the latest price.
-        uint128 latestPrice = SafeOracle.safeOraclePrice(unlockParams.oracle);
+        uint128 latestPrice = SafeOracle.validateOracle(unlockParams.oracle);
 
         // Check: the target price is greater than the latest price.
         if (unlockParams.targetPrice <= latestPrice) {

--- a/lockup/src/libraries/LockupMath.sol
+++ b/lockup/src/libraries/LockupMath.sol
@@ -263,7 +263,7 @@ library LockupMath {
         }
 
         // Get the latest price from the oracle with safety checks.
-        uint128 latestPrice = SafeOracle.safeOraclePrice(unlockParams.oracle);
+        (uint128 latestPrice,) = SafeOracle.safeOraclePrice(unlockParams.oracle);
 
         // If the oracle price is at or above the target price, return the deposited amount.
         if (latestPrice > 0 && latestPrice >= unlockParams.targetPrice) {

--- a/lockup/tests/integration/concrete/lockup-price-gated/create-with-durations-lpg/createWithDurationsLPG.t.sol
+++ b/lockup/tests/integration/concrete/lockup-price-gated/create-with-durations-lpg/createWithDurationsLPG.t.sol
@@ -102,7 +102,7 @@ contract CreateWithDurationsLPG_Integration_Concrete_Test is Lockup_PriceGated_I
 
         // It should revert.
         vm.expectRevert(
-            abi.encodeWithSelector(EvmUtilsErrors.SafeOracle_NegativePrice.selector, address(oracleNegativePrice))
+            abi.encodeWithSelector(EvmUtilsErrors.SafeOracle_NotPositivePrice.selector, address(oracleNegativePrice))
         );
         lockup.createWithDurationsLPG(_defaultParams.createWithDurations, unlockParams, duration);
     }

--- a/utils/src/SablierComptroller.sol
+++ b/utils/src/SablierComptroller.sol
@@ -430,11 +430,13 @@ contract SablierComptroller is
             return 0;
         }
 
-        // Get the latest price from the oracle.
-        uint256 price = SafeOracle.safeOraclePrice(AggregatorV3Interface(oracle));
+        // Get the latest price and feed updated timestamp from the oracle.
+        (uint256 price, uint256 updatedAt) = SafeOracle.safeOraclePrice(AggregatorV3Interface(oracle));
 
-        // If the price is 0, skip the calculations.
-        if (price == 0) {
+        // Skip the calculations if any of the following conditions are met:
+        // - The price is 0.
+        // - The oracle hasn't been updated in the last 24 hours. This is a safety check to avoid using outdated prices.
+        if (price == 0 || block.timestamp > 24 hours + updatedAt) {
             return 0;
         }
 

--- a/utils/src/libraries/Errors.sol
+++ b/utils/src/libraries/Errors.sol
@@ -81,6 +81,6 @@ library Errors {
     /// interface.
     error SafeOracle_MissesInterface(address oracle);
 
-    /// @notice Thrown when an oracle returns a negative price.
-    error SafeOracle_NegativePrice(address oracle);
+    /// @notice Thrown when the price returned by the oracle is not positive.
+    error SafeOracle_NotPositivePrice(address oracle);
 }

--- a/utils/src/libraries/SafeOracle.sol
+++ b/utils/src/libraries/SafeOracle.sol
@@ -11,9 +11,13 @@ import { Errors } from "./Errors.sol";
 library SafeOracle {
     using SafeCast for uint256;
 
-    /// @dev Fetches the latest price from the oracle without reverting. Returns 0 if the oracle address is zero, the
-    /// call fails, the price is non-positive, the `updatedAt` timestamp is in the future, or the price is outdated
-    /// (older than 24 hours).
+    /// @dev Fetches the latest price from the oracle without reverting. Returns 0 if any of the following conditions
+    /// are met:
+    /// - Oracle address is zero.
+    /// - Call to `latestRoundData()` fails.
+    /// - Oracle price is not positive.
+    /// - `updatedAt` timestamp is in the future.
+    /// - Price is outdated (older than 24 hours).
     function safeOraclePrice(AggregatorV3Interface oracle) internal view returns (uint128 price) {
         // If the oracle is not set, return 0.
         if (address(oracle) == address(0)) {
@@ -58,8 +62,10 @@ library SafeOracle {
         }
     }
 
-    /// @dev Validates the oracle address by checking that it is not zero, implements the `decimals()` function
-    /// returning 8, and returns a positive price via `latestRoundData()`. Reverts on any validation failure.
+    /// @dev Validates the oracle address and reverts if any of the following conditions are met:
+    /// - Oracle address is zero.
+    /// - Oracle does not implement the `decimals()` function or returns a non-8 decimals.
+    /// - Oracle does not return a positive price when `latestRoundData()` is called.
     function validateOracle(AggregatorV3Interface oracle) internal view returns (uint128 price) {
         // Check: oracle address is not zero. This is needed because calling a function on address(0) succeeds but
         // returns empty data, which causes the ABI decoder to fail.

--- a/utils/src/libraries/SafeOracle.sol
+++ b/utils/src/libraries/SafeOracle.sol
@@ -86,7 +86,7 @@ library SafeOracle {
         try oracle.latestRoundData() returns (uint80, int256 _price, uint256, uint256, uint80) {
             // Because users may not always use Chainlink oracles, we do not check for the staleness of the price.
             if (_price <= 0) {
-                revert Errors.SafeOracle_NegativePrice(address(oracle));
+                revert Errors.SafeOracle_NotPositivePrice(address(oracle));
             }
             price = uint256(_price).toUint128();
         } catch {

--- a/utils/src/libraries/SafeOracle.sol
+++ b/utils/src/libraries/SafeOracle.sol
@@ -31,7 +31,12 @@ library SafeOracle {
                 return 0;
             }
 
-            price = uint256(_price).toUint128();
+            // If the price is greater than max `uint128`, return zero.
+            if (uint256(_price) > type(uint128).max) {
+                return 0;
+            }
+
+            price = uint128(uint256(_price));
             updatedAt = _updatedAt;
         } catch {
             // If the oracle call fails, return 0.

--- a/utils/src/libraries/SafeOracle.sol
+++ b/utils/src/libraries/SafeOracle.sol
@@ -7,12 +7,55 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Errors } from "./Errors.sol";
 
 /// @title SafeOracle
-/// @notice Library with helper functions for validating oracle addresses.
+/// @notice Library with helper functions for fetching and validating oracle prices.
 library SafeOracle {
     using SafeCast for uint256;
 
-    /// @dev Validates the oracle address and returns the latest price.
-    function safeOraclePrice(AggregatorV3Interface oracle) internal view returns (uint128 latestPrice) {
+    /// @dev Fetches the latest price from the oracle without reverting. Returns 0 if the oracle address is zero, the
+    /// call fails, the price is non-positive, the `updatedAt` timestamp is in the future, or the price is outdated
+    /// (older than 24 hours).
+    function safeOraclePrice(AggregatorV3Interface oracle) internal view returns (uint128 price) {
+        // If the oracle is not set, return 0.
+        if (address(oracle) == address(0)) {
+            return 0;
+        }
+
+        uint256 updatedAt;
+
+        // Interactions: query the oracle price and the time at which it was updated.
+        try AggregatorV3Interface(oracle).latestRoundData() returns (
+            uint80, int256 _price, uint256, uint256 _updatedAt, uint80
+        ) {
+            // If the price is not greater than 0, skip the calculations.
+            if (_price <= 0) {
+                return 0;
+            }
+
+            price = uint256(_price).toUint128();
+            updatedAt = _updatedAt;
+        } catch {
+            // If the oracle call fails, return 0.
+            return 0;
+        }
+
+        // Due to reorgs and latency issues, the oracle can have an `updatedAt` timestamp that is in the future. In
+        // this case, we ignore the price and return 0.
+        if (block.timestamp < updatedAt) {
+            return 0;
+        }
+
+        // If the oracle hasn't been updated in the last 24 hours, we ignore the price and return 0. This is a safety
+        // check to avoid using outdated prices.
+        unchecked {
+            if (block.timestamp - updatedAt > 24 hours) {
+                return 0;
+            }
+        }
+    }
+
+    /// @dev Validates the oracle address by checking that it is not zero, implements the `decimals()` function
+    /// returning 8, and returns a positive price via `latestRoundData()`. Reverts on any validation failure.
+    function validateOracle(AggregatorV3Interface oracle) internal view returns (uint128 price) {
         // Check: oracle address is not zero. This is needed because calling a function on address(0) succeeds but
         // returns empty data, which causes the ABI decoder to fail.
         if (address(oracle) == address(0)) {
@@ -29,12 +72,12 @@ library SafeOracle {
         }
 
         // Check: oracle returns a positive price when `latestRoundData()` is called.
-        try oracle.latestRoundData() returns (uint80, int256 price, uint256, uint256, uint80) {
+        try oracle.latestRoundData() returns (uint80, int256 _price, uint256, uint256, uint80) {
             // Because users may not always use Chainlink oracles, we do not check for the staleness of the price.
-            if (price <= 0) {
+            if (_price <= 0) {
                 revert Errors.SafeOracle_NegativePrice(address(oracle));
             }
-            latestPrice = uint256(price).toUint128();
+            price = uint256(_price).toUint128();
         } catch {
             revert Errors.SafeOracle_MissesInterface(address(oracle));
         }

--- a/utils/src/mocks/ChainlinkMocks.sol
+++ b/utils/src/mocks/ChainlinkMocks.sol
@@ -13,6 +13,10 @@ contract SafeOracleMock {
     function safeOraclePrice(AggregatorV3Interface oracle) external view returns (uint128) {
         return SafeOracle.safeOraclePrice(oracle);
     }
+
+    function validateOracle(AggregatorV3Interface oracle) external view returns (uint128) {
+        return SafeOracle.validateOracle(oracle);
+    }
 }
 
 /*//////////////////////////////////////////////////////////////////////////

--- a/utils/src/mocks/ChainlinkMocks.sol
+++ b/utils/src/mocks/ChainlinkMocks.sol
@@ -82,6 +82,23 @@ contract ChainlinkOracleNegativePrice {
     }
 }
 
+/// @notice A mock Chainlink oracle that returns a price exceeding `type(uint128).max`.
+contract ChainlinkOracleOverflowPrice {
+    function decimals() external pure returns (uint8) {
+        return DEFAULT_DECIMALS;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        int256 answer_ = int256(uint256(type(uint128).max) + 1);
+        uint256 updatedAt_ = block.timestamp;
+        return (0, answer_, 0, updatedAt_, 0);
+    }
+}
+
 /// @notice A mock Chainlink oracle that was updated more than 24 hours ago.
 contract ChainlinkOracleOutdatedPrice {
     function decimals() external pure returns (uint8) {

--- a/utils/src/mocks/ChainlinkMocks.sol
+++ b/utils/src/mocks/ChainlinkMocks.sol
@@ -10,7 +10,7 @@ uint8 constant DEFAULT_DECIMALS = 8;
 
 /// @notice Mock contract to expose the internal SafeOracle library function.
 contract SafeOracleMock {
-    function safeOraclePrice(AggregatorV3Interface oracle) external view returns (uint128) {
+    function safeOraclePrice(AggregatorV3Interface oracle) external view returns (uint128, uint256) {
         return SafeOracle.safeOraclePrice(oracle);
     }
 

--- a/utils/tests/Base.t.sol
+++ b/utils/tests/Base.t.sol
@@ -7,6 +7,7 @@ import { StdAssertions } from "forge-std/src/StdAssertions.sol";
 import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
 import { AdminableMock } from "src/mocks/AdminableMock.sol";
 import { BatchMock } from "src/mocks/BatchMock.sol";
+import { SafeOracleMock } from "src/mocks/ChainlinkMocks.sol";
 import { ComptrollerableMock } from "src/mocks/ComptrollerableMock.sol";
 import { NoDelegateCallMock } from "src/mocks/NoDelegateCallMock.sol";
 import { RoleAdminableMock } from "src/mocks/RoleAdminableMock.sol";
@@ -41,6 +42,7 @@ abstract contract Base_Test is BaseTest, Modifiers, StdAssertions, Utils {
     MerkleMock internal merkleMock;
     NoDelegateCallMock internal noDelegateCallMock;
     RoleAdminableMock internal roleAdminableMock;
+    SafeOracleMock internal safeOracleMock;
 
     /*//////////////////////////////////////////////////////////////////////////
                                        SET-UP
@@ -64,6 +66,7 @@ abstract contract Base_Test is BaseTest, Modifiers, StdAssertions, Utils {
         merkleMock = new MerkleMock();
         noDelegateCallMock = new NoDelegateCallMock();
         roleAdminableMock = new RoleAdminableMock(admin);
+        safeOracleMock = new SafeOracleMock();
 
         // Set the admin as the msg.sender.
         setMsgSender(admin);

--- a/utils/tests/integration/concrete/comptroller/convert-usd-fee-to-wei/convertUSDFeeToWei.t.sol
+++ b/utils/tests/integration/concrete/comptroller/convert-usd-fee-to-wei/convertUSDFeeToWei.t.sol
@@ -1,25 +1,16 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.22;
 
-import { stdStorage, StdStorage } from "forge-std/src/StdStorage.sol";
-import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
-
 import {
-    ChainlinkOracleFutureDatedPrice,
-    ChainlinkOracleNegativePrice,
-    ChainlinkOracleOutdatedPrice,
     ChainlinkOracleWith18Decimals,
     ChainlinkOracleWith6Decimals,
     ChainlinkOracleWithRevertingDecimals,
-    ChainlinkOracleWithRevertingPrice,
     ChainlinkOracleZeroPrice
 } from "src/mocks/ChainlinkMocks.sol";
 
 import { Base_Test } from "tests/Base.t.sol";
 
 contract ConvertUSDFeeToWei_Comptroller_Concrete_Test is Base_Test {
-    using stdStorage for StdStorage;
-
     function test_GivenOracleZero(uint128 feeUSD) external {
         comptroller.setOracle(address(0));
 
@@ -32,67 +23,21 @@ contract ConvertUSDFeeToWei_Comptroller_Concrete_Test is Base_Test {
         assertEq(comptroller.convertUSDFeeToWei(0), 0, "zero fee");
     }
 
-    function test_WhenLatestRoundCallFails(uint128 feeUSD) external givenOracleNotZero whenFeeUSDNotZero {
-        address revertOracle = address(new ChainlinkOracleWithRevertingPrice());
-
-        // Use `vm.store` since `setOracle` function reverts if call to `latestRoundData` fails.
-        uint256 oracleSlot = stdstore.target(address(comptroller)).sig(ISablierComptroller.oracle.selector).find();
-        vm.store(address(comptroller), bytes32(oracleSlot), bytes32(uint256(uint160(revertOracle))));
-
-        // Check: the oracle is modified.
-        assertEq(comptroller.oracle(), revertOracle, "oracle not modified");
+    /// @dev SafeOracle failure modes (reverting oracle, negative price, future-dated, outdated, zero price) are
+    /// tested in {SafeOraclePrice_Concrete_Test}. Here we only verify the pass-through: when safeOraclePrice returns
+    /// 0, convertUSDFeeToWei returns 0.
+    function test_WhenSafeOraclePriceZero(uint128 feeUSD) external givenOracleNotZero whenFeeUSDNotZero {
+        comptroller.setOracle(address(new ChainlinkOracleZeroPrice()));
 
         // It should return zero.
-        assertEq(comptroller.convertUSDFeeToWei(feeUSD), 0, "oracle call failed");
-    }
-
-    function test_WhenOraclePriceNegative(uint128 feeUSD)
-        external
-        givenOracleNotZero
-        whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-    {
-        comptroller.setOracle(address(new ChainlinkOracleNegativePrice()));
-
-        // It should return zero.
-        assertEq(comptroller.convertUSDFeeToWei(feeUSD), 0, "negative price");
-    }
-
-    function test_WhenOracleUpdatedTimeInFuture(uint128 feeUSD)
-        external
-        givenOracleNotZero
-        whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-    {
-        comptroller.setOracle(address(new ChainlinkOracleFutureDatedPrice()));
-
-        // It should return zero.
-        assertEq(comptroller.convertUSDFeeToWei(feeUSD), 0, "future oracle");
-    }
-
-    function test_WhenOraclePriceOutdated(uint128 feeUSD)
-        external
-        givenOracleNotZero
-        whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOracleUpdatedTimeNotInFuture
-    {
-        comptroller.setOracle(address(new ChainlinkOracleOutdatedPrice()));
-
-        // It should return zero.
-        assertEq(comptroller.convertUSDFeeToWei(feeUSD), 0, "outdated oracle");
+        assertEq(comptroller.convertUSDFeeToWei(feeUSD), 0, "safe oracle price zero");
     }
 
     function test_WhenDecimalsCallFails(uint128 feeUSD)
         external
         givenOracleNotZero
         whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOracleUpdatedTimeNotInFuture
-        whenOraclePriceNotOutdated
+        whenSafeOraclePriceNotZero
     {
         comptroller.setOracle(address(new ChainlinkOracleWithRevertingDecimals()));
 
@@ -100,33 +45,13 @@ contract ConvertUSDFeeToWei_Comptroller_Concrete_Test is Base_Test {
         assertEq(comptroller.convertUSDFeeToWei(feeUSD), 0, "decimals call failed");
     }
 
-    function test_WhenOraclePriceZero(uint128 feeUSD)
-        external
-        givenOracleNotZero
-        whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOracleUpdatedTimeNotInFuture
-        whenOraclePriceNotOutdated
-        whenDecimalsCallNotFail
-    {
-        comptroller.setOracle(address(new ChainlinkOracleZeroPrice()));
-
-        // It should return zero.
-        assertEq(comptroller.convertUSDFeeToWei(feeUSD), 0, "zero price");
-    }
-
     function test_WhenOracleReturnsEightDecimals(uint128 feeUSD)
         external
         view
         givenOracleNotZero
         whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOracleUpdatedTimeNotInFuture
-        whenOraclePriceNotOutdated
+        whenSafeOraclePriceNotZero
         whenDecimalsCallNotFail
-        whenOraclePriceNotZero
     {
         // It should convert the fee to wei.
         uint256 actualFeeInWei = comptroller.convertUSDFeeToWei(feeUSD);
@@ -138,12 +63,8 @@ contract ConvertUSDFeeToWei_Comptroller_Concrete_Test is Base_Test {
         external
         givenOracleNotZero
         whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOracleUpdatedTimeNotInFuture
-        whenOraclePriceNotOutdated
+        whenSafeOraclePriceNotZero
         whenDecimalsCallNotFail
-        whenOraclePriceNotZero
     {
         comptroller.setOracle(address(new ChainlinkOracleWith18Decimals()));
 
@@ -157,12 +78,8 @@ contract ConvertUSDFeeToWei_Comptroller_Concrete_Test is Base_Test {
         external
         givenOracleNotZero
         whenFeeUSDNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOracleUpdatedTimeNotInFuture
-        whenOraclePriceNotOutdated
+        whenSafeOraclePriceNotZero
         whenDecimalsCallNotFail
-        whenOraclePriceNotZero
     {
         comptroller.setOracle(address(new ChainlinkOracleWith6Decimals()));
 

--- a/utils/tests/integration/concrete/comptroller/convert-usd-fee-to-wei/convertUSDFeeToWei.tree
+++ b/utils/tests/integration/concrete/comptroller/convert-usd-fee-to-wei/convertUSDFeeToWei.tree
@@ -5,27 +5,15 @@ ConvertUSDFeeToWei_Comptroller_Concrete_Test
    ├── when fee USD zero
    │  └── it should return zero
    └── when fee USD not zero
-      ├── when latest round call fails
+      ├── when safe oracle price zero
       │  └── it should return zero
-      └── when latest round call not fail
-         ├── when oracle price negative
+      └── when safe oracle price not zero
+         ├── when decimals call fails
          │  └── it should return zero
-         └── when oracle price not negative
-            ├── when oracle updated time in future
-            │  └── it should return zero
-            └── when oracle updated time not in future
-               ├── when oracle price outdated
-               │  └── it should return zero
-               └── when oracle price not outdated
-                  ├── when decimals call fails
-                  │  └── it should return zero
-                  └── when decimals call not fail
-                     ├── when oracle price zero
-                     │  └── it should return zero
-                     └── when oracle price not zero
-                        ├── when oracle returns eight decimals
-                        │  └── it should convert the fee to wei
-                        ├── when oracle returns more than eight decimals
-                        │  └── it should convert the fee to wei
-                        └── when oracle returns less than eight decimals
-                           └── it should convert the fee to wei
+         └── when decimals call not fail
+            ├── when oracle returns eight decimals
+            │  └── it should convert the fee to wei
+            ├── when oracle returns more than eight decimals
+            │  └── it should convert the fee to wei
+            └── when oracle returns less than eight decimals
+               └── it should convert the fee to wei

--- a/utils/tests/integration/concrete/comptroller/convert-usd-fee-to-wei/convertUSDFeeToWei.tree
+++ b/utils/tests/integration/concrete/comptroller/convert-usd-fee-to-wei/convertUSDFeeToWei.tree
@@ -8,12 +8,15 @@ ConvertUSDFeeToWei_Comptroller_Concrete_Test
       ├── when safe oracle price zero
       │  └── it should return zero
       └── when safe oracle price not zero
-         ├── when decimals call fails
+         ├── when oracle price outdated
          │  └── it should return zero
-         └── when decimals call not fail
-            ├── when oracle returns eight decimals
-            │  └── it should convert the fee to wei
-            ├── when oracle returns more than eight decimals
-            │  └── it should convert the fee to wei
-            └── when oracle returns less than eight decimals
-               └── it should convert the fee to wei
+         └── when oracle price not outdated
+            ├── when decimals call fails
+            │  └── it should return zero
+            └── when decimals call not fail
+               ├── when oracle returns eight decimals
+               │  └── it should convert the fee to wei
+               ├── when oracle returns more than eight decimals
+               │  └── it should convert the fee to wei
+               └── when oracle returns less than eight decimals
+                  └── it should convert the fee to wei

--- a/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.t.sol
+++ b/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22 <0.9.0;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+import {
+    ChainlinkOracleFutureDatedPrice,
+    ChainlinkOracleMock,
+    ChainlinkOracleNegativePrice,
+    ChainlinkOracleOutdatedPrice,
+    ChainlinkOracleWithRevertingPrice,
+    ChainlinkOracleZeroPrice,
+    SafeOracleMock
+} from "src/mocks/ChainlinkMocks.sol";
+
+import { Base_Test } from "../../../../Base.t.sol";
+
+contract SafeOraclePrice_Concrete_Test is Base_Test {
+    SafeOracleMock internal safeOracleMock;
+
+    function setUp() public override {
+        Base_Test.setUp();
+        safeOracleMock = new SafeOracleMock();
+    }
+
+    function test_WhenOracleAddressZero() external {
+        // It should return zero.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(0)));
+        assertEq(price, 0, "zero oracle");
+    }
+
+    function test_WhenLatestRoundCallFails() external whenOracleAddressNotZero {
+        ChainlinkOracleWithRevertingPrice oracle = new ChainlinkOracleWithRevertingPrice();
+
+        // It should return zero.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "reverting oracle");
+    }
+
+    function test_WhenOraclePriceNegative() external whenOracleAddressNotZero whenLatestRoundCallNotFail {
+        ChainlinkOracleNegativePrice oracle = new ChainlinkOracleNegativePrice();
+
+        // It should return zero.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "negative price");
+    }
+
+    function test_WhenOracleUpdatedTimeInFuture()
+        external
+        whenOracleAddressNotZero
+        whenLatestRoundCallNotFail
+        whenOraclePriceNotNegative
+    {
+        ChainlinkOracleFutureDatedPrice oracle = new ChainlinkOracleFutureDatedPrice();
+
+        // It should return zero.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "future oracle");
+    }
+
+    function test_WhenOraclePriceOutdated()
+        external
+        whenOracleAddressNotZero
+        whenLatestRoundCallNotFail
+        whenOraclePriceNotNegative
+        whenOracleUpdatedTimeNotInFuture
+    {
+        ChainlinkOracleOutdatedPrice oracle = new ChainlinkOracleOutdatedPrice();
+
+        // It should return zero.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "outdated oracle");
+    }
+
+    function test_WhenOraclePriceZero()
+        external
+        whenOracleAddressNotZero
+        whenLatestRoundCallNotFail
+        whenOraclePriceNotNegative
+        whenOracleUpdatedTimeNotInFuture
+        whenOraclePriceNotOutdated
+    {
+        ChainlinkOracleZeroPrice oracle = new ChainlinkOracleZeroPrice();
+
+        // It should return zero.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "zero price");
+    }
+
+    function test_WhenOraclePriceNotZero()
+        external
+        whenOracleAddressNotZero
+        whenLatestRoundCallNotFail
+        whenOraclePriceNotNegative
+        whenOracleUpdatedTimeNotInFuture
+        whenOraclePriceNotOutdated
+    {
+        ChainlinkOracleMock oracle = new ChainlinkOracleMock();
+
+        // It should return the latest price.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 3000e8, "latestPrice");
+    }
+}

--- a/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.t.sol
+++ b/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.t.sol
@@ -8,6 +8,7 @@ import {
     ChainlinkOracleMock,
     ChainlinkOracleNegativePrice,
     ChainlinkOracleOutdatedPrice,
+    ChainlinkOracleOverflowPrice,
     ChainlinkOracleWithRevertingPrice,
     ChainlinkOracleZeroPrice,
     SafeOracleMock
@@ -45,11 +46,25 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
         assertEq(price, 0, "negative price");
     }
 
+    function test_WhenOraclePriceExceedsUint128Max()
+        external
+        whenOracleAddressNotZero
+        whenLatestRoundCallNotFail
+        whenOraclePriceNotNegative
+    {
+        ChainlinkOracleOverflowPrice oracle = new ChainlinkOracleOverflowPrice();
+
+        // It should return zero.
+        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "overflow price");
+    }
+
     function test_WhenOracleUpdatedTimeInFuture()
         external
         whenOracleAddressNotZero
         whenLatestRoundCallNotFail
         whenOraclePriceNotNegative
+        whenOraclePriceNotExceedUint128Max
     {
         ChainlinkOracleFutureDatedPrice oracle = new ChainlinkOracleFutureDatedPrice();
 
@@ -63,6 +78,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
         whenOracleAddressNotZero
         whenLatestRoundCallNotFail
         whenOraclePriceNotNegative
+        whenOraclePriceNotExceedUint128Max
         whenOracleUpdatedTimeNotInFuture
     {
         ChainlinkOracleOutdatedPrice oracle = new ChainlinkOracleOutdatedPrice();
@@ -77,6 +93,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
         whenOracleAddressNotZero
         whenLatestRoundCallNotFail
         whenOraclePriceNotNegative
+        whenOraclePriceNotExceedUint128Max
         whenOracleUpdatedTimeNotInFuture
         whenOraclePriceNotOutdated
     {
@@ -92,6 +109,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
         whenOracleAddressNotZero
         whenLatestRoundCallNotFail
         whenOraclePriceNotNegative
+        whenOraclePriceNotExceedUint128Max
         whenOracleUpdatedTimeNotInFuture
         whenOraclePriceNotOutdated
     {

--- a/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.t.sol
+++ b/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.t.sol
@@ -7,116 +7,90 @@ import {
     ChainlinkOracleFutureDatedPrice,
     ChainlinkOracleMock,
     ChainlinkOracleNegativePrice,
-    ChainlinkOracleOutdatedPrice,
     ChainlinkOracleOverflowPrice,
     ChainlinkOracleWithRevertingPrice,
-    ChainlinkOracleZeroPrice,
-    SafeOracleMock
+    ChainlinkOracleZeroPrice
 } from "src/mocks/ChainlinkMocks.sol";
 
 import { Base_Test } from "../../../../Base.t.sol";
 
 contract SafeOraclePrice_Concrete_Test is Base_Test {
-    SafeOracleMock internal safeOracleMock;
-
-    function setUp() public override {
-        Base_Test.setUp();
-        safeOracleMock = new SafeOracleMock();
-    }
-
     function test_WhenOracleAddressZero() external {
-        // It should return zero.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(0)));
-        assertEq(price, 0, "zero oracle");
+        // It should return zero for both price and updatedAt.
+        (uint128 price, uint256 updatedAt) = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(0)));
+        assertEq(price, 0, "price");
+        assertEq(updatedAt, 0, "updatedAt");
     }
 
     function test_WhenLatestRoundCallFails() external whenOracleAddressNotZero {
         ChainlinkOracleWithRevertingPrice oracle = new ChainlinkOracleWithRevertingPrice();
 
-        // It should return zero.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
-        assertEq(price, 0, "reverting oracle");
+        // It should return zero for both price and updatedAt.
+        (uint128 price, uint256 updatedAt) = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "price");
+        assertEq(updatedAt, 0, "updatedAt");
     }
 
     function test_WhenOraclePriceNegative() external whenOracleAddressNotZero whenLatestRoundCallNotFail {
         ChainlinkOracleNegativePrice oracle = new ChainlinkOracleNegativePrice();
 
-        // It should return zero.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
-        assertEq(price, 0, "negative price");
+        // It should return zero for price.
+        (uint128 price, uint256 updatedAt) = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "price");
+        assertEq(updatedAt, getBlockTimestamp(), "updatedAt");
+    }
+
+    function test_WhenOraclePriceZero() external whenOracleAddressNotZero whenLatestRoundCallNotFail {
+        ChainlinkOracleZeroPrice oracle = new ChainlinkOracleZeroPrice();
+
+        // It should return zero for price.
+        (uint128 price, uint256 updatedAt) = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "price");
+        assertEq(updatedAt, getBlockTimestamp(), "updatedAt");
     }
 
     function test_WhenOraclePriceExceedsUint128Max()
         external
         whenOracleAddressNotZero
         whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
+        whenOraclePricePositive
     {
         ChainlinkOracleOverflowPrice oracle = new ChainlinkOracleOverflowPrice();
 
-        // It should return zero.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
-        assertEq(price, 0, "overflow price");
+        // It should return zero for price.
+        (uint128 price, uint256 updatedAt) = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "price");
+        assertEq(updatedAt, getBlockTimestamp(), "updatedAt");
     }
 
     function test_WhenOracleUpdatedTimeInFuture()
         external
         whenOracleAddressNotZero
         whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
+        whenOraclePricePositive
         whenOraclePriceNotExceedUint128Max
     {
         ChainlinkOracleFutureDatedPrice oracle = new ChainlinkOracleFutureDatedPrice();
 
-        // It should return zero.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
-        assertEq(price, 0, "future oracle");
+        // It should return zero for price.
+        (uint128 price, uint256 updatedAt) = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 0, "price");
+        assertEq(updatedAt, getBlockTimestamp() + 1, "updatedAt");
     }
 
-    function test_WhenOraclePriceOutdated()
+    function test_WhenOracleUpdatedTimeNotInFuture()
         external
         whenOracleAddressNotZero
         whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
+        whenOraclePricePositive
         whenOraclePriceNotExceedUint128Max
         whenOracleUpdatedTimeNotInFuture
-    {
-        ChainlinkOracleOutdatedPrice oracle = new ChainlinkOracleOutdatedPrice();
-
-        // It should return zero.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
-        assertEq(price, 0, "outdated oracle");
-    }
-
-    function test_WhenOraclePriceZero()
-        external
-        whenOracleAddressNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOraclePriceNotExceedUint128Max
-        whenOracleUpdatedTimeNotInFuture
-        whenOraclePriceNotOutdated
-    {
-        ChainlinkOracleZeroPrice oracle = new ChainlinkOracleZeroPrice();
-
-        // It should return zero.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
-        assertEq(price, 0, "zero price");
-    }
-
-    function test_WhenOraclePriceNotZero()
-        external
-        whenOracleAddressNotZero
-        whenLatestRoundCallNotFail
-        whenOraclePriceNotNegative
-        whenOraclePriceNotExceedUint128Max
-        whenOracleUpdatedTimeNotInFuture
-        whenOraclePriceNotOutdated
     {
         ChainlinkOracleMock oracle = new ChainlinkOracleMock();
 
-        // It should return the latest price.
-        uint128 price = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
-        assertEq(price, 3000e8, "latestPrice");
+        // It should return the latest price and updatedAt.
+        (uint128 price, uint256 updatedAt) = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        assertEq(price, 3000e8, "price");
+        assertEq(updatedAt, getBlockTimestamp(), "updatedAt");
     }
 }

--- a/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.tree
+++ b/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.tree
@@ -1,23 +1,19 @@
 SafeOraclePrice_Concrete_Test
 ├── when oracle address zero
-│  └── it should return zero
+│  └── it should return zero for both price and updatedAt
 └── when oracle address not zero
    ├── when latest round call fails
-   │  └── it should return zero
+   │  └── it should return zero for both price and updatedAt
    └── when latest round call not fail
       ├── when oracle price negative
-      │  └── it should return zero
-      └── when oracle price not negative
+      │  └── it should return zero for price
+      ├── when oracle price zero
+      │  └── it should return zero for price
+      └── when oracle price positive
          ├── when oracle price exceeds uint128 max
-         │  └── it should return zero
+         │  └── it should return zero for price
          └── when oracle price not exceed uint128 max
             ├── when oracle updated time in future
-            │  └── it should return zero
+            │  └── it should return zero for price
             └── when oracle updated time not in future
-               ├── when oracle price outdated
-               │  └── it should return zero
-               └── when oracle price not outdated
-                  ├── when oracle price zero
-                  │  └── it should return zero
-                  └── when oracle price not zero
-                     └── it should return the latest price
+               └── it should return the latest price and updatedAt

--- a/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.tree
+++ b/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.tree
@@ -8,13 +8,16 @@ SafeOraclePrice_Concrete_Test
       ├── when oracle price negative
       │  └── it should return zero
       └── when oracle price not negative
-         ├── when oracle updated time in future
+         ├── when oracle price exceeds uint128 max
          │  └── it should return zero
-         └── when oracle updated time not in future
-            ├── when oracle price outdated
+         └── when oracle price not exceed uint128 max
+            ├── when oracle updated time in future
             │  └── it should return zero
-            └── when oracle price not outdated
-               ├── when oracle price zero
+            └── when oracle updated time not in future
+               ├── when oracle price outdated
                │  └── it should return zero
-               └── when oracle price not zero
-                  └── it should return the latest price
+               └── when oracle price not outdated
+                  ├── when oracle price zero
+                  │  └── it should return zero
+                  └── when oracle price not zero
+                     └── it should return the latest price

--- a/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.tree
+++ b/utils/tests/integration/concrete/safe-oracle/safe-oracle-price/safeOraclePrice.tree
@@ -1,0 +1,20 @@
+SafeOraclePrice_Concrete_Test
+├── when oracle address zero
+│  └── it should return zero
+└── when oracle address not zero
+   ├── when latest round call fails
+   │  └── it should return zero
+   └── when latest round call not fail
+      ├── when oracle price negative
+      │  └── it should return zero
+      └── when oracle price not negative
+         ├── when oracle updated time in future
+         │  └── it should return zero
+         └── when oracle updated time not in future
+            ├── when oracle price outdated
+            │  └── it should return zero
+            └── when oracle price not outdated
+               ├── when oracle price zero
+               │  └── it should return zero
+               └── when oracle price not zero
+                  └── it should return the latest price

--- a/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.t.sol
+++ b/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.t.sol
@@ -69,7 +69,7 @@ contract ValidateOracle_Concrete_Test is Base_Test {
         ChainlinkOracleNegativePrice oracle = new ChainlinkOracleNegativePrice();
 
         // It should revert.
-        vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_NegativePrice.selector, address(oracle)));
+        vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_NotPositivePrice.selector, address(oracle)));
         safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
     }
 
@@ -83,7 +83,7 @@ contract ValidateOracle_Concrete_Test is Base_Test {
         ChainlinkOracleZeroPrice oracle = new ChainlinkOracleZeroPrice();
 
         // It should revert.
-        vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_NegativePrice.selector, address(oracle)));
+        vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_NotPositivePrice.selector, address(oracle)));
         safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
     }
 

--- a/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.t.sol
+++ b/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.t.sol
@@ -10,20 +10,12 @@ import {
     ChainlinkOracleWith18Decimals,
     ChainlinkOracleWithRevertingDecimals,
     ChainlinkOracleWithRevertingPrice,
-    ChainlinkOracleZeroPrice,
-    SafeOracleMock
+    ChainlinkOracleZeroPrice
 } from "src/mocks/ChainlinkMocks.sol";
 
 import { Base_Test } from "../../../../Base.t.sol";
 
 contract ValidateOracle_Concrete_Test is Base_Test {
-    SafeOracleMock internal safeOracleMock;
-
-    function setUp() public override {
-        Base_Test.setUp();
-        safeOracleMock = new SafeOracleMock();
-    }
-
     function test_RevertWhen_OracleAddressZero() external {
         // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_MissesInterface.selector, address(0)));

--- a/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.t.sol
+++ b/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.t.sol
@@ -14,9 +14,9 @@ import {
     SafeOracleMock
 } from "src/mocks/ChainlinkMocks.sol";
 
-import { Base_Test } from "../../../Base.t.sol";
+import { Base_Test } from "../../../../Base.t.sol";
 
-contract SafeOraclePrice_Concrete_Test is Base_Test {
+contract ValidateOracle_Concrete_Test is Base_Test {
     SafeOracleMock internal safeOracleMock;
 
     function setUp() public override {
@@ -27,7 +27,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
     function test_RevertWhen_OracleAddressZero() external {
         // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_MissesInterface.selector, address(0)));
-        safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(0)));
+        safeOracleMock.validateOracle(AggregatorV3Interface(address(0)));
     }
 
     function test_RevertWhen_OracleMissesDecimals() external whenOracleAddressNotZero {
@@ -35,7 +35,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
 
         // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_MissesInterface.selector, address(oracle)));
-        safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
     }
 
     function test_RevertWhen_OracleDecimalsNot8() external whenOracleAddressNotZero whenOracleNotMissDecimals {
@@ -43,7 +43,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
 
         // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_DecimalsNotEight.selector, address(oracle), 18));
-        safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
     }
 
     function test_RevertWhen_OracleMissesLatestRoundData()
@@ -56,7 +56,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
 
         // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_MissesInterface.selector, address(oracle)));
-        safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
     }
 
     function test_RevertWhen_OraclePriceNegative()
@@ -70,7 +70,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
 
         // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_NegativePrice.selector, address(oracle)));
-        safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
     }
 
     function test_RevertWhen_OraclePriceZero()
@@ -84,7 +84,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
 
         // It should revert.
         vm.expectRevert(abi.encodeWithSelector(Errors.SafeOracle_NegativePrice.selector, address(oracle)));
-        safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
     }
 
     function test_WhenOraclePricePositive()
@@ -97,7 +97,7 @@ contract SafeOraclePrice_Concrete_Test is Base_Test {
         ChainlinkOracleMock oracle = new ChainlinkOracleMock();
 
         // It should return the latest price.
-        uint128 latestPrice = safeOracleMock.safeOraclePrice(AggregatorV3Interface(address(oracle)));
+        uint128 latestPrice = safeOracleMock.validateOracle(AggregatorV3Interface(address(oracle)));
         assertEq(latestPrice, 3000e8, "latestPrice");
     }
 }

--- a/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.tree
+++ b/utils/tests/integration/concrete/safe-oracle/validate-oracle/validateOracle.tree
@@ -1,4 +1,4 @@
-SafeOraclePrice_Concrete_Test
+ValidateOracle_Concrete_Test
 ├── when oracle address zero
 │  └── it should revert
 └── when oracle address not zero

--- a/utils/tests/utils/Modifiers.sol
+++ b/utils/tests/utils/Modifiers.sol
@@ -154,7 +154,7 @@ abstract contract Modifiers is BaseTest {
         _;
     }
 
-    modifier whenOraclePriceNotZero() {
+    modifier whenSafeOraclePriceNotZero() {
         _;
     }
 

--- a/utils/tests/utils/Modifiers.sol
+++ b/utils/tests/utils/Modifiers.sol
@@ -86,10 +86,6 @@ abstract contract Modifiers is BaseTest {
         _;
     }
 
-    modifier whenFlowCallNotRevert() {
-        _;
-    }
-
     modifier whenFunctionExists() {
         _;
     }
@@ -150,19 +146,19 @@ abstract contract Modifiers is BaseTest {
         _;
     }
 
-    modifier whenOraclePriceNotNegative() {
-        _;
-    }
-
     modifier whenOraclePriceNotOutdated() {
         _;
     }
 
-    modifier whenSafeOraclePriceNotZero() {
+    modifier whenOraclePricePositive() {
         _;
     }
 
     modifier whenOracleUpdatedTimeNotInFuture() {
+        _;
+    }
+
+    modifier whenSafeOraclePriceNotZero() {
         _;
     }
 

--- a/utils/tests/utils/Modifiers.sol
+++ b/utils/tests/utils/Modifiers.sol
@@ -146,6 +146,10 @@ abstract contract Modifiers is BaseTest {
         _;
     }
 
+    modifier whenOraclePriceNotExceedUint128Max() {
+        _;
+    }
+
     modifier whenOraclePriceNotNegative() {
         _;
     }


### PR DESCRIPTION
this PR isolates the changes made to `lockup` and `utils` in my bob review

- rename the previous `SafeOracle.safeOraclePrice` to `SafeOracle.validateOracle`
- add `SafeOracle.safeOraclePrice`, which never reverts, and use it in `LockupMath`

note: lockup's size is still below the margin

<img width="909" height="53" alt="image" src="https://github.com/user-attachments/assets/efc06ba6-dafb-4bc6-8394-0f84e84685cb" />
