### PR TITLE
docs(lockup): fix misleading changelog entry for v3.0.0

### DIFF
--- a/lockup/CHANGELOG.md
+++ b/lockup/CHANGELOG.md
@@ -40,8 +40,6 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 
 ### Changed
 
-- **Breaking:** Rename `aggregateBalance` to `aggregateAmount`
-  ([#1228](https://github.com/sablier-labs/lockup/pull/1228))
 - Refactor `SablierLockup` contract into model-specific abstract contracts
   ([#1261](https://github.com/sablier-labs/lockup/pull/1261))
 - Refactor `DataTypes` into separate type files ([#1261](https://github.com/sablier-labs/lockup/pull/1261))
@@ -55,6 +53,7 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 
 ### Added
 
+- Add `aggregateAmount` getter function ([#1228](https://github.com/sablier-labs/lockup/pull/1228))
 - ERC20 recovery functionality ([#1182](https://github.com/sablier-labs/lockup/pull/1182))
 - Function to calculate minimum fee in wei ([#1270](https://github.com/sablier-labs/lockup/pull/1270))
 - `CreateBatchLockup` event in `BatchLockup` ([#1274](https://github.com/sablier-labs/lockup/pull/1274))


### PR DESCRIPTION
The v3.0.0 changelog entry claimed `aggregateBalance` was renamed to `aggregateAmount`, referencing [#1228](https://github.com/sablier-labs/evm-monorepo/pull/1228/changes). But `aggregateBalance` never existed as a public function in the v2.0 Lockup contract — verified by fetching the ABI from the deployed mainnet contract at [`0x7C01AA3783577E15fD7e272443D44B92d5b21056`](https://etherscan.io/address/0x7C01AA3783577E15fD7e272443D44B92d5b21056) via Etherscan.

The rename likely happened during development before v3.0.0 shipped, so from a release perspective, `aggregateAmount` was a new addition, not a rename. This PR moves the entry from "Changed" (breaking rename) to "Added" (new getter function).

cc @andreivladbrg @smol-ninja