### PR TITLE
chore: polish event names to follow verb + noun convention

### DIFF
--- a/airdrops/src/SablierMerkleVCA.sol
+++ b/airdrops/src/SablierMerkleVCA.sol
@@ -236,7 +236,7 @@ contract SablierMerkleVCA is
         isRedistributionEnabled = true;
 
         // Log the event.
-        emit RedistributionEnabled();
+        emit EnableRedistribution();
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -349,7 +349,7 @@ contract SablierMerkleVCA is
                     transferAmount += rewardAmount;
 
                     // Log the event.
-                    emit RedistributionReward(index, recipient, rewardAmount, to);
+                    emit RedistributeReward(index, recipient, rewardAmount, to);
                 }
             }
         }

--- a/airdrops/src/interfaces/ISablierMerkleVCA.sol
+++ b/airdrops/src/interfaces/ISablierMerkleVCA.sol
@@ -25,10 +25,10 @@ interface ISablierMerkleVCA is ISablierMerkleSignature {
     );
 
     /// @notice Emitted when the redistribution is enabled.
-    event RedistributionEnabled();
+    event EnableRedistribution();
 
     /// @notice Emitted when a recipient receives rewards from the forgone tokens pool.
-    event RedistributionReward(uint256 index, address indexed recipient, uint128 amount, address to);
+    event RedistributeReward(uint256 index, address indexed recipient, uint128 amount, address to);
 
     /*//////////////////////////////////////////////////////////////////////////
                                 READ-ONLY FUNCTIONS
@@ -88,7 +88,7 @@ interface ISablierMerkleVCA is ISablierMerkleSignature {
     /// reward amount based on the total amount of tokens forgone by early claimers and transfers it to the recipients
     /// claiming after the vesting end time.
     ///
-    /// @dev It emits a {ClaimVCA} event, and a {RedistributionReward} event if the redistribution is enabled.
+    /// @dev It emits a {ClaimVCA} event, and a {RedistributeReward} event if the redistribution is enabled.
     ///
     /// Notes:
     /// - There can be a race condition among recipients if:

--- a/airdrops/tests/fork/merkle-campaign/MerkleVCA.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleVCA.t.sol
@@ -115,10 +115,10 @@ abstract contract MerkleVCA_Fork_Test is MerkleBase_Fork_Test {
         if (getBlockTimestamp() >= vestingEndTime && enableRedistribution) {
             expectedRewardAmount = merkleVCA.calculateRedistributionRewards({ fullAmount: vars.leafToClaim.amount });
 
-            // It should emit a {RedistributionReward} event if there are rewards to distribute.
+            // It should emit a {RedistributeReward} event if there are rewards to distribute.
             if (expectedRewardAmount > 0) {
                 vm.expectEmit({ emitter: address(merkleVCA) });
-                emit ISablierMerkleVCA.RedistributionReward({
+                emit ISablierMerkleVCA.RedistributeReward({
                     index: vars.leafToClaim.index,
                     recipient: vars.leafToClaim.recipient,
                     amount: expectedRewardAmount,

--- a/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/claim-to/claimTo.t.sol
@@ -182,11 +182,11 @@ contract ClaimTo_MerkleVCA_Integration_Test is
         uint128 rewardAmount = expectedTransferAmount - claimAmount;
         uint128 previousRedistributionPaid = merkleVCA.totalRedistributionAmountPaid();
 
-        // It should emit a {RedistributionReward} event for claims made after the vesting end time only if
+        // It should emit a {RedistributeReward} event for claims made after the vesting end time only if
         // redistribution is enabled.
         if (isRedistributionEnabled) {
             vm.expectEmit({ emitter: address(merkleVCA) });
-            emit ISablierMerkleVCA.RedistributionReward({
+            emit ISablierMerkleVCA.RedistributeReward({
                 index: index,
                 recipient: users.recipient,
                 amount: rewardAmount,

--- a/airdrops/tests/integration/concrete/campaign/vca/enable-redistribution/enableRedistribution.t.sol
+++ b/airdrops/tests/integration/concrete/campaign/vca/enable-redistribution/enableRedistribution.t.sol
@@ -42,9 +42,9 @@ contract EnableRedistribution_MerkleVCA_Integration_Test is MerkleVCA_Integratio
     }
 
     function test_GivenRedistributionNotEnabled() external whenCallerCampaignCreator givenVestingEndTimeInFuture {
-        // It should emit {RedistributionEnabled} event.
+        // It should emit {EnableRedistribution} event.
         vm.expectEmit({ emitter: address(merkleVCA) });
-        emit ISablierMerkleVCA.RedistributionEnabled();
+        emit ISablierMerkleVCA.EnableRedistribution();
 
         merkleVCA.enableRedistribution();
 

--- a/airdrops/tests/integration/concrete/campaign/vca/enable-redistribution/enableRedistribution.tree
+++ b/airdrops/tests/integration/concrete/campaign/vca/enable-redistribution/enableRedistribution.tree
@@ -9,4 +9,4 @@ EnableRedistribution_MerkleVCA_Integration_Test
       │  └── it should revert
       └── given redistribution not enabled
          ├── it should enable redistribution
-         └── it should emit {RedistributionEnabled} event
+         └── it should emit {EnableRedistribution} event

--- a/airdrops/tests/integration/fuzz/MerkleVCA.t.sol
+++ b/airdrops/tests/integration/fuzz/MerkleVCA.t.sol
@@ -274,10 +274,10 @@ contract MerkleVCA_Fuzz_Test is Shared_Fuzz_Test {
             // Update the total redistribution amount paid.
             totalRedistributionAmountPaid += expectedRewardAmount;
 
-            // It should emit a {RedistributionReward} event if there are rewards to distribute.
+            // It should emit a {RedistributeReward} event if there are rewards to distribute.
             if (expectedRewardAmount > 0) {
                 vm.expectEmit({ emitter: address(merkleVCA) });
-                emit ISablierMerkleVCA.RedistributionReward({
+                emit ISablierMerkleVCA.RedistributeReward({
                     index: leafData.index,
                     recipient: leafData.recipient,
                     amount: expectedRewardAmount,

--- a/utils/src/RoleAdminable.sol
+++ b/utils/src/RoleAdminable.sol
@@ -69,8 +69,8 @@ abstract contract RoleAdminable is IRoleAdminable, Adminable {
         // Effect: grant the `role` to `account`.
         _roles[role][account] = true;
 
-        // Emit the {RoleGranted} event.
-        emit RoleGranted({ admin: msg.sender, account: account, role: role });
+        // Emit the {GrantRole} event.
+        emit GrantRole({ admin: msg.sender, account: account, role: role });
     }
 
     /// @inheritdoc IRoleAdminable

--- a/utils/src/interfaces/IRoleAdminable.sol
+++ b/utils/src/interfaces/IRoleAdminable.sol
@@ -15,7 +15,7 @@ interface IRoleAdminable is IAdminable {
     /// @param admin The address of the admin that granted the role.
     /// @param account The address of the account to which the role is granted.
     /// @param role The identifier of the role.
-    event RoleGranted(address indexed admin, address indexed account, bytes32 indexed role);
+    event GrantRole(address indexed admin, address indexed account, bytes32 indexed role);
 
     /// @notice Emitted when `account` is revoked `role`.
     /// @param admin The address of the admin that revoked the role.
@@ -45,7 +45,7 @@ interface IRoleAdminable is IAdminable {
 
     /// @notice Grants `role` to `account`. Reverts if `account` already has the role.
     ///
-    /// @dev Emits {RoleGranted} event.
+    /// @dev Emits {GrantRole} event.
     ///
     /// Requirements:
     /// - `msg.sender` must be the admin.

--- a/utils/tests/integration/concrete/role-adminable/grant-role/grantRole.t.sol
+++ b/utils/tests/integration/concrete/role-adminable/grant-role/grantRole.t.sol
@@ -22,9 +22,9 @@ contract GrantRole_RoleAdminable_Concrete_Test is Base_Test {
     }
 
     function test_GivenAccountNotHaveRole() external whenCallerAdmin {
-        // It should emit {RoleGranted} event.
+        // It should emit {GrantRole} event.
         vm.expectEmit({ emitter: address(roleAdminableMock) });
-        emit IRoleAdminable.RoleGranted({ admin: admin, account: users.eve, role: FEE_COLLECTOR_ROLE });
+        emit IRoleAdminable.GrantRole({ admin: admin, account: users.eve, role: FEE_COLLECTOR_ROLE });
 
         // Grant the role to Eve.
         roleAdminableMock.grantRole(FEE_COLLECTOR_ROLE, users.eve);

--- a/utils/tests/integration/concrete/role-adminable/grant-role/grantRole.tree
+++ b/utils/tests/integration/concrete/role-adminable/grant-role/grantRole.tree
@@ -6,4 +6,4 @@ GrantRole_RoleAdminable_Concrete_Test
    │  └── it should revert
    └── given account not have role
       ├── it should grant role to the account
-      └── it should emit {RoleGranted} event
+      └── it should emit {GrantRole} event

--- a/utils/tests/integration/fuzz/role-adminable/grantRole.t.sol
+++ b/utils/tests/integration/fuzz/role-adminable/grantRole.t.sol
@@ -34,7 +34,7 @@ contract GrantRole_RoleAdminable_Fuzz_Test is Base_Test {
 
         // Expect the relevant event to be emitted.
         vm.expectEmit({ emitter: address(roleAdminableMock) });
-        emit IRoleAdminable.RoleGranted({ admin: admin, account: account, role: role });
+        emit IRoleAdminable.GrantRole({ admin: admin, account: account, role: role });
 
         // Grant the role to account.
         roleAdminableMock.grantRole(role, account);


### PR DESCRIPTION
## Summary
- Rename `RedistributionEnabled` to `EnableRedistribution`
- Rename `RedistributionReward` to `RedistributeReward`
- Rename `RoleGranted` to `GrantRole`

Closes #1430