### PR TITLE
docs: add FREI-PI pattern to AI coding skills

### DIFF
--- a/.claude/skills/solidity-coding/references/coding-patterns.md
+++ b/.claude/skills/solidity-coding/references/coding-patterns.md
@@ -96,6 +96,12 @@ ______________________________________________________________________
 1. **CHECKS** - Validate inputs and state, revert if invalid
 2. **EFFECTS** - Update state before any external calls
 3. **INTERACTIONS** - External calls last (token transfers, hooks)
+4. **PROTOCOL INVARIANT** (optional) - `assert()` post-interaction state when a cheap protocol invariant exists
+
+### When to Use CEI-PI
+
+Use step 4 (CEI-PI / FREI-PI) only when a protocol-level invariant can be cheaply verified. Default to plain CEI
+otherwise. See `SablierFlow._withdraw` for a production example.
 
 ______________________________________________________________________
 

--- a/.claude/skills/solidity-coding/references/security-practices.md
+++ b/.claude/skills/solidity-coding/references/security-practices.md
@@ -2,7 +2,8 @@
 
 Security rules for Solidity contracts. Find examples in the actual codebase.
 
-> **Note**: CEI pattern and SafeERC20 basics are covered in the main SKILL.md. This reference covers advanced patterns.
+> **Note**: CEI pattern, CEI-PI (FREI-PI), and SafeERC20 basics are covered in `coding-patterns.md`. This reference
+> covers advanced patterns.
 
 ## Access Control
 


### PR DESCRIPTION
## Summary

Closes #1396 (partial — covers evm-monorepo AI skills; Notion docs and plugin-marketplace are out of scope for this PR).

Document the project's FREI-PI approach as discussed in #1395:

- **`coding-patterns.md`**: Add step 4 (`PROTOCOL INVARIANT`) to the CEI pattern order list, plus a "When to Use CEI-PI" subsection explaining the policy — use CEI-PI when a protocol-level invariant can be cheaply verified, default to plain CEI otherwise. References `SablierFlow._withdraw` as a production example.
- **`security-practices.md`**: Update the cross-reference note to mention CEI-PI (FREI-PI) alongside CEI and SafeERC20.

## Test plan

- [x] Pre-commit hooks pass (mdformat lint via lint-staged)
- [x] No code changes — docs only