### PR TITLE
chore: bump syncpack from v13.0.4 to v14.2.1

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -21,4 +21,4 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: "Check dependencies versions for mismatch"
-        run: bunx syncpack@13.0.4 list-mismatches
+        run: bunx syncpack@14.2.1 lint


### PR DESCRIPTION
## Summary

- Bump syncpack from v13.0.4 to v14.2.1 (Rust rewrite, 17x faster)
- Replace deprecated `list-mismatches` command with `lint`

No config changes needed — `.syncpackrc.json` is already v14-compatible.

And CI passes: https://github.com/sablier-labs/evm-monorepo/actions/runs/23486474856