### PR TITLE
fix: remove bun install from install-all just command

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,7 +97,6 @@ alias fwa := full-write-all
 [group("all")]
 @install-all:
     just for-each install
-    bun install
 
 # Run all tests
 [group("all")]


### PR DESCRIPTION
the `install-all` command now runs infinitely

https://github.com/user-attachments/assets/a79de80e-db1f-4615-8e55-0c43fa06272d

