### PR TITLE
docs: update hyperlinks to point to evm-monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+# Sablier EVM Monorepo [![Github Actions][gha-badge]][gha] [![Coverage][codecov-badge]][codecov] [![Foundry][foundry-badge]][foundry] [![Discord][discord-badge]][discord] [![Twitter][twitter-badge]][twitter]
+
+Monorepo for Sablier's EVM smart contracts. In-depth documentation is available at
+[docs.sablier.com](https://docs.sablier.com).
+
+## Packages
+
+| Package                  | Description                                           | Docs                                                        |
+| ------------------------ | ----------------------------------------------------- | ----------------------------------------------------------- |
+| [`airdrops`](./airdrops) | Merkle-based token distribution with optional vesting | [Airdrops Docs](https://docs.sablier.com/concepts/airdrops) |
+| [`bob`](./bob)           | Price-gated vaults with optional yield adapters       | [Bob README](./bob/README.md)                               |
+| [`flow`](./flow)         | Open-ended token streaming with no fixed end time     | [Flow Docs](https://docs.sablier.com/concepts/flow)         |
+| [`lockup`](./lockup)     | Fixed-term vesting and token distribution             | [Lockup Docs](https://docs.sablier.com/concepts/lockup)     |
+| [`utils`](./utils)       | Shared utilities, base contracts, and comptroller     | [Utils README](./utils/README.md)                           |
+
+Each package has its own README with protocol-specific details, installation instructions, and usage examples.
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org) (v20+)
+- [Bun](https://bun.sh) (package manager)
+- [Just](https://github.com/casey/just) (command runner)
+- [Foundry](https://github.com/foundry-rs/foundry) (EVM development framework)
+
+For a complete list of prerequisites, see the [Contributing](./CONTRIBUTING.md) guide.
+
+### Installation
+
+Clone the repository:
+
+```shell
+git clone git@github.com:sablier-labs/evm-monorepo.git && cd evm-monorepo
+```
+
+### Commands
+
+This monorepo uses [Just](https://github.com/casey/just) as its command runner. To see all available commands:
+
+```shell
+just --list
+```
+
+Commands can be run per package using the `<package>::<command>` convention, or across all packages using the `-all`
+suffix.
+
+### Set Up
+
+Install dependencies and run the one-time setup:
+
+```shell
+cp .env.example .env
+bun install && just setup
+```
+
+### Build
+
+```shell
+just build-all                # Build all packages
+just lockup::build            # Build a specific package
+```
+
+### Test
+
+```shell
+just test-all                 # Run all tests
+just lockup::test             # Test a specific package
+```
+
+## Security
+
+The codebase has undergone rigorous audits by leading security experts from Cantina, as well as independent auditors.
+For a comprehensive list of all audits conducted, please click [here](https://github.com/sablier-labs/audits).
+
+For any security-related concerns, please refer to the [SECURITY](./SECURITY.md) policy. This repository is subject to a
+bug bounty program per the terms outlined in the aforementioned policy.
+
+## Contributing
+
+Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues/new) an issue,
+[start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit a PR. For any informal
+concerns or feedback, please join our [Discord server](https://discord.gg/bSwRCwWRsT).
+
+For guidance on how to create PRs, see the [CONTRIBUTING](./CONTRIBUTING.md) guide.
+
+## License
+
+See [LICENSE.md](./LICENSE.md).
+
+[codecov]: https://codecov.io/gh/sablier-labs/evm-monorepo
+[codecov-badge]: https://codecov.io/gh/sablier-labs/evm-monorepo/branch/main/graph/badge.svg
+[discord]: https://discord.gg/bSwRCwWRsT
+[discord-badge]: https://img.shields.io/discord/659709894315868191
+[foundry]: https://getfoundry.sh
+[foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
+[gha]: https://github.com/sablier-labs/evm-monorepo/actions
+[gha-badge]: https://github.com/sablier-labs/evm-monorepo/actions/workflows/ci-module.yml/badge.svg
+[twitter]: https://x.com/Sablier
+[twitter-badge]: https://img.shields.io/twitter/follow/Sablier

--- a/airdrops/README.md
+++ b/airdrops/README.md
@@ -75,8 +75,8 @@ bug bounty program per the terms outlined in the aforementioned policy.
 
 ## Contributing
 
-Feel free to dive in! [Open](https://github.com/sablier-labs/airdrops/issues/new) an issue,
-[start](https://github.com/sablier-labs/airdrops/discussions/new) a discussion or submit a PR. For any informal concerns
+Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues/new) an issue,
+[start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit a PR. For any informal concerns
 or feedback, please join our [Discord server](https://discord.gg/bSwRCwWRsT).
 
 For guidance on how to create PRs, see the [CONTRIBUTING](./CONTRIBUTING.md) guide.
@@ -91,7 +91,7 @@ See [LICENSE.md](./LICENSE.md).
 [discord-badge]: https://img.shields.io/discord/659709894315868191
 [foundry]: https://getfoundry.sh
 [foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
-[gha]: https://github.com/sablier-labs/airdrops/actions
-[gha-badge]: https://github.com/sablier-labs/airdrops/actions/workflows/ci.yml/badge.svg
+[gha]: https://github.com/sablier-labs/evm-monorepo/actions
+[gha-badge]: https://github.com/sablier-labs/evm-monorepo/actions/workflows/ci-airdrops.yml/badge.svg
 [twitter]: https://x.com/Sablier
 [twitter-badge]: https://img.shields.io/twitter/follow/Sablier

--- a/airdrops/README.md
+++ b/airdrops/README.md
@@ -70,7 +70,7 @@ The list of all deployment addresses can be found [here](https://docs.sablier.co
 The codebase has undergone rigorous audits by leading security experts from Cantina, as well as independent auditors.
 For a comprehensive list of all audits conducted, please click [here](https://github.com/sablier-labs/audits).
 
-For any security-related concerns, please refer to the [SECURITY](./SECURITY.md) policy. This repository is subject to a
+For any security-related concerns, please refer to the [SECURITY](../SECURITY.md) policy. This repository is subject to a
 bug bounty program per the terms outlined in the aforementioned policy.
 
 ## Contributing
@@ -79,11 +79,11 @@ Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues
 [start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit a PR. For any informal concerns
 or feedback, please join our [Discord server](https://discord.gg/bSwRCwWRsT).
 
-For guidance on how to create PRs, see the [CONTRIBUTING](./CONTRIBUTING.md) guide.
+For guidance on how to create PRs, see the [CONTRIBUTING](../CONTRIBUTING.md) guide.
 
 ## License
 
-See [LICENSE.md](./LICENSE.md).
+See [LICENSE.md](../LICENSE.md).
 
 [codecov]: https://codecov.io/gh/sablier-labs/airdrops
 [codecov-badge]: https://codecov.io/gh/sablier-labs/airdrops/branch/main/graph/badge.svg

--- a/flow/README.md
+++ b/flow/README.md
@@ -14,7 +14,7 @@ time elapsed is linear and defined as:
 
 Sablier Flow can be used in several areas of everyday finance, such as payroll, subscriptions, grant distributions,
 insurance premiums, loans interest, token ESOPs etc. If you are looking for vesting and airdrops, please refer to our
-[Lockup](https://github.com/sablier-labs/v2-core/) protocol.
+[Lockup](../lockup/) protocol.
 
 ## Features
 
@@ -93,9 +93,9 @@ bug bounty program per the terms outlined in the aforementioned policy.
 
 ## Contributing
 
-Feel free to dive in! [Open](https://github.com/sablier-labs/flow/issues/new) an issue,
-[start](https://github.com/sablier-labs/flow/discussions/new) a discussion or submit
-[a PR](https://github.com/sablier-labs/flow/compare). For any concerns or feedback, please join our
+Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues/new) an issue,
+[start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit
+[a PR](https://github.com/sablier-labs/evm-monorepo/compare). For any concerns or feedback, please join our
 [Discord server](https://discord.gg/bSwRCwWRsT).
 
 Refer to [CONTRIBUTING](./CONTRIBUTING.md) guidelines if you wish to create a PR.
@@ -110,7 +110,7 @@ See [LICENSE.md](./LICENSE.md).
 [discord-badge]: https://img.shields.io/discord/659709894315868191
 [foundry]: https://getfoundry.sh
 [foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
-[gha]: https://github.com/sablier-labs/flow/actions
-[gha-badge]: https://github.com/sablier-labs/flow/actions/workflows/ci.yml/badge.svg
+[gha]: https://github.com/sablier-labs/evm-monorepo/actions
+[gha-badge]: https://github.com/sablier-labs/evm-monorepo/actions/workflows/ci-flow.yml/badge.svg
 [twitter]: https://x.com/Sablier
 [twitter-badge]: https://img.shields.io/twitter/follow/Sablier

--- a/flow/README.md
+++ b/flow/README.md
@@ -88,7 +88,7 @@ The list of all deployment addresses can be found [here](https://docs.sablier.co
 The codebase has undergone rigorous audits by leading security experts from Cantina, as well as independent auditors.
 For a comprehensive list of all audits conducted, please click [here](https://github.com/sablier-labs/audits).
 
-For any security-related concerns, please refer to the [SECURITY](./SECURITY.md) policy. This repository is subject to a
+For any security-related concerns, please refer to the [SECURITY](../SECURITY.md) policy. This repository is subject to a
 bug bounty program per the terms outlined in the aforementioned policy.
 
 ## Contributing
@@ -98,11 +98,11 @@ Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues
 [a PR](https://github.com/sablier-labs/evm-monorepo/compare). For any concerns or feedback, please join our
 [Discord server](https://discord.gg/bSwRCwWRsT).
 
-Refer to [CONTRIBUTING](./CONTRIBUTING.md) guidelines if you wish to create a PR.
+Refer to [CONTRIBUTING](../CONTRIBUTING.md) guidelines if you wish to create a PR.
 
 ## License
 
-See [LICENSE.md](./LICENSE.md).
+See [LICENSE.md](../LICENSE.md).
 
 [codecov]: https://codecov.io/gh/sablier-labs/flow
 [codecov-badge]: https://codecov.io/gh/sablier-labs/flow/branch/main/graph/badge.svg

--- a/lockup/README.md
+++ b/lockup/README.md
@@ -82,7 +82,7 @@ our docs.
 The codebase has undergone rigorous audits by leading security experts from Cantina, as well as independent auditors.
 For a comprehensive list of all audits conducted, please click [here](https://github.com/sablier-labs/audits).
 
-For any security-related concerns, please refer to the [SECURITY](./SECURITY.md) policy. This repository is subject to a
+For any security-related concerns, please refer to the [SECURITY](../SECURITY.md) policy. This repository is subject to a
 bug bounty program per the terms outlined in the aforementioned policy.
 
 ## Contributing
@@ -91,11 +91,11 @@ Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues
 [start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit a PR. For any informal concerns
 or feedback, please join our [Discord server](https://discord.gg/bSwRCwWRsT).
 
-For guidance on how to create PRs, see the [CONTRIBUTING](./CONTRIBUTING.md) guide.
+For guidance on how to create PRs, see the [CONTRIBUTING](../CONTRIBUTING.md) guide.
 
 ## License
 
-See [LICENSE.md](./LICENSE.md).
+See [LICENSE.md](../LICENSE.md).
 
 [codecov]: https://codecov.io/gh/sablier-labs/lockup
 [codecov-badge]: https://codecov.io/gh/sablier-labs/lockup/branch/main/graph/badge.svg

--- a/lockup/README.md
+++ b/lockup/README.md
@@ -87,8 +87,8 @@ bug bounty program per the terms outlined in the aforementioned policy.
 
 ## Contributing
 
-Feel free to dive in! [Open](https://github.com/sablier-labs/lockup/issues/new) an issue,
-[start](https://github.com/sablier-labs/lockup/discussions/new) a discussion or submit a PR. For any informal concerns
+Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues/new) an issue,
+[start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit a PR. For any informal concerns
 or feedback, please join our [Discord server](https://discord.gg/bSwRCwWRsT).
 
 For guidance on how to create PRs, see the [CONTRIBUTING](./CONTRIBUTING.md) guide.
@@ -103,7 +103,7 @@ See [LICENSE.md](./LICENSE.md).
 [discord-badge]: https://img.shields.io/discord/659709894315868191
 [foundry]: https://getfoundry.sh
 [foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
-[gha]: https://github.com/sablier-labs/lockup/actions
-[gha-badge]: https://github.com/sablier-labs/lockup/actions/workflows/ci.yml/badge.svg
+[gha]: https://github.com/sablier-labs/evm-monorepo/actions
+[gha-badge]: https://github.com/sablier-labs/evm-monorepo/actions/workflows/ci-lockup.yml/badge.svg
 [twitter]: https://x.com/Sablier
 [twitter-badge]: https://img.shields.io/twitter/follow/Sablier

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,6 +1,6 @@
 # Sablier EVM Utils [![Github Actions][gha-badge]][gha] [![Coverage][codecov-badge]][codecov] [![Foundry][foundry-badge]][foundry] [![Discord][discord-badge]][discord]
 
-This repository contains the following two sets of contracts:
+This package contains the following two sets of contracts:
 
 ### Sablier comptroller
 
@@ -23,7 +23,7 @@ In-depth documentation is available at [docs.sablier.com](https://docs.sablier.c
 
 ## Repository Structure
 
-This repo contains the following subdirectories:
+This package contains the following subdirectories:
 
 - [`src/interfaces`](./src/interfaces/): Interfaces to be used by external projects.
 - [`src/mocks`](./src/mocks/): Mock contracts used by external projects in tests.
@@ -75,11 +75,11 @@ Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues
 [start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit a PR. For any informal
 concerns or feedback, please join our [Discord server](https://discord.gg/bSwRCwWRsT).
 
-For guidance on how to create PRs, see the [CONTRIBUTING](./CONTRIBUTING.md) guide.
+For guidance on how to create PRs, see the [CONTRIBUTING](../CONTRIBUTING.md) guide.
 
 ## License
 
-See [LICENSE.md](./LICENSE.md).
+See [LICENSE.md](../LICENSE.md).
 
 [codecov]: https://codecov.io/gh/sablier-labs/evm-utils
 [codecov-badge]: https://codecov.io/gh/sablier-labs/evm-utils/graph/badge.svg?token=iWxbU4RAsi

--- a/utils/README.md
+++ b/utils/README.md
@@ -15,9 +15,9 @@ Its a standalone contract with the following responsibilities:
 Its a collection of smart contracts used across various Sablier Solidity projects. The motivation behind this is to
 reduce code duplication. The following projects imports these contracts:
 
-- [Sablier Airdrops](https://github.com/sablier-labs/airdrops/)
-- [Sablier Flow](https://github.com/sablier-labs/flow/)
-- [Sablier Lockup](https://github.com/sablier-labs/lockup/)
+- [Sablier Airdrops](https://github.com/sablier-labs/evm-monorepo/tree/main/airdrops)
+- [Sablier Flow](https://github.com/sablier-labs/evm-monorepo/tree/main/flow)
+- [Sablier Lockup](https://github.com/sablier-labs/evm-monorepo/tree/main/lockup)
 
 In-depth documentation is available at [docs.sablier.com](https://docs.sablier.com).
 
@@ -71,8 +71,8 @@ contract MyContract is Adminable, Batch, NoDelegateCall {
 
 ## Contributing
 
-Feel free to dive in! [Open](https://github.com/sablier-labs/evm-utils/issues/new) an issue,
-[start](https://github.com/sablier-labs/evm-utils/discussions/new) a discussion or submit a PR. For any informal
+Feel free to dive in! [Open](https://github.com/sablier-labs/evm-monorepo/issues/new) an issue,
+[start](https://github.com/sablier-labs/evm-monorepo/discussions/new) a discussion or submit a PR. For any informal
 concerns or feedback, please join our [Discord server](https://discord.gg/bSwRCwWRsT).
 
 For guidance on how to create PRs, see the [CONTRIBUTING](./CONTRIBUTING.md) guide.
@@ -87,5 +87,5 @@ See [LICENSE.md](./LICENSE.md).
 [discord-badge]: https://img.shields.io/discord/659709894315868191
 [foundry]: https://getfoundry.sh
 [foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
-[gha]: https://github.com/sablier-labs/evm-utils/actions
-[gha-badge]: https://github.com/sablier-labs/evm-utils/actions/workflows/ci.yml/badge.svg
+[gha]: https://github.com/sablier-labs/evm-monorepo/actions
+[gha-badge]: https://github.com/sablier-labs/evm-monorepo/actions/workflows/ci-utils.yml/badge.svg


### PR DESCRIPTION
like this issue: https://github.com/sablier-labs/lockup/issues/1459

these were outdated and need to be merged after we rename the repo