### PR TITLE
fix(adapter): check isStakedInAdapter in requestLidoWithdrawal to prevent cross-vault wstETH consumption

### DIFF
--- a/bob/src/SablierLidoAdapter.sol
+++ b/bob/src/SablierLidoAdapter.sol
@@ -259,6 +259,11 @@ contract SablierLidoAdapter is
             revert Errors.SablierLidoAdapter_VaultActive(vaultId);
         }
 
+        // Check: the vault tokens are still staked in the adapter.
+        if (!ISablierBobState(SABLIER_BOB).isStakedInAdapter(vaultId)) {
+            revert Errors.SablierLidoAdapter_VaultAlreadyUnstaked(vaultId);
+        }
+
         // Check: Lido withdrawal has not already been requested for this vault.
         if (_lidoWithdrawalRequestIds[vaultId].length > 0) {
             revert Errors.SablierLidoAdapter_LidoWithdrawalAlreadyRequested(vaultId);

--- a/bob/src/interfaces/ISablierLidoAdapter.sol
+++ b/bob/src/interfaces/ISablierLidoAdapter.sol
@@ -85,9 +85,10 @@ interface ISablierLidoAdapter is ISablierBobAdapter {
     ///
     /// Requirements:
     /// - The caller must be the comptroller.
-    /// - The vault must have wstETH to withdraw.
     /// - The status of the vault must not be ACTIVE.
+    /// - The vault must still be staked in the adapter (not already unstaked via Curve).
     /// - A withdrawal request must not have already been requested for this vault.
+    /// - The vault must have wstETH to withdraw.
     /// - The total amount to withdraw must not be less than the minimum amount per request.
     ///
     /// @param vaultId The ID of the vault.

--- a/bob/src/libraries/Errors.sol
+++ b/bob/src/libraries/Errors.sol
@@ -168,6 +168,9 @@ library Errors {
     /// @notice Thrown when trying to request a Lido withdrawal for a vault that is active.
     error SablierLidoAdapter_VaultActive(uint256 vaultId);
 
+    /// @notice Thrown when trying to request a Lido withdrawal for a vault that has already been unstaked.
+    error SablierLidoAdapter_VaultAlreadyUnstaked(uint256 vaultId);
+
     /// @notice Thrown when the calculated wstETH transfer amount rounds down to zero due to floor division.
     error SablierLidoAdapter_WstETHTransferAmountZero(uint256 vaultId, address from, address to);
 

--- a/bob/tests/bob/integration/concrete/lido-adapter/request-lido-withdrawal/requestLidoWithdrawal.t.sol
+++ b/bob/tests/bob/integration/concrete/lido-adapter/request-lido-withdrawal/requestLidoWithdrawal.t.sol
@@ -31,7 +31,23 @@ contract RequestLidoWithdrawal_Integration_Concrete_Test is Integration_Test {
         adapter.requestLidoWithdrawal(vaultIds.vaultWithAdapter);
     }
 
-    function test_RevertGiven_LidoWithdrawalRequested() external whenCallerComptroller givenNotACTIVEStatus {
+    function test_RevertGiven_AlreadyUnstaked() external whenCallerComptroller givenNotACTIVEStatus {
+        // Unstake via Curve path first.
+        bob.unstakeTokensViaAdapter(vaultIds.vaultWithAdapter);
+
+        // It should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.SablierLidoAdapter_VaultAlreadyUnstaked.selector, vaultIds.vaultWithAdapter)
+        );
+        adapter.requestLidoWithdrawal(vaultIds.vaultWithAdapter);
+    }
+
+    function test_RevertGiven_LidoWithdrawalRequested()
+        external
+        whenCallerComptroller
+        givenNotACTIVEStatus
+        givenNotAlreadyUnstaked
+    {
         // Request a Lido withdrawal so it reverts on the second request.
         adapter.requestLidoWithdrawal(vaultIds.vaultWithAdapter);
 
@@ -48,19 +64,24 @@ contract RequestLidoWithdrawal_Integration_Concrete_Test is Integration_Test {
         external
         whenCallerComptroller
         givenNotACTIVEStatus
+        givenNotAlreadyUnstaked
         givenLidoWithdrawalNotRequested
     {
+        // Create a vault with adapter but no deposits (wstETH balance is zero).
+        vm.warp(FEB_1_2026);
+        uint256 emptyVaultId = createVaultWithAdapter();
+        vm.warp(EXPIRY);
+
         // It should revert.
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.SablierLidoAdapter_NoWstETHToWithdraw.selector, vaultIds.defaultVault)
-        );
-        adapter.requestLidoWithdrawal(vaultIds.defaultVault);
+        vm.expectRevert(abi.encodeWithSelector(Errors.SablierLidoAdapter_NoWstETHToWithdraw.selector, emptyVaultId));
+        adapter.requestLidoWithdrawal(emptyVaultId);
     }
 
     function test_RevertGiven_AmountNotExceedMinPerRequest()
         external
         whenCallerComptroller
         givenNotACTIVEStatus
+        givenNotAlreadyUnstaked
         givenLidoWithdrawalNotRequested
         givenTotalWstETHNotZero
     {
@@ -87,6 +108,7 @@ contract RequestLidoWithdrawal_Integration_Concrete_Test is Integration_Test {
         external
         whenCallerComptroller
         givenNotACTIVEStatus
+        givenNotAlreadyUnstaked
         givenLidoWithdrawalNotRequested
         givenTotalWstETHNotZero
         givenAmountExceedsMinPerRequest
@@ -107,6 +129,7 @@ contract RequestLidoWithdrawal_Integration_Concrete_Test is Integration_Test {
         external
         whenCallerComptroller
         givenNotACTIVEStatus
+        givenNotAlreadyUnstaked
         givenLidoWithdrawalNotRequested
         givenTotalWstETHNotZero
         givenAmountExceedsMinPerRequest
@@ -130,6 +153,7 @@ contract RequestLidoWithdrawal_Integration_Concrete_Test is Integration_Test {
         external
         whenCallerComptroller
         givenNotACTIVEStatus
+        givenNotAlreadyUnstaked
         givenLidoWithdrawalNotRequested
         givenTotalWstETHNotZero
         givenAmountExceedsMinPerRequest

--- a/bob/tests/bob/integration/concrete/lido-adapter/request-lido-withdrawal/requestLidoWithdrawal.tree
+++ b/bob/tests/bob/integration/concrete/lido-adapter/request-lido-withdrawal/requestLidoWithdrawal.tree
@@ -5,29 +5,32 @@ RequestLidoWithdrawal_Integration_Concrete_Test
    ├── given ACTIVE status
    │  └── it should revert
    └── given not ACTIVE status
-      ├── given Lido withdrawal requested
+      ├── given already unstaked
       │  └── it should revert
-      └── given Lido withdrawal not requested
-         ├── given total wstETH zero
+      └── given not already unstaked
+         ├── given Lido withdrawal requested
          │  └── it should revert
-         └── given total wstETH not zero
-            ├── given amount not exceed min per request
+         └── given Lido withdrawal not requested
+            ├── given total wstETH zero
             │  └── it should revert
-            └── given amount exceeds min per request
-               ├── given amount not exceed max per request
-               │  ├── it should unwrap wstETH to stETH
-               │  ├── it should approve Lido withdrawal queue to spend stETH
-               │  ├── it should submit a single withdrawal request
-               │  ├── it should store one withdrawal request ID
-               │  └── it should emit a {RequestLidoWithdrawal} event
-               └── given amount exceeds max per request
-                  ├── when remainder not exceed min per request
-                  │  ├── it should adjust the second last and last request amounts
-                  │  ├── it should store multiple withdrawal request IDs
+            └── given total wstETH not zero
+               ├── given amount not exceed min per request
+               │  └── it should revert
+               └── given amount exceeds min per request
+                  ├── given amount not exceed max per request
+                  │  ├── it should unwrap wstETH to stETH
+                  │  ├── it should approve Lido withdrawal queue to spend stETH
+                  │  ├── it should submit a single withdrawal request
+                  │  ├── it should store one withdrawal request ID
                   │  └── it should emit a {RequestLidoWithdrawal} event
-                  └── when remainder exceeds min per request
-                     ├── it should unwrap wstETH to stETH
-                     ├── it should approve Lido withdrawal queue to spend stETH
-                     ├── it should split into multiple withdrawal requests
-                     ├── it should store multiple withdrawal request IDs
-                     └── it should emit a {RequestLidoWithdrawal} event
+                  └── given amount exceeds max per request
+                     ├── when remainder not exceed min per request
+                     │  ├── it should adjust the second last and last request amounts
+                     │  ├── it should store multiple withdrawal request IDs
+                     │  └── it should emit a {RequestLidoWithdrawal} event
+                     └── when remainder exceeds min per request
+                        ├── it should unwrap wstETH to stETH
+                        ├── it should approve Lido withdrawal queue to spend stETH
+                        ├── it should split into multiple withdrawal requests
+                        ├── it should store multiple withdrawal request IDs
+                        └── it should emit a {RequestLidoWithdrawal} event

--- a/bob/tests/bob/utils/Modifiers.sol
+++ b/bob/tests/bob/utils/Modifiers.sol
@@ -44,6 +44,10 @@ abstract contract Modifiers is Constants, EvmUtilsBase {
         _;
     }
 
+    modifier givenNotAlreadyUnstaked() {
+        _;
+    }
+
     modifier givenNoAdapter() {
         _;
     }


### PR DESCRIPTION
addresses: https://github.com/Cyfrin/audit-2026-02-sablier-bob-2/issues/25#issuecomment-4038031830