### PR TITLE
feat: add enumerable custom fee user getter

### DIFF
--- a/utils/src/SablierComptroller.sol
+++ b/utils/src/SablierComptroller.sol
@@ -8,6 +8,7 @@ import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/int
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import { IComptrollerable } from "./interfaces/IComptrollerable.sol";
 import { ISablierComptroller } from "./interfaces/ISablierComptroller.sol";
@@ -43,6 +44,7 @@ contract SablierComptroller is
     RoleAdminable, // 3 inherited components
     UUPSUpgradeable // 1 inherited component
 {
+    using EnumerableSet for EnumerableSet.AddressSet;
     using SafeERC20 for IERC20;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -68,11 +70,14 @@ contract SablierComptroller is
     /// @inheritdoc ISablierComptroller
     address public override attestor;
 
+    /// @dev A mapping that tracks all users with custom fees for each protocol, enabling enumeration.
+    mapping(Protocol => EnumerableSet.AddressSet) private _customFeeUsers;
+
     /// @dev We reserve 50 storage slots to allow for adding new state variables in this and its parent contracts in the
-    /// future. A gap of 45 slots is added in addition to 1 slot used by admin in {Adminable}, 1 empty slot used by the
-    /// roles mapping, 1 slot used by the oracle, 1 empty slot used by protocol fees mapping and 1 slot used by the
-    /// attestor.
-    uint256[45] private __gap;
+    /// future. A gap of 44 slots is added in addition to 1 slot used by admin in {Adminable}, 1 empty slot used by the
+    /// roles mapping, 1 slot used by the oracle, 1 empty slot used by protocol fees mapping, 1 slot used by the
+    /// attestor and 1 empty slot used by the custom fee users mapping.
+    uint256[44] private __gap;
 
     /*//////////////////////////////////////////////////////////////////////////
                                      MODIFIERS
@@ -166,6 +171,23 @@ contract SablierComptroller is
     }
 
     /// @inheritdoc ISablierComptroller
+    function getCustomFeeUsers(Protocol protocol)
+        external
+        view
+        override
+        returns (address[] memory users, uint256[] memory fees)
+    {
+        uint256 count = _customFeeUsers[protocol].length();
+        users = new address[](count);
+        fees = new uint256[](count);
+        for (uint256 i = 0; i < count; ++i) {
+            address user = _customFeeUsers[protocol].at(i);
+            users[i] = user;
+            fees[i] = _protocolFees[protocol].customFeesUSD[user].fee;
+        }
+    }
+
+    /// @inheritdoc ISablierComptroller
     function getMinFeeUSD(Protocol protocol) external view override returns (uint256) {
         return _protocolFees[protocol].minFeeUSD;
     }
@@ -197,6 +219,9 @@ contract SablierComptroller is
 
         // Effect: delete the custom fee for the provided protocol and user.
         delete _protocolFees[protocol].customFeesUSD[user];
+
+        // Effect: remove the user from the custom fee users set.
+        _customFeeUsers[protocol].remove(user);
 
         // Log the update.
         emit ISablierComptroller.UpdateCustomFeeUSD({
@@ -332,6 +357,9 @@ contract SablierComptroller is
 
         // Effect: update the custom fee for the provided protocol and user.
         _protocolFees[protocol].customFeesUSD[user].fee = customFeeUSD;
+
+        // Effect: add the user to the custom fee users set (no-op if already present).
+        _customFeeUsers[protocol].add(user);
 
         // Log the update.
         emit ISablierComptroller.UpdateCustomFeeUSD({

--- a/utils/src/interfaces/ISablierComptroller.sol
+++ b/utils/src/interfaces/ISablierComptroller.sol
@@ -119,6 +119,17 @@ interface ISablierComptroller is IERC165, IERC1822Proxiable, IRoleAdminable {
     /// @return The fee in wei, denominated in 18 decimals (1e18 = 1 native token).
     function convertUSDFeeToWei(uint256 feeUSD) external view returns (uint256);
 
+    /// @notice Retrieves all users with custom fees and their corresponding fee amounts for the given protocol.
+    /// @dev Iterates over the internal enumerable set of custom fee users for the specified protocol.
+    /// @param protocol The protocol as defined in {Protocol} enum.
+    /// @return users An array of addresses that have custom fees set.
+    /// @return fees An array of fee amounts corresponding to each user, denominated in Chainlink's 8-decimal format for
+    /// USD prices, where 1e8 is $1.
+    function getCustomFeeUsers(Protocol protocol)
+        external
+        view
+        returns (address[] memory users, uint256[] memory fees);
+
     /// @notice Get the minimum fee in USD for the given protocol, paid in the native token of the chain, e.g.,
     /// ETH for Ethereum Mainnet. Use {calculateMinFeeWei} to retrieve the fee in wei.
     /// @dev The fee is denominated in Chainlink's 8-decimal format for USD prices, where 1e8 is $1.

--- a/utils/tests/integration/concrete/comptroller/disable-custom-fee-usd-for/disableCustomFeeUSDFor.t.sol
+++ b/utils/tests/integration/concrete/comptroller/disable-custom-fee-usd-for/disableCustomFeeUSDFor.t.sol
@@ -60,5 +60,11 @@ contract DisableCustomFeeUSDFor_Comptroller_Concrete_Test is Base_Test {
         // It should disable the custom fee.
         assertEq(comptroller.calculateMinFeeWeiFor(protocol, users.sender), getFeeInWei(protocol), "custom fee not set");
         assertNotEq(comptroller.calculateMinFeeWeiFor(protocol, users.sender), 0, "custom fee not disabled");
+
+        // It should remove the user from the custom fee users set.
+        (address[] memory customUsers,) = comptroller.getCustomFeeUsers(protocol);
+        for (uint256 i = 0; i < customUsers.length; ++i) {
+            assertNotEq(customUsers[i], users.sender, "user still in custom fee users");
+        }
     }
 }

--- a/utils/tests/integration/concrete/comptroller/get-custom-fee-users/getCustomFeeUsers.t.sol
+++ b/utils/tests/integration/concrete/comptroller/get-custom-fee-users/getCustomFeeUsers.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+import { ISablierComptroller } from "src/interfaces/ISablierComptroller.sol";
+
+import { Base_Test } from "../../../../Base.t.sol";
+
+contract GetCustomFeeUsers_Comptroller_Concrete_Test is Base_Test {
+    function test_GivenNoCustomFeesSet(uint8 protocolIndex) external view {
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+
+        (address[] memory returnedUsers, uint256[] memory fees) = comptroller.getCustomFeeUsers(protocol);
+
+        // It should return empty arrays.
+        assertEq(returnedUsers.length, 0, "users length");
+        assertEq(fees.length, 0, "fees length");
+    }
+
+    modifier givenOneCustomFeeSet() {
+        _;
+    }
+
+    function test_GivenOneCustomFeeSet(uint8 protocolIndex, uint128 customFeeUSD) external givenOneCustomFeeSet {
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+        customFeeUSD = boundUint128(customFeeUSD, 1, uint128(MAX_FEE_USD));
+
+        comptroller.setCustomFeeUSDFor(protocol, users.alice, customFeeUSD);
+
+        (address[] memory returnedUsers, uint256[] memory fees) = comptroller.getCustomFeeUsers(protocol);
+
+        // It should return one user.
+        assertEq(returnedUsers.length, 1, "users length");
+        // It should return the correct fee.
+        assertEq(returnedUsers[0], users.alice, "user address");
+        assertEq(fees[0], customFeeUSD, "fee amount");
+    }
+
+    function test_WhenFeeIsZero(uint8 protocolIndex) external givenOneCustomFeeSet {
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+
+        // Set a custom fee of 0 (enabled = true, fee = 0).
+        comptroller.setCustomFeeUSDFor(protocol, users.alice, 0);
+
+        (address[] memory returnedUsers, uint256[] memory fees) = comptroller.getCustomFeeUsers(protocol);
+
+        // It should include the zero fee user.
+        assertEq(returnedUsers.length, 1, "users length");
+        assertEq(returnedUsers[0], users.alice, "user address");
+        assertEq(fees[0], 0, "fee amount");
+    }
+
+    function test_GivenSameUserSetTwice(uint8 protocolIndex, uint128 firstFee, uint128 secondFee) external {
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+        firstFee = boundUint128(firstFee, 0, uint128(MAX_FEE_USD));
+        secondFee = boundUint128(secondFee, 0, uint128(MAX_FEE_USD));
+
+        // Set the custom fee twice for the same user.
+        comptroller.setCustomFeeUSDFor(protocol, users.alice, firstFee);
+        comptroller.setCustomFeeUSDFor(protocol, users.alice, secondFee);
+
+        (address[] memory returnedUsers, uint256[] memory fees) = comptroller.getCustomFeeUsers(protocol);
+
+        // It should not duplicate the user.
+        assertEq(returnedUsers.length, 1, "users length");
+        assertEq(returnedUsers[0], users.alice, "user address");
+        assertEq(fees[0], secondFee, "fee should be updated to second value");
+    }
+
+    function test_GivenCustomFeesSetOnDifferentProtocols() external {
+        uint256 feeAlice = 5e8;
+        uint256 feeEve = 10e8;
+
+        // Set custom fees on different protocols.
+        comptroller.setCustomFeeUSDFor(ISablierComptroller.Protocol.Airdrops, users.alice, feeAlice);
+        comptroller.setCustomFeeUSDFor(ISablierComptroller.Protocol.Flow, users.eve, feeEve);
+
+        // Check Airdrops: should only contain Alice.
+        (address[] memory airdropUsers, uint256[] memory airdropFees) =
+            comptroller.getCustomFeeUsers(ISablierComptroller.Protocol.Airdrops);
+        assertEq(airdropUsers.length, 1, "airdrops users length");
+        assertEq(airdropUsers[0], users.alice, "airdrops user");
+        assertEq(airdropFees[0], feeAlice, "airdrops fee");
+
+        // Check Flow: should only contain Eve.
+        (address[] memory flowUsers, uint256[] memory flowFees) =
+            comptroller.getCustomFeeUsers(ISablierComptroller.Protocol.Flow);
+        assertEq(flowUsers.length, 1, "flow users length");
+        assertEq(flowUsers[0], users.eve, "flow user");
+        assertEq(flowFees[0], feeEve, "flow fee");
+
+        // Check Lockup: should be empty.
+        (address[] memory lockupUsers, uint256[] memory lockupFees) =
+            comptroller.getCustomFeeUsers(ISablierComptroller.Protocol.Lockup);
+        assertEq(lockupUsers.length, 0, "lockup users length");
+        assertEq(lockupFees.length, 0, "lockup fees length");
+
+        // Check Staking: should be empty.
+        (address[] memory stakingUsers, uint256[] memory stakingFees) =
+            comptroller.getCustomFeeUsers(ISablierComptroller.Protocol.Staking);
+        assertEq(stakingUsers.length, 0, "staking users length");
+        assertEq(stakingFees.length, 0, "staking fees length");
+
+        // Check Bob: should be empty.
+        (address[] memory bobUsers, uint256[] memory bobFees) =
+            comptroller.getCustomFeeUsers(ISablierComptroller.Protocol.Bob);
+
+        // It should isolate users per protocol.
+        assertEq(bobUsers.length, 0, "bob users length");
+        assertEq(bobFees.length, 0, "bob fees length");
+    }
+
+    modifier givenMultipleCustomFeesSet() {
+        _;
+    }
+
+    function test_GivenMultipleCustomFeesSet(
+        uint8 protocolIndex,
+        uint128 feeAlice,
+        uint128 feeEve
+    )
+        external
+        givenMultipleCustomFeesSet
+    {
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+        feeAlice = boundUint128(feeAlice, 0, uint128(MAX_FEE_USD));
+        feeEve = boundUint128(feeEve, 0, uint128(MAX_FEE_USD));
+
+        comptroller.setCustomFeeUSDFor(protocol, users.alice, feeAlice);
+        comptroller.setCustomFeeUSDFor(protocol, users.eve, feeEve);
+
+        (address[] memory returnedUsers, uint256[] memory fees) = comptroller.getCustomFeeUsers(protocol);
+
+        // It should return all users.
+        assertEq(returnedUsers.length, 2, "users length");
+        // It should return the correct fees.
+        assertEq(fees.length, 2, "fees length");
+
+        // Verify both users and fees are present (order depends on EnumerableSet).
+        bool foundAlice;
+        bool foundEve;
+        for (uint256 i = 0; i < returnedUsers.length; ++i) {
+            if (returnedUsers[i] == users.alice) {
+                assertEq(fees[i], feeAlice, "alice fee");
+                foundAlice = true;
+            } else if (returnedUsers[i] == users.eve) {
+                assertEq(fees[i], feeEve, "eve fee");
+                foundEve = true;
+            }
+        }
+        assertTrue(foundAlice, "alice not found");
+        assertTrue(foundEve, "eve not found");
+    }
+
+    function test_WhenACustomFeeIsDisabled(uint8 protocolIndex) external givenMultipleCustomFeesSet {
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+
+        uint256 feeAlice = 5e8;
+        uint256 feeEve = 10e8;
+        comptroller.setCustomFeeUSDFor(protocol, users.alice, feeAlice);
+        comptroller.setCustomFeeUSDFor(protocol, users.eve, feeEve);
+
+        // Disable the custom fee for Alice.
+        comptroller.disableCustomFeeUSDFor(protocol, users.alice);
+
+        (address[] memory returnedUsers, uint256[] memory fees) = comptroller.getCustomFeeUsers(protocol);
+
+        // It should not include the disabled user.
+        assertEq(returnedUsers.length, 1, "users length after disable");
+        // It should return remaining users and fees (order-independent check).
+        bool foundEve;
+        for (uint256 i = 0; i < returnedUsers.length; ++i) {
+            if (returnedUsers[i] == users.eve) {
+                assertEq(fees[i], feeEve, "eve fee");
+                foundEve = true;
+            }
+        }
+        assertTrue(foundEve, "eve not found");
+    }
+
+    function test_WhenANon_existentUserIsDisabled(uint8 protocolIndex) external givenMultipleCustomFeesSet {
+        ISablierComptroller.Protocol protocol = boundProtocolEnum(protocolIndex);
+
+        uint256 feeAlice = 5e8;
+        uint256 feeEve = 10e8;
+        comptroller.setCustomFeeUSDFor(protocol, users.alice, feeAlice);
+        comptroller.setCustomFeeUSDFor(protocol, users.eve, feeEve);
+
+        // Disable a user that was never set — should be a no-op.
+        comptroller.disableCustomFeeUSDFor(protocol, users.sender);
+
+        (address[] memory returnedUsers, uint256[] memory fees) = comptroller.getCustomFeeUsers(protocol);
+
+        // It should not affect existing users.
+        assertEq(returnedUsers.length, 2, "users length unchanged");
+
+        bool foundAlice;
+        bool foundEve;
+        for (uint256 i = 0; i < returnedUsers.length; ++i) {
+            if (returnedUsers[i] == users.alice) {
+                assertEq(fees[i], feeAlice, "alice fee");
+                foundAlice = true;
+            } else if (returnedUsers[i] == users.eve) {
+                assertEq(fees[i], feeEve, "eve fee");
+                foundEve = true;
+            }
+        }
+        assertTrue(foundAlice, "alice not found");
+        assertTrue(foundEve, "eve not found");
+    }
+}

--- a/utils/tests/integration/concrete/comptroller/get-custom-fee-users/getCustomFeeUsers.tree
+++ b/utils/tests/integration/concrete/comptroller/get-custom-fee-users/getCustomFeeUsers.tree
@@ -1,0 +1,20 @@
+GetCustomFeeUsers_Comptroller_Concrete_Test
+├── given no custom fees set
+│  └── it should return empty arrays
+├── given one custom fee set
+│  ├── it should return one user
+│  ├── it should return the correct fee
+│  └── when fee is zero
+│     └── it should include the zero fee user
+├── given same user set twice
+│  └── it should not duplicate the user
+├── given custom fees set on different protocols
+│  └── it should isolate users per protocol
+└── given multiple custom fees set
+   ├── it should return all users
+   ├── it should return the correct fees
+   ├── when a custom fee is disabled
+   │  ├── it should not include the disabled user
+   │  └── it should return remaining users and fees
+   └── when a non-existent user is disabled
+      └── it should not affect existing users

--- a/utils/tests/integration/concrete/comptroller/set-custom-fee-usd-for/setCustomFeeUSDFor.t.sol
+++ b/utils/tests/integration/concrete/comptroller/set-custom-fee-usd-for/setCustomFeeUSDFor.t.sol
@@ -140,5 +140,16 @@ contract SetCustomFeeUSDFor_Comptroller_Concrete_Test is Base_Test {
 
         // It should set the custom fee.
         assertEq(comptroller.getMinFeeUSDFor(protocol, user), newCustomFeeUSD, "custom fee USD");
+
+        // It should add the user to the custom fee users set.
+        (address[] memory customUsers,) = comptroller.getCustomFeeUsers(protocol);
+        bool found;
+        for (uint256 i = 0; i < customUsers.length; ++i) {
+            if (customUsers[i] == user) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "user not in custom fee users");
     }
 }


### PR DESCRIPTION
## Summary

Closes #1414.

Adds `getCustomFeeUsers(Protocol)` to `SablierComptroller`, enabling off-chain enumeration of all users with custom fees for a given protocol.

### Implementation

- **Storage**: New `mapping(Protocol => EnumerableSet.AddressSet) private _customFeeUsers` at slot 5, with `__gap` reduced from 45 to 44 (total 50 slots preserved).
- **Getter**: `getCustomFeeUsers(Protocol)` returns parallel `(address[] users, uint256[] fees)` arrays by iterating the EnumerableSet.
- **Set maintenance**: `setCustomFeeUSDFor` calls `_customFeeUsers[protocol].add(user)`; `disableCustomFeeUSDFor` calls `_customFeeUsers[protocol].remove(user)`.

### Gas Impact

| Function | Before (median) | After (median) | Delta |
|----------|-----------------|----------------|-------|
| `setCustomFeeUSDFor` | 51,740 | 118,664 | +66,924 |
| `disableCustomFeeUSDFor` | 29,498 | 45,385 | +15,887 |
| `getCustomFeeUsers` | N/A | ~15,000–240,000 | new |

The increase is expected — EnumerableSet.add/remove maintain an internal array + mapping for O(1) membership checks and O(n) enumeration.

## Test Plan

- [x] 8 BTT fuzz tests with `.tree` file covering:
  - Empty state, single user, multiple users, zero-fee user
  - Duplicate set (idempotency), cross-protocol isolation (all 5 protocols)
  - Disable removes user, disable non-existent user is no-op
- [x] Order-independent assertions (no coupling to EnumerableSet internals)
- [x] Cross-function coverage: `setCustomFeeUSDFor` and `disableCustomFeeUSDFor` shared helpers verify `getCustomFeeUsers` reflects mutations
- [x] All 184 utils tests pass
- [x] Storage layout verified via `forge inspect --diff`
- [x] Pre-commit hooks pass (forge fmt, solhint, prettier)