### PR TITLE
Update fork tests to use mainnet addresses

### DIFF
--- a/airdrops/tests/fork/Fork.t.sol
+++ b/airdrops/tests/fork/Fork.t.sol
@@ -3,9 +3,12 @@ pragma solidity >=0.8.22 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ISablierComptroller } from "@sablier/evm-utils/src/interfaces/ISablierComptroller.sol";
-import { LockupNFTDescriptor } from "@sablier/lockup/src/LockupNFTDescriptor.sol";
-import { SablierLockup } from "@sablier/lockup/src/SablierLockup.sol";
-
+import { ISablierLockup } from "@sablier/lockup/src/interfaces/ISablierLockup.sol";
+import { ISablierFactoryMerkleExecute } from "src/interfaces/ISablierFactoryMerkleExecute.sol";
+import { ISablierFactoryMerkleInstant } from "src/interfaces/ISablierFactoryMerkleInstant.sol";
+import { ISablierFactoryMerkleLL } from "src/interfaces/ISablierFactoryMerkleLL.sol";
+import { ISablierFactoryMerkleLT } from "src/interfaces/ISablierFactoryMerkleLT.sol";
+import { ISablierFactoryMerkleVCA } from "src/interfaces/ISablierFactoryMerkleVCA.sol";
 import { Base_Test } from "../Base.t.sol";
 
 /// @notice Common logic needed by all fork tests.
@@ -35,14 +38,15 @@ abstract contract Fork_Test is Base_Test {
 
         // Load deployed addresses from Ethereum Mainnet.
         comptroller = ISablierComptroller(0x0000008ABbFf7a84a2fE09f9A9b74D3BC2072399);
-        deployFactoriesConditionally();
+        factoryMerkleExecute = ISablierFactoryMerkleExecute(0x75ca3677966737E70649336ee8f9be57AC9f74bA);
+        factoryMerkleInstant = ISablierFactoryMerkleInstant(0xb2855845067e126207DE2155Ad1c8AD5C495cb3F);
+        factoryMerkleLL = ISablierFactoryMerkleLL(0x3210E9b8ed75f9E2Db00ef17167C775e658c2221);
+        factoryMerkleLT = ISablierFactoryMerkleLT(0x239BD5431aDa12F09cA95d0a5d4388A5644268e9);
+        factoryMerkleVCA = ISablierFactoryMerkleVCA(0xe60Df8e04cE1616a06db8AD11ce71c05dDcB5D88);
+
+        lockup = ISablierLockup(0x93b37Bd5B6b278373217333Ac30D7E74c85fBDCB);
 
         // Label the token contract.
         labelForkedToken(FORK_TOKEN);
-
-        // TODO: Update lockup address from Ethereum Mainnet.
-        // lockup = ISablierLockup(0xcF8ce57fa442ba50aCbC57147a62aD03873FfA73);
-        address nftDescriptor = address(new LockupNFTDescriptor());
-        lockup = new SablierLockup(address(comptroller), nftDescriptor);
     }
 }

--- a/airdrops/tests/fork/merkle-campaign/MerkleExecute.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleExecute.t.sol
@@ -60,8 +60,6 @@ abstract contract MerkleExecute_Fork_Test is MerkleBase_Fork_Test {
             token: FORK_TOKEN
         });
 
-        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleExecute` function to compute the
-        // expected address.
         vars.expectedMerkleCampaign =
             factoryMerkleExecute.computeMerkleExecute(params.campaignCreator, constructorParams);
 

--- a/airdrops/tests/fork/merkle-campaign/MerkleExecute.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleExecute.t.sol
@@ -60,8 +60,10 @@ abstract contract MerkleExecute_Fork_Test is MerkleBase_Fork_Test {
             token: FORK_TOKEN
         });
 
+        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleExecute` function to compute the
+        // expected address.
         vars.expectedMerkleCampaign =
-            computeMerkleExecuteAddress({ params: constructorParams, campaignCreator: params.campaignCreator });
+            factoryMerkleExecute.computeMerkleExecute(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleExecute) });
         emit ISablierFactoryMerkleExecute.CreateMerkleExecute({

--- a/airdrops/tests/fork/merkle-campaign/MerkleInstant.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleInstant.t.sol
@@ -45,8 +45,6 @@ abstract contract MerkleInstant_Fork_Test is MerkleBase_Fork_Test {
             tokenAddress: FORK_TOKEN
         });
 
-        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleInstant` function to compute the
-        // expected address.
         vars.expectedMerkleCampaign =
             factoryMerkleInstant.computeMerkleInstant(params.campaignCreator, constructorParams);
 

--- a/airdrops/tests/fork/merkle-campaign/MerkleInstant.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleInstant.t.sol
@@ -45,8 +45,10 @@ abstract contract MerkleInstant_Fork_Test is MerkleBase_Fork_Test {
             tokenAddress: FORK_TOKEN
         });
 
+        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleInstant` function to compute the
+        // expected address.
         vars.expectedMerkleCampaign =
-            computeMerkleInstantAddress({ params: constructorParams, campaignCreator: params.campaignCreator });
+            factoryMerkleInstant.computeMerkleInstant(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleInstant) });
         emit ISablierFactoryMerkleInstant.CreateMerkleInstant({

--- a/airdrops/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -65,8 +65,9 @@ abstract contract MerkleLL_Fork_Test is MerkleBase_Fork_Test {
             vestingStartTime: vestingStartTime
         });
 
-        vars.expectedMerkleCampaign =
-            computeMerkleLLAddress({ params: constructorParams, campaignCreator: params.campaignCreator });
+        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleLL` function to compute the
+        // expected address.
+        vars.expectedMerkleCampaign = factoryMerkleLL.computeMerkleLL(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleLL) });
         emit ISablierFactoryMerkleLL.CreateMerkleLL({

--- a/airdrops/tests/fork/merkle-campaign/MerkleLL.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleLL.t.sol
@@ -65,8 +65,6 @@ abstract contract MerkleLL_Fork_Test is MerkleBase_Fork_Test {
             vestingStartTime: vestingStartTime
         });
 
-        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleLL` function to compute the
-        // expected address.
         vars.expectedMerkleCampaign = factoryMerkleLL.computeMerkleLL(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleLL) });

--- a/airdrops/tests/fork/merkle-campaign/MerkleLT.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleLT.t.sol
@@ -63,8 +63,6 @@ abstract contract MerkleLT_Fork_Test is MerkleBase_Fork_Test {
             vestingStartTime: vestingStartTime
         });
 
-        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleLT` function to compute the
-        // expected address.
         vars.expectedMerkleCampaign = factoryMerkleLT.computeMerkleLT(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleLT) });

--- a/airdrops/tests/fork/merkle-campaign/MerkleLT.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleLT.t.sol
@@ -63,8 +63,9 @@ abstract contract MerkleLT_Fork_Test is MerkleBase_Fork_Test {
             vestingStartTime: vestingStartTime
         });
 
-        vars.expectedMerkleCampaign =
-            computeMerkleLTAddress({ params: constructorParams, campaignCreator: params.campaignCreator });
+        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleLT` function to compute the
+        // expected address.
+        vars.expectedMerkleCampaign = factoryMerkleLT.computeMerkleLT(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleLT) });
         emit ISablierFactoryMerkleLT.CreateMerkleLT({

--- a/airdrops/tests/fork/merkle-campaign/MerkleVCA.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleVCA.t.sol
@@ -74,8 +74,9 @@ abstract contract MerkleVCA_Fork_Test is MerkleBase_Fork_Test {
             vestingStartTime: vestingStartTime
         });
 
-        vars.expectedMerkleCampaign =
-            computeMerkleVCAAddress({ params: constructorParams, campaignCreator: params.campaignCreator });
+        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleVCA` function to compute the
+        // expected address.
+        vars.expectedMerkleCampaign = factoryMerkleVCA.computeMerkleVCA(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleVCA) });
         emit ISablierFactoryMerkleVCA.CreateMerkleVCA({

--- a/airdrops/tests/fork/merkle-campaign/MerkleVCA.t.sol
+++ b/airdrops/tests/fork/merkle-campaign/MerkleVCA.t.sol
@@ -74,8 +74,6 @@ abstract contract MerkleVCA_Fork_Test is MerkleBase_Fork_Test {
             vestingStartTime: vestingStartTime
         });
 
-        // Since the mainnet contracts are deployed using `via_ir`, use `computeMerkleVCA` function to compute the
-        // expected address.
         vars.expectedMerkleCampaign = factoryMerkleVCA.computeMerkleVCA(params.campaignCreator, constructorParams);
 
         vm.expectEmit({ emitter: address(factoryMerkleVCA) });

--- a/bob/tests/bob/fork/Fork.t.sol
+++ b/bob/tests/bob/fork/Fork.t.sol
@@ -3,11 +3,10 @@ pragma solidity >=0.8.22 <0.9.0;
 
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ISablierComptroller } from "@sablier/evm-utils/src/interfaces/ISablierComptroller.sol";
 
 import { ISablierBob } from "src/interfaces/ISablierBob.sol";
 import { ISablierLidoAdapter } from "src/interfaces/ISablierLidoAdapter.sol";
-import { SablierBob } from "src/SablierBob.sol";
-import { SablierLidoAdapter } from "src/SablierLidoAdapter.sol";
 
 import { Base_Test } from "./../Base.t.sol";
 
@@ -51,7 +50,15 @@ abstract contract Fork_Test is Base_Test {
         // Fork Ethereum Mainnet at the latest block number.
         vm.createSelectFork({ urlOrAlias: "ethereum" });
 
-        Base_Test.setUp();
+        // Load deployed contracts from Ethereum mainnet.
+        forkBob = ISablierBob(0xC8AB7E45E6DF99596b86870c26C25c721eB5C9af);
+        forkAdapter = ISablierLidoAdapter(0x40c564A59bB2f1544222D6848E3eEc1Cb68837E6);
+        comptroller = ISablierComptroller(0x0000008ABbFf7a84a2fE09f9A9b74D3BC2072399);
+
+        // Create test user.
+        address[] memory spenders = new address[](1);
+        spenders[0] = address(forkBob);
+        users.depositor = createUser("Depositor", spenders);
 
         // Label the mainnet addresses.
         vm.label(address(FORK_WETH), "WETH");
@@ -61,28 +68,8 @@ abstract contract Fork_Test is Base_Test {
         vm.label(FORK_LIDO_WITHDRAWAL_QUEUE, "LidoWithdrawalQueue");
         vm.label(address(FORK_ETH_USD_ORACLE), "ETH/USD Oracle");
         vm.label(FORK_STETH_ETH_ORACLE, "stETH/ETH Oracle");
-
-        // Deploy fresh Bob and adapter on the fork using real mainnet Lido/Curve addresses.
-        forkBob = new SablierBob(address(comptroller));
         vm.label(address(forkBob), "ForkSablierBob");
-
-        forkAdapter = new SablierLidoAdapter({
-            initialComptroller: address(comptroller),
-            sablierBob: address(forkBob),
-            curvePool: FORK_CURVE_POOL,
-            lidoWithdrawalQueue: FORK_LIDO_WITHDRAWAL_QUEUE,
-            steth: FORK_STETH,
-            stethEthOracle: FORK_STETH_ETH_ORACLE,
-            weth: address(FORK_WETH),
-            wsteth: FORK_WSTETH,
-            initialSlippageTolerance: SLIPPAGE_TOLERANCE,
-            initialYieldFee: YIELD_FEE
-        });
         vm.label(address(forkAdapter), "ForkSablierLidoAdapter");
-
-        // Set the default adapter for WETH via comptroller.
-        setMsgSender(address(comptroller));
-        forkBob.setDefaultAdapter(FORK_WETH, forkAdapter);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/flow/tests/fork/Fork.t.sol
+++ b/flow/tests/fork/Fork.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ISablierFlow } from "src/interfaces/ISablierFlow.sol";
 
 import { Base_Test } from "../Base.t.sol";
 
@@ -32,15 +33,11 @@ abstract contract Fork_Test is Base_Test {
         // Fork Ethereum Mainnet at the latest block number.
         vm.createSelectFork({ urlOrAlias: "ethereum" });
 
-        // TODO: Load mainnet address.
-        // flow = ISablierFlow(0x7a86d3e6894f9c5B5f25FFBDAaE658CFc7569623);
+        // Load mainnet address.
+        flow = ISablierFlow(0x844344Cd871B28221d725ecE9630E8bDE4E3a181);
 
         // Label the flow contract.
         vm.label(address(flow), "Flow");
-
-        // We need these in case we work on a new iteration.
-        Base_Test.setUp();
-        vm.etch(address(FORK_TOKEN), address(usdc).code);
 
         // Label the addresses.
         labelForkedToken(FORK_TOKEN);

--- a/lockup/tests/fork/Fork.t.sol
+++ b/lockup/tests/fork/Fork.t.sol
@@ -4,6 +4,10 @@ pragma solidity >=0.8.22 <0.9.0;
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { ILockupNFTDescriptor } from "src/interfaces/ILockupNFTDescriptor.sol";
+import { ISablierBatchLockup } from "src/interfaces/ISablierBatchLockup.sol";
+import { ISablierLockup } from "src/interfaces/ISablierLockup.sol";
+
 import { Base_Test } from "./../Base.t.sol";
 import { Defaults } from "./../utils/Defaults.sol";
 
@@ -33,16 +37,12 @@ abstract contract Fork_Test is Base_Test {
         // Fork Ethereum Mainnet at the latest block number.
         vm.createSelectFork({ urlOrAlias: "ethereum" });
 
-        // TODO: Load deployed addresses from Ethereum mainnet.
-        // batchLockup = ISablierBatchLockup(0x0636D83B184D65C242c43de6AAd10535BFb9D45a);
-        // nftDescriptor = ILockupNFTDescriptor(0xA9dC6878C979B5cc1d98a1803F0664ad725A1f56);
-        // lockup = ISablierLockup(0xcF8ce57fa442ba50aCbC57147a62aD03873FfA73);
+        // Load deployed addresses from Ethereum mainnet.
+        batchLockup = ISablierBatchLockup(0x4f3be262D1358A82b468CF81bfc5A9cC32Cf9875);
+        nftDescriptor = ILockupNFTDescriptor(0xA9dC6878C979B5cc1d98a1803F0664ad725A1f56);
+        lockup = ISablierLockup(0x93b37Bd5B6b278373217333Ac30D7E74c85fBDCB);
 
         defaults = new Defaults();
-
-        // We need these in case we work on a new iteration.
-        Base_Test.setUp();
-        vm.etch(address(FORK_TOKEN), address(usdc).code);
 
         // Create a random user for this test suite.
         forkTokenHolder = vm.randomAddress();

--- a/lockup/tests/fork/LockupPriceGated.t.sol
+++ b/lockup/tests/fork/LockupPriceGated.t.sol
@@ -195,6 +195,9 @@ abstract contract Lockup_PriceGated_Fork_Test is Lockup_Fork_Test {
         varsLPG.initialLockupBalance = varsLPG.actualLockupBalance;
         varsLPG.initialRecipientBalance = FORK_TOKEN.balanceOf(params.create.recipient);
 
+        // Get the current fee from the mainnet.
+        uint256 actualMinFeeWei = lockup.calculateMinFeeWei(varsLPG.streamId);
+
         // Expect the relevant events to be emitted.
         vm.expectEmit({ emitter: address(lockup) });
         emit ISablierLockup.WithdrawFromLockupStream({
@@ -209,7 +212,7 @@ abstract contract Lockup_PriceGated_Fork_Test is Lockup_Fork_Test {
         // Make the withdrawal and pay a fee.
         setMsgSender(params.create.recipient);
         vm.deal({ account: params.create.recipient, newBalance: 100 ether });
-        lockup.withdraw{ value: LOCKUP_MIN_FEE_WEI }({
+        lockup.withdraw{ value: actualMinFeeWei }({
             streamId: varsLPG.streamId,
             to: params.create.recipient,
             amount: params.withdrawAmount
@@ -242,7 +245,7 @@ abstract contract Lockup_PriceGated_Fork_Test is Lockup_Fork_Test {
         // Assert that the contract's ETH balance has been updated.
         assertEq(
             address(lockup).balance,
-            varsLPG.initialComptrollerBalanceETH + LOCKUP_MIN_FEE_WEI,
+            varsLPG.initialComptrollerBalanceETH + actualMinFeeWei,
             "post-withdraw Lockup balance ETH"
         );
 

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -28,7 +28,7 @@ contract Comptroller_Fork_Test is Base_Test {
         vm.createSelectFork({ urlOrAlias: "ethereum" });
 
         // Set the current mainnet admin address.
-        currentMainnetAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
+        currentMainnetAdmin = 0x58290bbdb51A4c6B022A81e9cDeD24BE19Ca57fd;
 
         // Deploy the `BaseScriptMock` contract.
         baseScript = new BaseScriptMock();
@@ -36,10 +36,12 @@ contract Comptroller_Fork_Test is Base_Test {
         // Load comptroller address from the mainnet.
         comptroller = ISablierComptroller(0x0000008ABbFf7a84a2fE09f9A9b74D3BC2072399);
 
-        // Load Lockup and Flow addresses from the mainnet.
-        protocolAddresses = new address[](2);
-        protocolAddresses[0] = 0xcF8ce57fa442ba50aCbC57147a62aD03873FfA73;
-        protocolAddresses[1] = 0x7a86d3e6894f9c5B5f25FFBDAaE658CFc7569623;
+        // Load Airdrops (only Merkle Instant Factory) Bob, Flow and Lockup addresses from the mainnet.
+        protocolAddresses = new address[](4);
+        protocolAddresses[0] = 0xb2855845067e126207DE2155Ad1c8AD5C495cb3F;
+        protocolAddresses[1] = 0xC8AB7E45E6DF99596b86870c26C25c721eB5C9af;
+        protocolAddresses[2] = 0x844344Cd871B28221d725ecE9630E8bDE4E3a181;
+        protocolAddresses[3] = 0x93b37Bd5B6b278373217333Ac30D7E74c85fBDCB;
 
         // Set comptroller admin as the caller.
         setMsgSender(currentMainnetAdmin);
@@ -61,7 +63,7 @@ contract Comptroller_Fork_Test is Base_Test {
         if (protocol == ISablierComptroller.Protocol.Staking) {
             assertEq(minFeeInWei, 0, "Staking: minFeeInWei > 0");
         } else {
-            assertGt(minFeeInWei, 0, "Lockup, Flow, Airdrops: minFeeInWei == 0");
+            assertGt(minFeeInWei, 0, "Airdrops, Bob, Flow, Lockup: minFeeInWei == 0");
         }
     }
 

--- a/utils/tests/fork/Comptroller.t.sol
+++ b/utils/tests/fork/Comptroller.t.sol
@@ -53,7 +53,7 @@ contract Comptroller_Fork_Test is Base_Test {
 
     /// @dev Checklist:
     /// - It should return zero value for Staking protocol.
-    /// - It should return non-zero value for Lockup, Flow and Airdrops.
+    /// - It should return non-zero value for Airdrops, Bob, Flow and Lockup.
     function testForkFuzz_CalculateMinFeeWei(uint8 protocolIndex) external view {
         // Bound the protocol enum to a valid enum value.
         ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);


### PR DESCRIPTION
Updated fork tests to use the mainnet contracts. Also closes https://github.com/sablier-labs/evm-monorepo/issues/1335